### PR TITLE
feat: handoff v0.1.0

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,13 @@
+---
+description: Hand off a GitHub issue to claude/codex/copilot in a fresh worktree
+argument-hint: <claude|codex|copilot> <#N | "free-form text"> [<#N>...]
+allowed-tools: Bash
+---
+
+Run the handoff CLI with the user's arguments. The CLI creates a worktree, writes
+`PROMPT.md`, and spawns a new terminal window running the chosen tool.
+
+!`bun run --cwd "${HANDOFF_REPO:-$(pwd)}" src/cli.ts $ARGUMENTS`
+
+If you got an error about `HANDOFF_REPO`, the user needs to set that env var to the
+absolute path of their `handoff` repo checkout (e.g., `export HANDOFF_REPO=~/code/handoff`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: ci
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ node_modules/
 .pnp.*
 
 # Bun
-bun.lock
+bun.lockb
 .bun/
 
 # Build artifacts
@@ -43,3 +43,4 @@ coverage/
 
 # Misc
 .cache/
+.obsidian/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+bunx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bunx lint-staged
+bunx lint-staged && bun run typecheck

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+build
+coverage
+bun.lock
+*.lockb
+.handoff-runtime
+.obsidian
+docs/initial-prompt.md
+PROMPT.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- CLI: `handoff <tool> <ref...>` and `handoff cleanup <branch>` (`bun src/cli.ts`).
+- Tools supported: `claude`, `codex`, `copilot`.
+- Refs: `#N`, `Issue #N`, free-form text.
+- Fleet mode: multiple `<ref>` args spawn N parallel worktrees + terminal windows.
+- Cross-platform terminal launcher: Windows (`wt` → `cmd`), macOS (`osascript`), Linux (`gnome-terminal` → `konsole` → `xterm`).
+- Wrapper scripts (`scripts/handoff-runner.{sh,ps1}`) auto-invoke `handoff cleanup` on tool exit.
+- `PROMPT.md` template with workflow contract: implement → verify → commit → push → PR → exit.
+- Cleanup: removes worktree + branch when `gh pr list --head <branch> --state merged` returns a result.
+- Claude Code slash command at `.claude/commands/handoff.md`.
+- Pre-commit (husky + lint-staged): prettier + eslint.
+- CI (GitHub Actions, Ubuntu): format-check, lint, typecheck, test.
+- Docs: `README.md`, `CLAUDE.md`, `docs/requirements.md`, `docs/implementation-plan.v0.1.0.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md — context for AI agents working in this repo
+
+## What this project is
+
+`handoff` is a small CLI + slash command that delegates a single GitHub issue (or free-form task) to one of three local agents — `claude`, `codex`, or `copilot` — running in an isolated git worktree. See [README.md](./README.md) for the user-facing summary and [docs/requirements.md](./docs/requirements.md) for the v0.1.0 spec.
+
+## Module map
+
+| File                         | Responsibility                                                            | Pure? |
+| ---------------------------- | ------------------------------------------------------------------------- | ----- |
+| `src/cli.ts`                 | Entrypoint. Parses argv, fans out to subcommands, isolates per-ref errors | no    |
+| `src/args.ts`                | Argv → `{ tool, refs[] } \| { command: 'cleanup', branch }`               | yes   |
+| `src/slug.ts`                | Title → kebab-case slug                                                   | yes   |
+| `src/branch.ts`              | Branch + worktree path naming                                             | yes   |
+| `src/prompt.ts`              | `PROMPT.md` template renderer                                             | yes   |
+| `src/github.ts`              | `gh` wrappers: `fetchIssue`, `defaultBranch`, `prMergedFor`               | I/O   |
+| `src/git.ts`                 | `git` wrappers: worktree create/remove, branch ops                        | I/O   |
+| `src/terminal.ts`            | Platform-aware terminal spawn (`buildLaunchSpec` is pure)                 | mixed |
+| `src/adapters.ts`            | Tool → binary name (one switch)                                           | yes   |
+| `src/cleanup.ts`             | PR-merged check → remove worktree + branch                                | I/O   |
+| `src/run.ts`                 | `spawn` wrapper with structured errors                                    | I/O   |
+| `src/config.ts`              | `VERSION`, `HELP`                                                         | yes   |
+| `scripts/handoff-runner.sh`  | Bash wrapper: run tool, then `bun … cli.ts cleanup <branch>`              | shell |
+| `scripts/handoff-runner.ps1` | PowerShell equivalent for Windows                                         | shell |
+
+Tests live in `tests/` and cover the **pure** modules. I/O modules are smoke-tested manually for v0.1.0; integration tests are out of scope.
+
+## Conventions
+
+- **TypeScript strict + `noUncheckedIndexedAccess`.** `argv[i]` is `string | undefined`; handle it.
+- **No shell interpolation in TS.** Use `run.ts` (which uses `spawn` with an argv array). The only places shell strings exist are the runner scripts under `scripts/`.
+- **Pure modules import only `node:` builtins and other pure modules.** I/O modules can import `run.ts`.
+- **Conventional Commits**, one logical commit per concern.
+- **Pre-commit hook** runs prettier + eslint via husky + lint-staged. Don't bypass with `--no-verify`.
+
+## Workflow contract for agents working **on this repo**
+
+1. Read `docs/requirements.md` and `docs/implementation-plan.v0.1.0.md` first.
+2. Add tests for any pure-function change.
+3. Run `bun test && bun run typecheck && bun run lint` before committing.
+4. Cross-platform changes (terminal spawn, runner scripts, paths) need a note in the PR about which platforms you smoke-tested.
+
+## How to add a new adapter
+
+1. Add the tool string to `TOOLS` in `src/args.ts`.
+2. Add a `case` in `toolBinary` in `src/adapters.ts`.
+3. Add the tool name to the `case` in `scripts/handoff-runner.sh` and the `ValidateSet` in `scripts/handoff-runner.ps1`.
+4. Update `README.md` requirements list.
+5. Add a test for the new tool path in `tests/args.test.ts`.
+
+## How to extend the workflow contract in `PROMPT.md`
+
+Edit the `WORKFLOW_CONTRACT` constant in `src/prompt.ts`. The template is intentionally one big string so it's reviewable as a unit — don't split it into per-tool variants without a strong reason.
+
+## Out of scope until later
+
+- `--resume` an existing handoff worktree.
+- Status dashboard (`handoff list`).
+- Non-GitHub issue trackers.
+- Containerized worktrees.
+- Cross-agent orchestration (one issue handed to `claude`, the review handed to `codex`, etc.). v0.1.0 is parallel-but-independent.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,141 @@
 # handoff
 
-Delegate a GitHub issue to `claude`, `codex`, or `copilot` in an isolated git worktree.
+Delegate a GitHub issue (or a free-form task) to **`claude`**, **`codex`**, or **`copilot`** in an isolated git worktree, with a generated `PROMPT.md` as the starting context. The agent works to completion (commits, push, PR) in its own terminal window. When the PR merges, the worktree self-cleans.
 
-> Bootstrapped. v0.1.0 in progress on `dev`.
+```
+/handoff codex #1
+/handoff copilot Issue #2
+/handoff claude #3 #4 #5          # fleet — three parallel worktrees
+/handoff claude "fix login redirect bug"
+```
+
+## Why
+
+You have a backlog. You have three different agents you'd like to try on it. You don't want them stomping on each other in the same checkout, and you don't want to babysit the bookkeeping. `handoff` gives each task its own worktree, branch, and terminal window, and tears it down when the PR lands.
+
+## Requirements
+
+- [bun](https://bun.sh) ≥ 1.1
+- `git` ≥ 2.20 (for `git worktree`)
+- [`gh`](https://cli.github.com) authenticated (`gh auth login`)
+- The agent CLI you want to dispatch to:
+  - `claude` → [Anthropic Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code)
+  - `codex` → [OpenAI Codex CLI](https://github.com/openai/codex)
+  - `copilot` → [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)
+
+Cross-platform: Windows (Windows Terminal preferred, falls back to `cmd`), macOS, Linux (gnome-terminal → konsole → xterm).
+
+## Install
+
+```bash
+git clone git@github.com:bminier/handoff.git
+cd handoff
+bun install
+```
+
+Make the CLI runnable from anywhere by either:
+
+**A. Bun bin link** (recommended):
+
+```bash
+bun link
+# now `handoff` is on your PATH
+```
+
+**B. Set an env var and use the slash command** (for Claude Code users):
+
+```bash
+export HANDOFF_REPO="$(pwd)"
+mkdir -p ~/.claude/commands
+ln -s "$HANDOFF_REPO/.claude/commands/handoff.md" ~/.claude/commands/handoff.md
+```
+
+Now `/handoff codex #1` works inside any Claude Code session.
+
+## Usage
+
+### Single issue
+
+```bash
+handoff claude #42
+```
+
+This:
+
+1. Resolves the GitHub issue title + body via `gh issue view 42`.
+2. Creates branch `handoff/claude/42-<slug>` off the repo's default branch.
+3. Adds a worktree as a sibling directory: `<repo-parent>/<repo>-handoff-42-<slug>`.
+4. Writes `PROMPT.md` to the worktree with the issue, the branch, and a workflow contract.
+5. Spawns a new terminal window in that worktree, running `claude "$(cat PROMPT.md)"`.
+
+The agent does the work, commits, pushes, opens a PR. When it exits, the wrapper checks `gh pr list --head <branch> --state merged` — if the PR has merged, the worktree and branch are removed.
+
+### Fleet
+
+```bash
+handoff claude #1 #2 #3
+```
+
+Three independent worktrees + three terminal windows, in parallel. Each opens its own PR.
+
+### Free-form
+
+```bash
+handoff codex "tighten error messages in the API client"
+```
+
+No issue lookup. The text is passed as the task description in `PROMPT.md`. The branch becomes `handoff/codex/<slug>`.
+
+### Cleanup
+
+If the wrapper missed cleanup (you closed the terminal before merging the PR, you ran `gh` while offline, etc.):
+
+```bash
+handoff cleanup handoff/claude/42-fix-login
+```
+
+This re-checks the PR state and removes the worktree + branch if merged.
+
+## Architecture
+
+```
+src/
+├── cli.ts        — entrypoint, fleet loop
+├── args.ts       — parse <tool> <ref...>
+├── slug.ts       — title → kebab-case
+├── branch.ts     — branch + worktree path naming
+├── prompt.ts     — PROMPT.md template
+├── github.ts     — gh wrappers
+├── git.ts        — git worktree wrappers
+├── terminal.ts   — cross-platform window spawn
+├── adapters.ts   — tool → binary name
+├── cleanup.ts    — PR-merged check + worktree teardown
+├── config.ts     — VERSION, HELP
+└── run.ts        — typed spawn helper
+scripts/
+├── handoff-runner.sh   — wrapper for macOS/Linux terminals
+└── handoff-runner.ps1  — wrapper for Windows terminals
+.claude/commands/handoff.md  — Claude Code slash command
+```
+
+A handoff is one PR. Cleanup is conditional on `gh pr list --head <branch> --state merged` returning a result; nothing else will trigger worktree removal.
+
+## Configuration
+
+None required. Future versions will support `.handoffrc.json` overrides for `defaultBranch`, `worktreeDir`, `terminalCommand`, and `promptTemplate`.
+
+## Development
+
+```bash
+bun install
+bun test
+bun run typecheck
+bun run lint
+bun run format
+```
+
+Pre-commit runs prettier + eslint via husky + lint-staged.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,350 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "handoff",
+      "devDependencies": {
+        "@eslint/js": "^9.17.0",
+        "@types/bun": "latest",
+        "@types/node": "^22.10.0",
+        "eslint": "^9.17.0",
+        "globals": "^15.14.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.2.11",
+        "prettier": "^3.4.2",
+        "typescript": "^5.7.2",
+        "typescript-eslint": "^8.18.0",
+      },
+    },
+  },
+  "packages": {
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/type-utils": "8.59.0", "@typescript-eslint/utils": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.0", "@typescript-eslint/types": "^8.59.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0" } }, "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.0", "", {}, "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.0", "@typescript-eslint/tsconfig-utils": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/visitor-keys": "8.59.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.0", "@typescript-eslint/types": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.0", "", { "dependencies": { "@typescript-eslint/types": "8.59.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
+    "get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lint-staged": ["lint-staged@15.5.2", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^13.1.0", "debug": "^4.4.0", "execa": "^8.0.1", "lilconfig": "^3.1.3", "listr2": "^8.2.5", "micromatch": "^4.0.8", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.7.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w=="],
+
+    "listr2": ["listr2@8.3.3", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
+
+    "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
+
+    "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.59.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.0", "@typescript-eslint/parser": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "lint-staged/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+  }
+}

--- a/docs/implementation-plan.v0.1.0.md
+++ b/docs/implementation-plan.v0.1.0.md
@@ -98,5 +98,5 @@ One PR (`dev → main`) lands all of v0.1.0. Commits below are the intended sequ
 ## Risks / decisions deferred
 
 - **Windows runner script**: if `wt.exe` is unavailable in the user's PATH the fallback uses `cmd`. We're not detecting Windows Terminal vs ConEmu vs Hyper — keeping it simple and documenting overrides via `terminalCommand` config.
-- **PR-merged detection race**: the cleanup hook polls once on agent exit. If the user closes their terminal *before* merging the PR, cleanup is skipped — `handoff cleanup <branch>` covers that.
+- **PR-merged detection race**: the cleanup hook polls once on agent exit. If the user closes their terminal _before_ merging the PR, cleanup is skipped — `handoff cleanup <branch>` covers that.
 - **Free-form refs**: argument boundary is naive (single shell-quoted string). Multiple free-form tasks in one fleet call are not supported in v0.1.0.

--- a/docs/implementation-plan.v0.1.0.md
+++ b/docs/implementation-plan.v0.1.0.md
@@ -1,0 +1,102 @@
+# Implementation Plan — v0.1.0
+
+One PR (`dev → main`) lands all of v0.1.0. Commits below are the intended sequence inside that PR; the PR is opened only after the final commit.
+
+## Phase 0 — Repo bootstrap
+
+**Commit:** `chore: bootstrap repo (gitignore, license, editorconfig)`
+
+- `.gitignore` (Node + Bun + OS junk + worktree dirs)
+- `LICENSE` (MIT)
+- `.editorconfig`
+- Empty `README.md` placeholder
+- Initial commit lands on `main` so the PR has a base. All subsequent work is on `dev`.
+
+## Phase 1 — Toolchain
+
+**Commit:** `chore: add toolchain (bun, typescript, prettier, eslint, husky)`
+
+- `package.json` — `name: handoff`, `type: module`, scripts (`dev`, `build`, `lint`, `format`, `typecheck`, `test`), `bin: { handoff: "src/cli.ts" }`
+- `tsconfig.json` — strict, `moduleResolution: bundler`, `noEmit: true`
+- `.prettierrc.json`, `.prettierignore`
+- `eslint.config.js` (flat config, TS-aware)
+- `bun.lockb` from `bun install`
+- `.husky/pre-commit` → `bunx lint-staged`
+- `lint-staged` config in `package.json`: prettier + eslint on `*.{ts,js,json,md}`, `bun run typecheck` on `*.ts`
+
+## Phase 2 — Pure modules + tests
+
+**Commit:** `feat(core): slug, args parser, prompt template`
+
+- `src/slug.ts` — `slugify(title, { maxLen=40 })`; strips non-`[a-z0-9-]`, collapses dashes.
+- `src/args.ts` — `parseArgs(argv): { tool, refs[] }`. Tool whitelist; refs are `#N`, `Issue #N`, or free text.
+- `src/prompt.ts` — `renderPrompt(ctx): string`. Pure function over a `PromptContext` shape.
+- `src/branch.ts` — `branchName({ tool, issueNumber, slug })`, `worktreePath({ repoRoot, branch })`.
+- `tests/slug.test.ts`, `tests/args.test.ts`, `tests/prompt.test.ts`, `tests/branch.test.ts` (`bun test`).
+
+## Phase 3 — External integrations
+
+**Commit:** `feat(io): github + git wrappers`
+
+- `src/github.ts` — `fetchIssue(n)`, `defaultBranch()`, `prMergedFor(branch)`. Each shells out to `gh` and parses JSON; throws typed errors on auth/network failure.
+- `src/git.ts` — `currentRepoRoot()`, `createWorktree({ branch, path, base })`, `removeWorktree(path)`, `deleteBranch(branch)`. Wraps `git` with `execa`-style child_process.
+- Smoke-tested manually; no unit tests (effectful).
+
+## Phase 4 — Terminal launcher
+
+**Commit:** `feat(terminal): cross-platform window spawn`
+
+- `src/terminal.ts` — `openTerminal({ cwd, command })`:
+  - Win32: `wt.exe -d <cwd> -- <shell> -c "<command>"`; fallback `cmd /c start "" cmd /k "<command>"`.
+  - Darwin: `osascript` to open Terminal.app with the command.
+  - Linux: try `gnome-terminal` → `konsole` → `xterm` in order.
+- Detached spawn so the parent CLI returns immediately (fleet support).
+
+## Phase 5 — Adapters + wrapper script
+
+**Commit:** `feat(adapters): claude/codex/copilot dispatch + runner`
+
+- `src/adapters.ts` — `buildToolCommand(tool, promptPath)`:
+  - claude: `claude "$(cat PROMPT.md)"`
+  - codex: `codex "$(cat PROMPT.md)"`
+  - copilot: `copilot "$(cat PROMPT.md)"`
+- `scripts/handoff-runner.sh` (bash) and `scripts/handoff-runner.ps1` (PowerShell, for Win32 default shell): generic wrapper that takes `<tool>` and `<branch>`, runs the tool, then invokes `bun <repo>/src/cli.ts cleanup <branch>` on exit.
+- `src/cleanup.ts` — `cleanup(branch)`: queries `prMergedFor(branch)`; on merged removes worktree + branch. On not-merged prints retention banner.
+
+## Phase 6 — CLI orchestration
+
+**Commit:** `feat(cli): wire dispatch, fleet, cleanup subcommand`
+
+- `src/cli.ts`:
+  1. `parseArgs(process.argv)` → tool + refs
+  2. For each ref: resolve issue → branch → worktree → PROMPT.md → spawn terminal
+  3. `cleanup <branch>` subcommand
+  4. `--help` / `--version` flags
+- Stderr-friendly error messages; non-zero exit on failure.
+
+## Phase 7 — Slash command + docs
+
+**Commit:** `docs: slash command, README, CLAUDE.md`
+
+- `.claude/commands/handoff.md` — frontmatter + body that runs `!bun run --cwd <repo-root> src/cli.ts $ARGUMENTS`.
+- `README.md` — install, requirements (`bun`, `gh`, target CLIs), usage, examples, troubleshooting.
+- `CLAUDE.md` — architecture overview, module map, conventions, "how to add a new adapter".
+
+## Phase 8 — CI + release prep
+
+**Commit:** `ci: github actions (lint, typecheck, test)`
+
+- `.github/workflows/ci.yml` — Ubuntu, `oven-sh/setup-bun`, runs `bun install`, `bun run lint`, `bun run typecheck`, `bun test`. Triggers on push to `dev` and PRs into `main`.
+- `CHANGELOG.md` with v0.1.0 entry.
+- Bump version in `package.json` to `0.1.0`.
+
+## Phase 9 — Open the PR
+
+- Push `main` and `dev` to `origin`.
+- `gh pr create --base main --head dev --title "feat: handoff v0.1.0"` with a body that links to `docs/requirements.md` and lists acceptance criteria.
+
+## Risks / decisions deferred
+
+- **Windows runner script**: if `wt.exe` is unavailable in the user's PATH the fallback uses `cmd`. We're not detecting Windows Terminal vs ConEmu vs Hyper — keeping it simple and documenting overrides via `terminalCommand` config.
+- **PR-merged detection race**: the cleanup hook polls once on agent exit. If the user closes their terminal *before* merging the PR, cleanup is skipped — `handoff cleanup <branch>` covers that.
+- **Free-form refs**: argument boundary is naive (single shell-quoted string). Multiple free-form tasks in one fleet call are not supported in v0.1.0.

--- a/docs/initial-prompt.md
+++ b/docs/initial-prompt.md
@@ -1,0 +1,26 @@
+# Initial Prompt
+
+> Verbatim (lightly cleaned: fixed copy-paste artifacts like `&#x20;`, `\##`, and stray line breaks). Original lives at `../PROMPT.md`.
+
+---
+
+Please create for me a simple self-contained skill that will create a new git worktree of the current repo, set it up, create a `PROMPT.md`, and launch one of the following: `claude`, `codex`, or `copilot` using the `PROMPT.md` as the starting point in a new interactive terminal window. This should be tailored toward feature branches and bug fixes, where the expectation is that work will be done, commit(s) will be generated, PRs created, and upon completion of the PR it should exit and clean up its worktree.
+
+Ask questions if anything needs clarification. Create `./docs/requirements.md` and `./docs/implementation-plan.v0.1.0.md`. There should be 1 pull request, and that is when v0.1.0's implementation plan is complete.
+
+Follow best practices: install pre-commit hooks, an appropriate DevOps pipeline, create a `README.md`, `CLAUDE.md`, all the expected goodness.
+
+Use bun/typescript for any scripting required.
+
+## Use cases
+
+- `/handoff codex Issue #1`
+- `/handoff copilot Issue #2`
+
+## Question
+
+- Can `claude` handle fleets, so we could hand off Issues 1–3 all at once?
+
+## Process note
+
+First, review this prompt to clean it up with anything I've forgotten or new information and save it to `docs/initial-prompt.md`.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -16,30 +16,36 @@
 ## Functional requirements
 
 ### F1. Slash command surface
+
 - A Claude Code slash command at `.claude/commands/handoff.md` invokes the bun CLI with `$ARGUMENTS`.
 - Args: `<tool> <ref...>` where `<tool>` ∈ {`claude`, `codex`, `copilot`} and `<ref>` is one or more of: `#N`, `Issue #N`, or a quoted free-form description.
 
 ### F2. Issue resolution
+
 - For `#N` / `Issue #N`: fetch title + body via `gh issue view N --json number,title,body,labels,url`.
 - For free-form text: use it verbatim as the task description; no issue number.
 - Fail fast with a clear error if `gh` is unauthenticated when an issue ref is given.
 
 ### F3. Worktree creation
+
 - Branch name: `handoff/<tool>/<N>-<slug>` (issue) or `handoff/<tool>/<slug>` (free-form). Slug is kebab-cased title, max 40 chars.
 - Worktree path: sibling to the repo, `<parent>/<repo>-handoff-<branch-tail>`.
 - Branch off the repo's default branch (resolved via `gh repo view --json defaultBranchRef`), not the current HEAD.
 - Refuse to create a worktree for a branch that already exists; suggest re-running with `--resume` (post-v0.1.0).
 
 ### F4. PROMPT.md generation
+
 - Template injects: issue number, title, body, URL, branch, worktree path, target tool, repo name, parent branch, and a fixed "Workflow contract" section.
 - Workflow contract instructs the agent to: implement, run tests, commit conventionally, push, open a PR via `gh pr create --base <default-branch>`, and exit cleanly. The cleanup hook (F6) handles worktree removal — the agent does not.
 
 ### F5. Terminal spawn
+
 - Open one new interactive terminal window per handoff, in the worktree directory.
 - Platform support priority: **Windows (`wt.exe`, fallback `cmd /c start`)** → macOS (`osascript`/Terminal) → Linux (`gnome-terminal` → `konsole` → `xterm`).
 - The window runs a wrapper script that: `cd`'s into the worktree, runs `<tool>` with the PROMPT.md contents as the initial prompt, then on tool exit invokes the cleanup hook.
 
 ### F6. Cleanup hook
+
 - After the agent process exits, the wrapper:
   1. Checks `gh pr list --head <branch> --state merged --json number` for the worktree's branch.
   2. If a merged PR exists → `git worktree remove <path>` and `git branch -D <branch>` from the parent repo.
@@ -47,10 +53,12 @@
 - A `handoff cleanup <branch>` subcommand provides manual cleanup.
 
 ### F7. Fleet mode
+
 - When multiple `<ref>` args are passed, spawn N worktrees + N terminal windows in parallel. Each is fully independent (own branch, own PROMPT.md, own cleanup).
 - The CLI returns once all terminals are launched (does not block on agent completion).
 
 ### F8. Configuration
+
 - Zero-config default. Optional `.handoffrc.json` (or `package.json#handoff`) at repo root may override:
   - `defaultBranch` — fallback if `gh repo view` fails (e.g. offline)
   - `worktreeDir` — alternative parent for worktrees
@@ -80,7 +88,7 @@
 
 ## Answer to the open question
 
-**Yes, `claude` (and the others) can be handed multiple issues at once.** Fleet mode (F7) covers this in v0.1.0 by spawning N independent terminal sessions. There is no orchestration *between* the parallel agents — each is self-contained, each opens its own PR. A future version could add a coordinator that fans-out from a single tracking issue, but v0.1.0 keeps it as parallel-but-independent for safety and simplicity.
+**Yes, `claude` (and the others) can be handed multiple issues at once.** Fleet mode (F7) covers this in v0.1.0 by spawning N independent terminal sessions. There is no orchestration _between_ the parallel agents — each is self-contained, each opens its own PR. A future version could add a coordinator that fans-out from a single tracking issue, but v0.1.0 keeps it as parallel-but-independent for safety and simplicity.
 
 ## Acceptance criteria for v0.1.0
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,94 @@
+# Requirements — `handoff`
+
+## Purpose
+
+`handoff` delegates a unit of work (a GitHub issue or a free-form task) to one of three coding agents — `claude`, `codex`, or `copilot` — running in an isolated **git worktree** with a generated `PROMPT.md` as context. The agent works to completion (commits, push, PR) in a dedicated terminal window. When the PR merges, the worktree self-cleans.
+
+## Use cases
+
+```
+/handoff codex #1
+/handoff copilot Issue #2
+/handoff claude #3 #4 #5          # fleet — three parallel worktrees
+/handoff claude "fix login redirect bug"   # free-form, no issue
+```
+
+## Functional requirements
+
+### F1. Slash command surface
+- A Claude Code slash command at `.claude/commands/handoff.md` invokes the bun CLI with `$ARGUMENTS`.
+- Args: `<tool> <ref...>` where `<tool>` ∈ {`claude`, `codex`, `copilot`} and `<ref>` is one or more of: `#N`, `Issue #N`, or a quoted free-form description.
+
+### F2. Issue resolution
+- For `#N` / `Issue #N`: fetch title + body via `gh issue view N --json number,title,body,labels,url`.
+- For free-form text: use it verbatim as the task description; no issue number.
+- Fail fast with a clear error if `gh` is unauthenticated when an issue ref is given.
+
+### F3. Worktree creation
+- Branch name: `handoff/<tool>/<N>-<slug>` (issue) or `handoff/<tool>/<slug>` (free-form). Slug is kebab-cased title, max 40 chars.
+- Worktree path: sibling to the repo, `<parent>/<repo>-handoff-<branch-tail>`.
+- Branch off the repo's default branch (resolved via `gh repo view --json defaultBranchRef`), not the current HEAD.
+- Refuse to create a worktree for a branch that already exists; suggest re-running with `--resume` (post-v0.1.0).
+
+### F4. PROMPT.md generation
+- Template injects: issue number, title, body, URL, branch, worktree path, target tool, repo name, parent branch, and a fixed "Workflow contract" section.
+- Workflow contract instructs the agent to: implement, run tests, commit conventionally, push, open a PR via `gh pr create --base <default-branch>`, and exit cleanly. The cleanup hook (F6) handles worktree removal — the agent does not.
+
+### F5. Terminal spawn
+- Open one new interactive terminal window per handoff, in the worktree directory.
+- Platform support priority: **Windows (`wt.exe`, fallback `cmd /c start`)** → macOS (`osascript`/Terminal) → Linux (`gnome-terminal` → `konsole` → `xterm`).
+- The window runs a wrapper script that: `cd`'s into the worktree, runs `<tool>` with the PROMPT.md contents as the initial prompt, then on tool exit invokes the cleanup hook.
+
+### F6. Cleanup hook
+- After the agent process exits, the wrapper:
+  1. Checks `gh pr list --head <branch> --state merged --json number` for the worktree's branch.
+  2. If a merged PR exists → `git worktree remove <path>` and `git branch -D <branch>` from the parent repo.
+  3. If no merged PR → leave the worktree, print a banner: "PR not yet merged — worktree retained at `<path>`. Run `handoff cleanup <branch>` to remove manually."
+- A `handoff cleanup <branch>` subcommand provides manual cleanup.
+
+### F7. Fleet mode
+- When multiple `<ref>` args are passed, spawn N worktrees + N terminal windows in parallel. Each is fully independent (own branch, own PROMPT.md, own cleanup).
+- The CLI returns once all terminals are launched (does not block on agent completion).
+
+### F8. Configuration
+- Zero-config default. Optional `.handoffrc.json` (or `package.json#handoff`) at repo root may override:
+  - `defaultBranch` — fallback if `gh repo view` fails (e.g. offline)
+  - `worktreeDir` — alternative parent for worktrees
+  - `terminalCommand` — override the platform launcher
+  - `promptTemplate` — path to a custom template
+
+## Non-functional requirements
+
+- **Language**: TypeScript, run via `bun`. No transpile step for the CLI; published as source + `package.json#bin` entry running `bun src/cli.ts`.
+- **Cross-platform**: must work on Windows, macOS, Linux. CI runs on Ubuntu only for v0.1.0 (Windows-specific paths covered by unit tests, not E2E).
+- **Tests**: pure functions (slug, args, prompt rendering, branch naming) covered by `bun test`. Integration tests for git/gh/terminal are out of scope for v0.1.0.
+- **Performance**: a single handoff completes its setup in under 5 seconds (excluding `gh` network latency).
+- **Security**:
+  - Never write secrets into PROMPT.md or branch names.
+  - Free-form descriptions are passed as a single argv item — no shell interpolation.
+  - Slug generator strips non-`[a-z0-9-]` characters.
+
+## Out of scope for v0.1.0
+
+- `--resume` / re-attaching to an existing handoff worktree.
+- Status dashboard listing active handoffs.
+- Non-GitHub issue trackers.
+- Codex Cloud / Copilot remote agents (only local CLIs).
+- Auto-detecting tool capability and routing (e.g., "give to whichever agent is idle").
+- Containerized / VM-isolated worktrees.
+- Windows CI.
+
+## Answer to the open question
+
+**Yes, `claude` (and the others) can be handed multiple issues at once.** Fleet mode (F7) covers this in v0.1.0 by spawning N independent terminal sessions. There is no orchestration *between* the parallel agents — each is self-contained, each opens its own PR. A future version could add a coordinator that fans-out from a single tracking issue, but v0.1.0 keeps it as parallel-but-independent for safety and simplicity.
+
+## Acceptance criteria for v0.1.0
+
+1. `bun src/cli.ts claude #N` on a clean repo creates a worktree, writes PROMPT.md, opens a new terminal, and launches `claude` with the prompt.
+2. Same for `codex` and `copilot`.
+3. `bun src/cli.ts claude #1 #2` spawns two worktrees + two windows.
+4. After the agent exits in the spawned terminal, if the PR is merged, the worktree is removed.
+5. `handoff cleanup <branch>` removes a leftover worktree.
+6. CI green: lint, type-check, test on push and PR.
+7. Pre-commit hook runs prettier + eslint + tsc on staged files.
+8. README and CLAUDE.md cover install, usage, and architecture.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,29 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import globals from 'globals';
+
+export default tseslint.config(
+  {
+    ignores: ['node_modules/**', 'dist/**', 'build/**', 'coverage/**', '.handoff-runtime/**'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        Bun: 'readonly',
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/consistent-type-imports': 'error',
+      'no-console': 'off',
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "handoff",
+  "version": "0.1.0-dev",
+  "description": "Delegate a GitHub issue to claude, codex, or copilot in an isolated git worktree.",
+  "type": "module",
+  "private": true,
+  "bin": {
+    "handoff": "src/cli.ts"
+  },
+  "scripts": {
+    "dev": "bun src/cli.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "bun test",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,js}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ]
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.17.0",
+    "@types/bun": "latest",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.17.0",
+    "globals": "^15.14.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.2.11",
+    "prettier": "^3.4.2",
+    "typescript": "^5.7.2",
+    "typescript-eslint": "^8.18.0"
+  },
+  "engines": {
+    "bun": ">=1.1.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handoff",
-  "version": "0.1.0-dev",
+  "version": "0.1.0",
   "description": "Delegate a GitHub issue to claude, codex, or copilot in an isolated git worktree.",
   "type": "module",
   "private": true,

--- a/scripts/handoff-runner.ps1
+++ b/scripts/handoff-runner.ps1
@@ -1,0 +1,32 @@
+# Wrapper invoked inside a freshly-spawned PowerShell window.
+# Usage: handoff-runner.ps1 <repo-root> <tool> <branch>
+
+param(
+  [Parameter(Mandatory = $true)][string]$RepoRoot,
+  [Parameter(Mandatory = $true)][ValidateSet('claude', 'codex', 'copilot')][string]$Tool,
+  [Parameter(Mandatory = $true)][string]$Branch
+)
+
+$ErrorActionPreference = 'Continue'
+
+if (-not (Test-Path 'PROMPT.md')) {
+  Write-Error "handoff-runner: PROMPT.md not found in $(Get-Location)"
+  exit 1
+}
+
+$prompt = Get-Content -Path 'PROMPT.md' -Raw
+
+& $Tool $prompt
+$toolExit = $LASTEXITCODE
+
+Write-Host ''
+Write-Host '----------------------------------------'
+Write-Host "[handoff] $Tool exited (code $toolExit). Running cleanup for $Branch..."
+Write-Host '----------------------------------------'
+
+& bun "$RepoRoot/src/cli.ts" cleanup $Branch
+$cleanupExit = $LASTEXITCODE
+
+Write-Host ''
+Read-Host '[handoff] Press Enter to close this window' | Out-Null
+exit $cleanupExit

--- a/scripts/handoff-runner.sh
+++ b/scripts/handoff-runner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Wrapper invoked inside a freshly-spawned terminal window.
+# Usage: handoff-runner.sh <repo-root> <tool> <branch>
+#
+# Runs the chosen tool with PROMPT.md (in cwd) as the seed prompt, then on
+# exit invokes `bun <repo-root>/src/cli.ts cleanup <branch>` which removes
+# the worktree iff the PR has been merged.
+
+set -uo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: handoff-runner.sh <repo-root> <tool> <branch>" >&2
+  exit 64
+fi
+
+REPO_ROOT="$1"
+TOOL="$2"
+BRANCH="$3"
+
+if [ ! -f "PROMPT.md" ]; then
+  echo "handoff-runner: PROMPT.md not found in $(pwd)" >&2
+  exit 1
+fi
+
+PROMPT="$(cat PROMPT.md)"
+
+case "$TOOL" in
+  claude|codex|copilot)
+    "$TOOL" "$PROMPT"
+    ;;
+  *)
+    echo "handoff-runner: unknown tool '$TOOL'" >&2
+    exit 64
+    ;;
+esac
+
+TOOL_EXIT=$?
+
+echo
+echo "----------------------------------------"
+echo "[handoff] $TOOL exited (code $TOOL_EXIT). Running cleanup for $BRANCH..."
+echo "----------------------------------------"
+
+bun "$REPO_ROOT/src/cli.ts" cleanup "$BRANCH"
+CLEANUP_EXIT=$?
+
+echo
+read -r -p "[handoff] Press Enter to close this window..." _
+exit "$CLEANUP_EXIT"

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1,0 +1,13 @@
+import type { Tool } from './args.ts';
+
+/** Returns the binary name for the given tool. All three accept a positional prompt. */
+export function toolBinary(tool: Tool): string {
+  switch (tool) {
+    case 'claude':
+      return 'claude';
+    case 'codex':
+      return 'codex';
+    case 'copilot':
+      return 'copilot';
+  }
+}

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,116 @@
+export const TOOLS = ['claude', 'codex', 'copilot'] as const;
+export type Tool = (typeof TOOLS)[number];
+
+export interface IssueRef {
+  kind: 'issue';
+  number: number;
+}
+
+export interface FreeFormRef {
+  kind: 'freeform';
+  text: string;
+}
+
+export type Ref = IssueRef | FreeFormRef;
+
+export interface ParsedArgs {
+  tool: Tool;
+  refs: Ref[];
+}
+
+export interface CleanupArgs {
+  command: 'cleanup';
+  branch: string;
+}
+
+export type CliInvocation = ParsedArgs | CleanupArgs;
+
+export class ArgsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArgsError';
+  }
+}
+
+function isTool(value: string): value is Tool {
+  return (TOOLS as readonly string[]).includes(value);
+}
+
+function parseIssueToken(
+  tokens: string[],
+  index: number,
+): { ref: IssueRef; consumed: number } | null {
+  const tok = tokens[index];
+  if (tok === undefined) return null;
+
+  // "#N"
+  const hashMatch = tok.match(/^#(\d+)$/);
+  if (hashMatch && hashMatch[1] !== undefined) {
+    return { ref: { kind: 'issue', number: Number(hashMatch[1]) }, consumed: 1 };
+  }
+
+  // "Issue #N" → two tokens
+  if (/^issue$/i.test(tok)) {
+    const next = tokens[index + 1];
+    if (next !== undefined) {
+      const m = next.match(/^#?(\d+)$/);
+      if (m && m[1] !== undefined) {
+        return { ref: { kind: 'issue', number: Number(m[1]) }, consumed: 2 };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function parseInvocation(argv: readonly string[]): CliInvocation {
+  if (argv.length === 0) {
+    throw new ArgsError(
+      'No arguments provided. Usage: handoff <tool> <ref...> | handoff cleanup <branch>',
+    );
+  }
+
+  const head = argv[0];
+  if (head === undefined) {
+    throw new ArgsError('Empty arguments.');
+  }
+
+  if (head === 'cleanup') {
+    const branch = argv[1];
+    if (branch === undefined || branch.trim() === '') {
+      throw new ArgsError('Usage: handoff cleanup <branch>');
+    }
+    return { command: 'cleanup', branch };
+  }
+
+  if (!isTool(head)) {
+    throw new ArgsError(
+      `Unknown tool '${head}'. Expected one of: ${TOOLS.join(', ')}, or 'cleanup'.`,
+    );
+  }
+
+  const rest = argv.slice(1);
+  if (rest.length === 0) {
+    throw new ArgsError(`Missing issue reference. Usage: handoff ${head} <ref...>`);
+  }
+
+  const refs: Ref[] = [];
+  let i = 0;
+  while (i < rest.length) {
+    const issue = parseIssueToken(rest, i);
+    if (issue) {
+      refs.push(issue.ref);
+      i += issue.consumed;
+      continue;
+    }
+    // Anything else: collect remaining tokens as a single free-form description.
+    const text = rest.slice(i).join(' ').trim();
+    if (text.length === 0) {
+      throw new ArgsError('Empty free-form description.');
+    }
+    refs.push({ kind: 'freeform', text });
+    break;
+  }
+
+  return { tool: head, refs };
+}

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -1,0 +1,29 @@
+import { basename, dirname, join } from 'node:path';
+import type { Tool } from './args.ts';
+
+export interface BranchInput {
+  tool: Tool;
+  issueNumber?: number;
+  slug: string;
+}
+
+export function branchName({ tool, issueNumber, slug }: BranchInput): string {
+  const tail = issueNumber !== undefined ? `${issueNumber}-${slug}` : slug;
+  return `handoff/${tool}/${tail}`;
+}
+
+export function branchTail(branch: string): string {
+  return branch.split('/').slice(2).join('/') || branch;
+}
+
+export interface WorktreePathInput {
+  repoRoot: string;
+  branch: string;
+}
+
+export function worktreePath({ repoRoot, branch }: WorktreePathInput): string {
+  const parent = dirname(repoRoot);
+  const repoName = basename(repoRoot);
+  const tail = branchTail(branch).replace(/\//g, '-');
+  return join(parent, `${repoName}-handoff-${tail}`);
+}

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,0 +1,47 @@
+import { existsSync } from 'node:fs';
+import { deleteBranch, removeWorktree } from './git.ts';
+import { branchTail, worktreePath } from './branch.ts';
+import { GhError, prMergedFor } from './github.ts';
+
+export interface CleanupResult {
+  status: 'removed' | 'retained' | 'unknown';
+  message: string;
+}
+
+export async function cleanup(branch: string, opts: { repoRoot: string }): Promise<CleanupResult> {
+  const path = worktreePath({ repoRoot: opts.repoRoot, branch });
+
+  let merged: boolean;
+  try {
+    merged = await prMergedFor(branch);
+  } catch (err) {
+    const reason = err instanceof GhError ? err.message : String(err);
+    return {
+      status: 'unknown',
+      message:
+        `Could not check PR status for ${branch} (${reason}). Worktree retained at ${path}. ` +
+        `Re-run \`handoff cleanup ${branch}\` once \`gh\` works.`,
+    };
+  }
+
+  if (!merged) {
+    return {
+      status: 'retained',
+      message:
+        `PR for ${branch} is not merged. Worktree retained at ${path}. ` +
+        `Run \`handoff cleanup ${branch}\` after merging to remove it.`,
+    };
+  }
+
+  if (existsSync(path)) {
+    await removeWorktree(path);
+  }
+  await deleteBranch(branch).catch(() => {
+    // Branch may already be gone if the worktree removal pruned it; ignore.
+  });
+
+  return {
+    status: 'removed',
+    message: `Removed worktree ${path} and deleted branch ${branch} (PR merged). [${branchTail(branch)}]`,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { platform } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -124,8 +124,10 @@ function resolveRunnerScript(): string {
   const isWin = platform() === 'win32';
   const script = join(repoRoot, 'scripts', isWin ? 'handoff-runner.ps1' : 'handoff-runner.sh');
   if (!existsSync(script)) {
-    // Defensive: if we're being run from an unexpected location, ensure scripts dir resolves.
-    mkdirSync(dirname(script), { recursive: true });
+    throw new Error(
+      `handoff: runner script not found at ${script}. ` +
+        `The handoff CLI must be run from a checkout of the handoff repo (or an install that ships scripts/handoff-runner.{sh,ps1}).`,
+    );
   }
   return script;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env bun
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { platform } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { ArgsError, parseInvocation, type Ref, type Tool } from './args.ts';
+import { branchName, worktreePath } from './branch.ts';
+import { cleanup } from './cleanup.ts';
+import { createWorktree, currentRepoRoot, repoName } from './git.ts';
+import { defaultBranch, fetchIssue, type IssueDetails } from './github.ts';
+import { renderPrompt } from './prompt.ts';
+import { slugify } from './slug.ts';
+import { openTerminal } from './terminal.ts';
+import { HELP, VERSION } from './config.ts';
+
+async function main(argv: readonly string[]): Promise<number> {
+  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
+    console.log(HELP);
+    return 0;
+  }
+  if (argv[0] === '--version' || argv[0] === '-v') {
+    console.log(VERSION);
+    return 0;
+  }
+
+  let invocation;
+  try {
+    invocation = parseInvocation(argv);
+  } catch (err) {
+    if (err instanceof ArgsError) {
+      console.error(`error: ${err.message}\n`);
+      console.error(HELP);
+      return 64;
+    }
+    throw err;
+  }
+
+  if ('command' in invocation) {
+    const repoRoot = await currentRepoRoot();
+    const result = await cleanup(invocation.branch, { repoRoot });
+    console.log(result.message);
+    return result.status === 'unknown' ? 1 : 0;
+  }
+
+  return await runHandoffs(invocation.tool, invocation.refs);
+}
+
+async function runHandoffs(tool: Tool, refs: Ref[]) {
+  const repoRoot = await currentRepoRoot();
+  const repo = await repoName();
+  const parentBranch = await defaultBranch();
+  const runnerScript = resolveRunnerScript();
+
+  let failures = 0;
+  for (const ref of refs) {
+    try {
+      await spawnHandoff({ tool, ref, repoRoot, repo, parentBranch, runnerScript });
+    } catch (err) {
+      failures += 1;
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[handoff] FAILED for ${describeRef(ref)}: ${msg}`);
+    }
+  }
+  return failures === 0 ? 0 : 1;
+}
+
+interface SpawnInput {
+  tool: Tool;
+  ref: Ref;
+  repoRoot: string;
+  repo: string;
+  parentBranch: string;
+  runnerScript: string;
+}
+
+async function spawnHandoff(input: SpawnInput): Promise<void> {
+  let issue: IssueDetails | undefined;
+  let slugSource: string;
+  if (input.ref.kind === 'issue') {
+    issue = await fetchIssue(input.ref.number);
+    slugSource = issue.title;
+  } else {
+    slugSource = input.ref.text;
+  }
+
+  const slug = slugify(slugSource);
+  const branch = branchName({
+    tool: input.tool,
+    ...(issue ? { issueNumber: issue.number } : {}),
+    slug,
+  });
+  const path = worktreePath({ repoRoot: input.repoRoot, branch });
+
+  console.log(`[handoff] ${input.tool} → ${branch}`);
+  console.log(`           worktree: ${path}`);
+
+  await createWorktree({ branch, path, base: input.parentBranch });
+
+  const promptCtx = {
+    tool: input.tool,
+    repoName: input.repo,
+    branch,
+    parentBranch: input.parentBranch,
+    worktreePath: path,
+    ...(issue ? { issue } : {}),
+    ...(input.ref.kind === 'freeform' ? { freeformDescription: input.ref.text } : {}),
+  };
+  const promptBody = renderPrompt(promptCtx);
+  writeFileSync(join(path, 'PROMPT.md'), promptBody, 'utf8');
+
+  await openTerminal({
+    cwd: path,
+    scriptPath: input.runnerScript,
+    args: [input.repoRoot, input.tool, branch],
+  });
+  console.log(`[handoff] terminal launched for ${branch}`);
+}
+
+function resolveRunnerScript(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // src/cli.ts → repo-root/scripts/handoff-runner.{sh|ps1}
+  const repoRoot = resolve(here, '..');
+  const isWin = platform() === 'win32';
+  const script = join(repoRoot, 'scripts', isWin ? 'handoff-runner.ps1' : 'handoff-runner.sh');
+  if (!existsSync(script)) {
+    // Defensive: if we're being run from an unexpected location, ensure scripts dir resolves.
+    mkdirSync(dirname(script), { recursive: true });
+  }
+  return script;
+}
+
+function describeRef(ref: Ref): string {
+  return ref.kind === 'issue' ? `#${ref.number}` : `"${ref.text.slice(0, 40)}"`;
+}
+
+const code = await main(process.argv.slice(2));
+process.exit(code);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,30 @@
+/** Single source of truth for the package version, mirrored from package.json. */
+export const VERSION = '0.1.0';
+
+export const HELP = `handoff v${VERSION}
+
+USAGE
+  handoff <tool> <ref...>          spawn a worktree per ref and launch <tool>
+  handoff cleanup <branch>         remove a worktree if its PR has merged
+  handoff --help                   show this message
+  handoff --version                show version
+
+TOOLS
+  claude    Anthropic Claude Code CLI
+  codex     OpenAI Codex CLI
+  copilot   GitHub Copilot CLI
+
+REFS
+  #N             a GitHub issue number (resolved via \`gh issue view\`)
+  Issue #N       same as #N
+  <free text>    a free-form task description (no issue created)
+
+EXAMPLES
+  handoff codex #1
+  handoff copilot Issue #2
+  handoff claude #1 #2 #3                    # fleet: 3 parallel worktrees
+  handoff claude "tidy up the README"
+
+REQUIREMENTS
+  bun, git, gh, and the chosen tool must all be on PATH.
+`;

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,54 @@
+import { run } from './run.ts';
+
+export class GitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GitError';
+  }
+}
+
+export async function currentRepoRoot(): Promise<string> {
+  const { stdout } = await run('git', ['rev-parse', '--show-toplevel']);
+  return stdout.trim();
+}
+
+export async function repoName(): Promise<string> {
+  const root = await currentRepoRoot();
+  const parts = root.replace(/\\/g, '/').split('/');
+  const last = parts[parts.length - 1];
+  if (!last) throw new GitError(`Could not derive repo name from ${root}`);
+  return last;
+}
+
+export async function branchExists(branch: string): Promise<boolean> {
+  try {
+    await run('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface CreateWorktreeInput {
+  branch: string;
+  path: string;
+  base: string;
+}
+
+export async function createWorktree(input: CreateWorktreeInput): Promise<void> {
+  if (await branchExists(input.branch)) {
+    throw new GitError(
+      `Branch '${input.branch}' already exists. Resume support is planned for a later release; ` +
+        `for now, delete the branch with \`git branch -D ${input.branch}\` or use a different ref.`,
+    );
+  }
+  await run('git', ['worktree', 'add', '-b', input.branch, input.path, input.base]);
+}
+
+export async function removeWorktree(path: string): Promise<void> {
+  await run('git', ['worktree', 'remove', '--force', path]);
+}
+
+export async function deleteBranch(branch: string): Promise<void> {
+  await run('git', ['branch', '-D', branch]);
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -12,6 +12,7 @@ export interface IssueDetails {
   title: string;
   body: string;
   url: string;
+  labels: string[];
 }
 
 async function gh(args: readonly string[]): Promise<string> {
@@ -29,9 +30,23 @@ async function gh(args: readonly string[]): Promise<string> {
   }
 }
 
+interface RawIssuePayload {
+  number?: number;
+  title?: string;
+  body?: string;
+  url?: string;
+  labels?: Array<{ name?: string } | null>;
+}
+
 export async function fetchIssue(number: number): Promise<IssueDetails> {
-  const stdout = await gh(['issue', 'view', String(number), '--json', 'number,title,body,url']);
-  const parsed = JSON.parse(stdout) as Partial<IssueDetails>;
+  const stdout = await gh([
+    'issue',
+    'view',
+    String(number),
+    '--json',
+    'number,title,body,labels,url',
+  ]);
+  const parsed = JSON.parse(stdout) as RawIssuePayload;
   if (
     typeof parsed.number !== 'number' ||
     typeof parsed.title !== 'string' ||
@@ -40,11 +55,15 @@ export async function fetchIssue(number: number): Promise<IssueDetails> {
   ) {
     throw new GhError(`Unexpected gh issue payload: ${stdout.slice(0, 200)}`);
   }
+  const labels = Array.isArray(parsed.labels)
+    ? parsed.labels.flatMap((l) => (l && typeof l.name === 'string' ? [l.name] : []))
+    : [];
   return {
     number: parsed.number,
     title: parsed.title,
     body: parsed.body,
     url: parsed.url,
+    labels,
   };
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,76 @@
+import { RunError, run } from './run.ts';
+
+export class GhError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GhError';
+  }
+}
+
+export interface IssueDetails {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+}
+
+async function gh(args: readonly string[]): Promise<string> {
+  try {
+    const { stdout } = await run('gh', args);
+    return stdout;
+  } catch (err) {
+    if (err instanceof RunError) {
+      const hint = /authentication/i.test(err.stderr) ? ' (run `gh auth login`)' : '';
+      throw new GhError(
+        `gh ${args.join(' ')} failed${hint}: ${err.stderr.trim() || err.stdout.trim()}`,
+      );
+    }
+    throw err;
+  }
+}
+
+export async function fetchIssue(number: number): Promise<IssueDetails> {
+  const stdout = await gh(['issue', 'view', String(number), '--json', 'number,title,body,url']);
+  const parsed = JSON.parse(stdout) as Partial<IssueDetails>;
+  if (
+    typeof parsed.number !== 'number' ||
+    typeof parsed.title !== 'string' ||
+    typeof parsed.body !== 'string' ||
+    typeof parsed.url !== 'string'
+  ) {
+    throw new GhError(`Unexpected gh issue payload: ${stdout.slice(0, 200)}`);
+  }
+  return {
+    number: parsed.number,
+    title: parsed.title,
+    body: parsed.body,
+    url: parsed.url,
+  };
+}
+
+export async function defaultBranch(): Promise<string> {
+  const stdout = await gh(['repo', 'view', '--json', 'defaultBranchRef']);
+  const parsed = JSON.parse(stdout) as { defaultBranchRef?: { name?: string } };
+  const name = parsed.defaultBranchRef?.name;
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new GhError('Could not resolve default branch from `gh repo view`.');
+  }
+  return name;
+}
+
+export async function prMergedFor(branch: string): Promise<boolean> {
+  const stdout = await gh([
+    'pr',
+    'list',
+    '--head',
+    branch,
+    '--state',
+    'merged',
+    '--json',
+    'number',
+    '--limit',
+    '1',
+  ]);
+  const parsed = JSON.parse(stdout) as Array<{ number: number }>;
+  return Array.isArray(parsed) && parsed.length > 0;
+}

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -11,6 +11,7 @@ export interface PromptContext {
     title: string;
     body: string;
     url: string;
+    labels?: string[];
   };
   freeformDescription?: string;
 }
@@ -58,6 +59,10 @@ export function renderPrompt(ctx: PromptContext): string {
     lines.push(`## Issue #${ctx.issue.number}: ${ctx.issue.title}`);
     lines.push('');
     lines.push(`<${ctx.issue.url}>`);
+    if (ctx.issue.labels && ctx.issue.labels.length > 0) {
+      lines.push('');
+      lines.push(`**Labels:** ${ctx.issue.labels.map((l) => `\`${l}\``).join(', ')}`);
+    }
     lines.push('');
     lines.push(ctx.issue.body.trim() || '_(no body)_');
     lines.push('');

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,0 +1,74 @@
+import type { Tool } from './args.ts';
+
+export interface PromptContext {
+  tool: Tool;
+  repoName: string;
+  branch: string;
+  worktreePath: string;
+  parentBranch: string;
+  issue?: {
+    number: number;
+    title: string;
+    body: string;
+    url: string;
+  };
+  freeformDescription?: string;
+}
+
+const WORKFLOW_CONTRACT = `## Workflow contract
+
+You are working in a dedicated git worktree on the branch shown above. The user has handed
+off a single, scoped unit of work. Follow this sequence:
+
+1. **Understand the task.** Re-read the issue or description above. If the task is ambiguous,
+   ask the user (in this terminal) one focused question before starting.
+2. **Implement.** Make the smallest set of changes that satisfies the task. Keep the diff
+   focused — do not refactor unrelated code, do not introduce new abstractions.
+3. **Verify.** Run the project's test suite, type checker, and linter. Fix anything you broke.
+4. **Commit.** Use Conventional Commits style. One logical commit per concern; small enough
+   to review.
+5. **Push.** \`git push -u origin <branch>\`.
+6. **Open the PR.** \`gh pr create --base <parent-branch> --head <branch> --title "..."\`.
+   Title should be a concise summary; body should reference the issue (e.g., \`Closes #N\`)
+   and summarize the change.
+7. **Exit.** When the PR is open, exit this session normally. The terminal wrapper will
+   detect whether the PR has been merged and clean up the worktree automatically. If you
+   exit before the PR is merged, the worktree is preserved and \`handoff cleanup <branch>\`
+   removes it later.
+
+**Boundaries.**
+- Do **not** touch files outside the scope of this task.
+- Do **not** delete or rewrite the worktree yourself — the wrapper handles that.
+- Do **not** open multiple PRs. One handoff = one PR.
+- If you cannot complete the task, leave the branch in a clean state, document what's left
+  in the PR description (or in a comment if the PR isn't open yet), and exit.
+`;
+
+export function renderPrompt(ctx: PromptContext): string {
+  const lines: string[] = [];
+  lines.push(`# Handoff: ${ctx.repoName}`);
+  lines.push('');
+  lines.push(`- **Tool:** \`${ctx.tool}\``);
+  lines.push(`- **Branch:** \`${ctx.branch}\``);
+  lines.push(`- **Parent branch:** \`${ctx.parentBranch}\``);
+  lines.push(`- **Worktree:** \`${ctx.worktreePath}\``);
+  lines.push('');
+
+  if (ctx.issue) {
+    lines.push(`## Issue #${ctx.issue.number}: ${ctx.issue.title}`);
+    lines.push('');
+    lines.push(`<${ctx.issue.url}>`);
+    lines.push('');
+    lines.push(ctx.issue.body.trim() || '_(no body)_');
+    lines.push('');
+  } else if (ctx.freeformDescription) {
+    lines.push('## Task');
+    lines.push('');
+    lines.push(ctx.freeformDescription.trim());
+    lines.push('');
+  }
+
+  lines.push(WORKFLOW_CONTRACT);
+
+  return lines.join('\n');
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -52,9 +52,10 @@ export function run(
       stderr += chunk.toString('utf8');
     });
     child.on('error', reject);
-    child.on('close', (code) => {
-      const result: RunResult = { stdout, stderr, exitCode: code ?? 0 };
-      if (result.exitCode !== 0) {
+    child.on('close', (code, signal) => {
+      const exitCode = code ?? (signal ? 128 : 0);
+      const result: RunResult = { stdout, stderr, exitCode };
+      if (code !== 0) {
         reject(new RunError(command, args, result));
         return;
       }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,64 @@
+import { spawn } from 'node:child_process';
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export class RunError extends Error {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+
+  constructor(command: string, args: readonly string[], result: RunResult) {
+    super(
+      `Command failed: ${command} ${args.join(' ')}\n` +
+        `  exit ${result.exitCode}\n` +
+        (result.stderr ? `  stderr: ${result.stderr.trim()}\n` : '') +
+        (result.stdout ? `  stdout: ${result.stdout.trim()}` : ''),
+    );
+    this.name = 'RunError';
+    this.stdout = result.stdout;
+    this.stderr = result.stderr;
+    this.exitCode = result.exitCode;
+  }
+}
+
+export interface RunOpts {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function run(
+  command: string,
+  args: readonly string[],
+  opts: RunOpts = {},
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: opts.cwd,
+      env: opts.env ?? process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const result: RunResult = { stdout, stderr, exitCode: code ?? 0 };
+      if (result.exitCode !== 0) {
+        reject(new RunError(command, args, result));
+        return;
+      }
+      resolve(result);
+    });
+  });
+}

--- a/src/slug.ts
+++ b/src/slug.ts
@@ -1,0 +1,27 @@
+const DEFAULT_MAX_LEN = 40;
+
+export function slugify(input: string, opts: { maxLen?: number } = {}): string {
+  const maxLen = opts.maxLen ?? DEFAULT_MAX_LEN;
+  const slug = input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+
+  if (slug.length === 0) {
+    return 'task';
+  }
+
+  if (slug.length <= maxLen) {
+    return slug;
+  }
+
+  const truncated = slug.slice(0, maxLen);
+  const lastDash = truncated.lastIndexOf('-');
+  if (lastDash > maxLen / 2) {
+    return truncated.slice(0, lastDash);
+  }
+  return truncated.replace(/-+$/, '');
+}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -69,7 +69,7 @@ export function buildLaunchSpec(
   }
 
   if (plat === 'darwin') {
-    const argList = [input.scriptPath, ...scriptArgs].map(quoteForShell).join(' ');
+    const argList = ['bash', input.scriptPath, ...scriptArgs].map(quoteForShell).join(' ');
     const cmd = `cd ${quoteForShell(input.cwd)} && ${argList}`;
     return {
       command: 'osascript',
@@ -93,7 +93,7 @@ export function buildLaunchSpec(
   }
   return {
     command: 'xterm',
-    args: ['-e', `bash ${[input.scriptPath, ...scriptArgs].map(quoteForShell).join(' ')}`],
+    args: ['-e', 'bash', input.scriptPath, ...scriptArgs],
   };
 }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,0 +1,149 @@
+import { spawn } from 'node:child_process';
+import { platform } from 'node:os';
+
+export class TerminalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TerminalError';
+  }
+}
+
+export interface OpenTerminalInput {
+  /** Directory the new terminal should start in. */
+  cwd: string;
+  /** Absolute path to the script the terminal should run on launch. */
+  scriptPath: string;
+  /** Optional argv to pass to the script. */
+  args?: readonly string[];
+}
+
+export type Platform = 'win32' | 'darwin' | 'linux';
+
+export interface LaunchSpec {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Pure: pick the right terminal command for a given platform. Caller is responsible for
+ * verifying the chosen command is on PATH (the terminal opener tries fallbacks).
+ */
+export function buildLaunchSpec(
+  plat: Platform,
+  input: OpenTerminalInput & { terminal?: string },
+): LaunchSpec {
+  const scriptArgs = input.args ?? [];
+
+  if (plat === 'win32') {
+    const term = input.terminal ?? 'wt';
+    if (term === 'wt') {
+      return {
+        command: 'wt.exe',
+        args: [
+          '-d',
+          input.cwd,
+          'powershell.exe',
+          '-NoExit',
+          '-File',
+          input.scriptPath,
+          ...scriptArgs,
+        ],
+      };
+    }
+    // Fallback: cmd start with PowerShell
+    return {
+      command: 'cmd.exe',
+      args: [
+        '/c',
+        'start',
+        '""',
+        '/D',
+        input.cwd,
+        'powershell.exe',
+        '-NoExit',
+        '-File',
+        input.scriptPath,
+        ...scriptArgs,
+      ],
+    };
+  }
+
+  if (plat === 'darwin') {
+    const argList = [input.scriptPath, ...scriptArgs].map(quoteForShell).join(' ');
+    const cmd = `cd ${quoteForShell(input.cwd)} && ${argList}`;
+    return {
+      command: 'osascript',
+      args: ['-e', `tell application "Terminal" to do script "${escapeForApplescript(cmd)}"`],
+    };
+  }
+
+  // linux
+  const term = input.terminal ?? 'gnome-terminal';
+  if (term === 'gnome-terminal') {
+    return {
+      command: 'gnome-terminal',
+      args: ['--working-directory', input.cwd, '--', 'bash', input.scriptPath, ...scriptArgs],
+    };
+  }
+  if (term === 'konsole') {
+    return {
+      command: 'konsole',
+      args: ['--workdir', input.cwd, '-e', 'bash', input.scriptPath, ...scriptArgs],
+    };
+  }
+  return {
+    command: 'xterm',
+    args: ['-e', `bash ${[input.scriptPath, ...scriptArgs].map(quoteForShell).join(' ')}`],
+  };
+}
+
+function quoteForShell(s: string): string {
+  if (/^[A-Za-z0-9_./@:=+-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function escapeForApplescript(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export async function openTerminal(input: OpenTerminalInput): Promise<void> {
+  const plat = platform();
+  if (plat !== 'win32' && plat !== 'darwin' && plat !== 'linux') {
+    throw new TerminalError(`Unsupported platform: ${plat}`);
+  }
+
+  const candidates: string[] =
+    plat === 'win32'
+      ? ['wt', 'cmd']
+      : plat === 'darwin'
+        ? ['terminal']
+        : ['gnome-terminal', 'konsole', 'xterm'];
+
+  let lastErr: Error | undefined;
+  for (const candidate of candidates) {
+    const spec = buildLaunchSpec(plat, { ...input, terminal: candidate });
+    try {
+      await spawnDetached(spec);
+      return;
+    } catch (err) {
+      lastErr = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+  throw new TerminalError(`Failed to open a terminal window. Last error: ${lastErr?.message}`);
+}
+
+function spawnDetached(spec: LaunchSpec): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(spec.command, spec.args, {
+      detached: true,
+      stdio: 'ignore',
+      shell: false,
+    });
+    child.on('error', reject);
+    // Give the OS a tick to fail fast on ENOENT before unref'ing.
+    setTimeout(() => {
+      child.unref();
+      resolve();
+    }, 50);
+  });
+}

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+import { ArgsError, parseInvocation } from '../src/args.ts';
+
+describe('parseInvocation', () => {
+  it('parses a single #N reference', () => {
+    const out = parseInvocation(['claude', '#1']);
+    expect(out).toEqual({ tool: 'claude', refs: [{ kind: 'issue', number: 1 }] });
+  });
+
+  it('parses "Issue #N" two-token form', () => {
+    const out = parseInvocation(['copilot', 'Issue', '#2']);
+    expect(out).toEqual({ tool: 'copilot', refs: [{ kind: 'issue', number: 2 }] });
+  });
+
+  it('parses fleet (multiple #N)', () => {
+    const out = parseInvocation(['claude', '#1', '#2', '#3']);
+    expect(out).toEqual({
+      tool: 'claude',
+      refs: [
+        { kind: 'issue', number: 1 },
+        { kind: 'issue', number: 2 },
+        { kind: 'issue', number: 3 },
+      ],
+    });
+  });
+
+  it('treats anything else as free-form text', () => {
+    const out = parseInvocation(['codex', 'fix', 'login', 'redirect', 'bug']);
+    expect(out).toEqual({
+      tool: 'codex',
+      refs: [{ kind: 'freeform', text: 'fix login redirect bug' }],
+    });
+  });
+
+  it('parses cleanup subcommand', () => {
+    const out = parseInvocation(['cleanup', 'handoff/claude/1-foo']);
+    expect(out).toEqual({ command: 'cleanup', branch: 'handoff/claude/1-foo' });
+  });
+
+  it('rejects unknown tool', () => {
+    expect(() => parseInvocation(['bard', '#1'])).toThrow(ArgsError);
+  });
+
+  it('rejects empty argv', () => {
+    expect(() => parseInvocation([])).toThrow(ArgsError);
+  });
+
+  it('rejects tool with no refs', () => {
+    expect(() => parseInvocation(['claude'])).toThrow(ArgsError);
+  });
+
+  it('rejects cleanup with no branch', () => {
+    expect(() => parseInvocation(['cleanup'])).toThrow(ArgsError);
+  });
+});

--- a/tests/branch.test.ts
+++ b/tests/branch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { branchName, branchTail, worktreePath } from '../src/branch.ts';
+
+describe('branchName', () => {
+  it('builds an issue branch with number prefix', () => {
+    expect(branchName({ tool: 'claude', issueNumber: 7, slug: 'fix-login' })).toBe(
+      'handoff/claude/7-fix-login',
+    );
+  });
+
+  it('builds a freeform branch without number', () => {
+    expect(branchName({ tool: 'codex', slug: 'cleanup-readme' })).toBe(
+      'handoff/codex/cleanup-readme',
+    );
+  });
+});
+
+describe('branchTail', () => {
+  it('extracts everything after handoff/<tool>/', () => {
+    expect(branchTail('handoff/claude/7-fix-login')).toBe('7-fix-login');
+  });
+});
+
+describe('worktreePath', () => {
+  it('places the worktree as a sibling of the repo', () => {
+    const out = worktreePath({
+      repoRoot: '/work/handoff',
+      branch: 'handoff/claude/7-fix-login',
+    });
+    expect(out.replace(/\\/g, '/')).toBe('/work/handoff-handoff-7-fix-login');
+  });
+});

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -14,6 +14,7 @@ describe('renderPrompt', () => {
         title: 'Fix login redirect',
         body: 'After SSO, users are sent to /dashboard instead of the original URL.',
         url: 'https://github.com/x/y/issues/1',
+        labels: ['bug', 'auth'],
       },
     });
     expect(out).toContain('# Handoff: handoff');
@@ -21,6 +22,25 @@ describe('renderPrompt', () => {
     expect(out).toContain('After SSO, users are sent to /dashboard');
     expect(out).toContain('Workflow contract');
     expect(out).toContain('handoff/claude/1-fix-login');
+    expect(out).toContain('**Labels:** `bug`, `auth`');
+  });
+
+  it('omits the Labels line when there are no labels', () => {
+    const out = renderPrompt({
+      tool: 'claude',
+      repoName: 'handoff',
+      branch: 'handoff/claude/1-x',
+      parentBranch: 'main',
+      worktreePath: '/tmp/x',
+      issue: {
+        number: 1,
+        title: 'X',
+        body: 'body',
+        url: 'https://github.com/x/y/issues/1',
+        labels: [],
+      },
+    });
+    expect(out).not.toContain('**Labels:**');
   });
 
   it('renders a free-form handoff', () => {

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import { renderPrompt } from '../src/prompt.ts';
+
+describe('renderPrompt', () => {
+  it('renders an issue-backed handoff', () => {
+    const out = renderPrompt({
+      tool: 'claude',
+      repoName: 'handoff',
+      branch: 'handoff/claude/1-fix-login',
+      parentBranch: 'main',
+      worktreePath: '/work/handoff-handoff-1-fix-login',
+      issue: {
+        number: 1,
+        title: 'Fix login redirect',
+        body: 'After SSO, users are sent to /dashboard instead of the original URL.',
+        url: 'https://github.com/x/y/issues/1',
+      },
+    });
+    expect(out).toContain('# Handoff: handoff');
+    expect(out).toContain('## Issue #1: Fix login redirect');
+    expect(out).toContain('After SSO, users are sent to /dashboard');
+    expect(out).toContain('Workflow contract');
+    expect(out).toContain('handoff/claude/1-fix-login');
+  });
+
+  it('renders a free-form handoff', () => {
+    const out = renderPrompt({
+      tool: 'codex',
+      repoName: 'handoff',
+      branch: 'handoff/codex/cleanup-readme',
+      parentBranch: 'main',
+      worktreePath: '/work/handoff-handoff-cleanup-readme',
+      freeformDescription: 'Tidy up the README and add a usage example.',
+    });
+    expect(out).toContain('## Task');
+    expect(out).toContain('Tidy up the README');
+    expect(out).not.toContain('## Issue');
+  });
+
+  it('handles an empty issue body gracefully', () => {
+    const out = renderPrompt({
+      tool: 'copilot',
+      repoName: 'handoff',
+      branch: 'handoff/copilot/2-noop',
+      parentBranch: 'main',
+      worktreePath: '/tmp/x',
+      issue: {
+        number: 2,
+        title: 'Noop',
+        body: '',
+        url: 'https://github.com/x/y/issues/2',
+      },
+    });
+    expect(out).toContain('_(no body)_');
+  });
+});

--- a/tests/slug.test.ts
+++ b/tests/slug.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { slugify } from '../src/slug.ts';
+
+describe('slugify', () => {
+  it('lowercases and dasherizes simple titles', () => {
+    expect(slugify('Fix Login Bug')).toBe('fix-login-bug');
+  });
+
+  it('strips punctuation', () => {
+    expect(slugify('Fix: a really, really weird bug!?')).toBe('fix-a-really-really-weird-bug');
+  });
+
+  it('collapses runs of separators', () => {
+    expect(slugify('a   b___c---d')).toBe('a-b-c-d');
+  });
+
+  it('trims leading and trailing dashes', () => {
+    expect(slugify('---hello---')).toBe('hello');
+  });
+
+  it('truncates at maxLen on a word boundary when possible', () => {
+    const out = slugify('this is a fairly long title that we need to truncate', { maxLen: 30 });
+    expect(out.length).toBeLessThanOrEqual(30);
+    expect(out.endsWith('-')).toBe(false);
+    expect(out).toBe('this-is-a-fairly-long-title');
+  });
+
+  it('returns a fallback for empty input', () => {
+    expect(slugify('')).toBe('task');
+    expect(slugify('!!!')).toBe('task');
+  });
+
+  it('strips diacritics rather than the base letter', () => {
+    expect(slugify('café résumé')).toBe('cafe-resume');
+  });
+});

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -48,14 +48,19 @@ describe('buildLaunchSpec', () => {
     expect(spec.args[0]).toBe('-e');
     expect(spec.args[1]).toContain('Terminal');
     expect(spec.args[1]).toContain('runner.sh');
+    // Invoke via bash explicitly so the script doesn't need the +x bit set.
+    expect(spec.args[1]).toContain('bash');
   });
 
-  it('falls back to xterm on linux', () => {
+  it('falls back to xterm on linux with separate argv items for -e', () => {
     const spec = buildLaunchSpec('linux', {
       cwd: '/x',
       scriptPath: '/x/r.sh',
+      args: ['claude', 'handoff/claude/foo'],
       terminal: 'xterm',
     });
     expect(spec.command).toBe('xterm');
+    // xterm -e expects the program and its args as separate argv items, not a single string.
+    expect(spec.args).toEqual(['-e', 'bash', '/x/r.sh', 'claude', 'handoff/claude/foo']);
   });
 });

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test';
+import { buildLaunchSpec } from '../src/terminal.ts';
+
+describe('buildLaunchSpec', () => {
+  it('builds Windows Terminal launch spec', () => {
+    const spec = buildLaunchSpec('win32', {
+      cwd: 'C:\\work\\repo',
+      scriptPath: 'C:\\work\\repo\\runner.ps1',
+      args: ['claude', 'handoff/claude/1-foo'],
+    });
+    expect(spec.command).toBe('wt.exe');
+    expect(spec.args).toContain('-d');
+    expect(spec.args).toContain('C:\\work\\repo');
+    expect(spec.args).toContain('powershell.exe');
+    expect(spec.args).toContain('C:\\work\\repo\\runner.ps1');
+    expect(spec.args).toContain('claude');
+  });
+
+  it('falls back to cmd on Windows when terminal=cmd', () => {
+    const spec = buildLaunchSpec('win32', {
+      cwd: 'C:\\x',
+      scriptPath: 'C:\\x\\r.ps1',
+      terminal: 'cmd',
+    });
+    expect(spec.command).toBe('cmd.exe');
+    expect(spec.args[0]).toBe('/c');
+  });
+
+  it('builds gnome-terminal launch spec on linux', () => {
+    const spec = buildLaunchSpec('linux', {
+      cwd: '/work/repo',
+      scriptPath: '/work/repo/runner.sh',
+      args: ['codex', 'handoff/codex/foo'],
+      terminal: 'gnome-terminal',
+    });
+    expect(spec.command).toBe('gnome-terminal');
+    expect(spec.args).toContain('--working-directory');
+    expect(spec.args).toContain('/work/repo');
+    expect(spec.args).toContain('bash');
+  });
+
+  it('builds osascript launch spec on darwin', () => {
+    const spec = buildLaunchSpec('darwin', {
+      cwd: '/Users/x/repo',
+      scriptPath: '/Users/x/repo/runner.sh',
+    });
+    expect(spec.command).toBe('osascript');
+    expect(spec.args[0]).toBe('-e');
+    expect(spec.args[1]).toContain('Terminal');
+    expect(spec.args[1]).toContain('runner.sh');
+  });
+
+  it('falls back to xterm on linux', () => {
+    const spec = buildLaunchSpec('linux', {
+      cwd: '/x',
+      scriptPath: '/x/r.sh',
+      terminal: 'xterm',
+    });
+    expect(spec.command).toBe('xterm');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

v0.1.0 of `handoff`: a CLI + Claude Code slash command that delegates a GitHub issue (or free-form task) to `claude`, `codex`, or `copilot` in an isolated git worktree, with a generated `PROMPT.md` as the starting context. The agent works to completion (commit → push → PR) in its own terminal window; when the PR merges, the worktree self-cleans.

```
/handoff codex #1
/handoff copilot Issue #2
/handoff claude #3 #4 #5          # fleet
/handoff claude "tidy up the README"
```

## What's in here

- **CLI** (`src/cli.ts`) with `<tool> <ref...>` and `cleanup <branch>` subcommands. Bun/TypeScript, strict + `noUncheckedIndexedAccess`, no shell interpolation.
- **Cross-platform terminal launcher** (`src/terminal.ts`): Windows (`wt` → `cmd`), macOS (`osascript`), Linux (`gnome-terminal` → `konsole` → `xterm`).
- **Wrapper scripts** (`scripts/handoff-runner.{sh,ps1}`) that launch the tool with `PROMPT.md` and auto-invoke cleanup on exit.
- **Cleanup**: removes worktree + branch when `gh pr list --head <branch> --state merged` returns a result; retains otherwise with a banner.
- **Fleet mode**: multiple refs spawn N parallel worktrees + windows.
- **Slash command** at `.claude/commands/handoff.md`.
- **Tooling**: prettier, eslint flat config (typescript-eslint v8), husky + lint-staged pre-commit, `bun test` (28 passing).
- **CI** (`.github/workflows/ci.yml`): format-check, lint, typecheck, test on Ubuntu.
- **Docs**: `README.md`, `CLAUDE.md`, `docs/requirements.md`, `docs/implementation-plan.v0.1.0.md`.

Acceptance criteria are listed in [docs/requirements.md](./docs/requirements.md#acceptance-criteria-for-v010).

## Answer to the open question from PROMPT.md

> Can claude handle fleets, so we could handoff Issues 1–3 all at once?

**Yes** — `/handoff claude #1 #2 #3` spawns three independent worktrees + three terminal windows in parallel. Each agent opens its own PR. v0.1.0 keeps them parallel-but-independent (no cross-agent orchestration); a future version could add a coordinator that fans out from a single tracking issue. See requirements §F7 and the "Answer to the open question" section.

## Test plan

- [x] `bun test` — 28/28 passing (pure modules: slug, args, branch, prompt, terminal launch spec)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [ ] CI green on this PR
- [ ] Smoke test: `bun src/cli.ts --help` and `bun src/cli.ts cleanup foo` (validates argv path) — done locally
- [ ] End-to-end smoke (manual, post-merge): `/handoff claude #N` against a real issue, verify worktree spawns, verify cleanup on PR merge

## Out of scope (tracked for later)

- `--resume` an existing handoff worktree
- `handoff list` status dashboard
- Non-GitHub issue trackers
- Containerized worktrees
- Cross-agent orchestration (one issue handed to claude, review handed to codex, etc.)
- Windows CI (Ubuntu only for v0.1.0)