### PR TITLE
Fix runner path, branch naming, and cleanup workflow issues

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -7,4 +7,4 @@ allowed-tools: Bash
 Run the handoff CLI with the user's arguments. The CLI creates a worktree, writes
 `PROMPT.md`, and spawns a new terminal window running the chosen tool.
 
-!`IFS=' ' read -ra ARGS <<< "$ARGUMENTS" && bun run --cwd "${HANDOFF_REPO:-$(pwd)}" src/cli.ts "${ARGS[@]}"`
+!`xargs bun run --cwd "${HANDOFF_REPO:-$(pwd)}" src/cli.ts <<< "$ARGUMENTS"`

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -7,7 +7,4 @@ allowed-tools: Bash
 Run the handoff CLI with the user's arguments. The CLI creates a worktree, writes
 `PROMPT.md`, and spawns a new terminal window running the chosen tool.
 
-!`bun run --cwd "${HANDOFF_REPO:-$(pwd)}" src/cli.ts $ARGUMENTS`
-
-The `${HANDOFF_REPO:-$(pwd)}` placeholder is rewritten to the checkout's absolute
-path by `scripts/install.py` when this command is installed into `~/.claude/commands/`.
+!`IFS=' ' read -ra ARGS <<< "$ARGUMENTS" && bun run --cwd "${HANDOFF_REPO:-$(pwd)}" src/cli.ts "${ARGS[@]}"`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You have a backlog. You have three different agents you'd like to try on it. You
 - [bun](https://bun.sh) ≥ 1.1
 - `git` ≥ 2.20 (for `git worktree`)
 - [`gh`](https://cli.github.com) authenticated (`gh auth login`)
+- Python ≥ 3.8 (only for `scripts/install.py` — invoke as `python3` on macOS/Linux, `py -3` on Windows if `python` isn't on PATH)
 - The agent CLI you want to dispatch to:
   - `claude` → [Anthropic Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code)
   - `codex` → [OpenAI Codex CLI](https://github.com/openai/codex)
@@ -41,7 +42,7 @@ python scripts/install.py
 
 This:
 
-1. Renders `.claude/commands/handoff.md` into `~/.claude/commands/handoff.md` with this checkout's absolute path baked in, so `/handoff` works in any Claude Code session.
+1. Renders `.claude/commands/handoff.md` into `~/.claude/commands/handoff.md` with this checkout's absolute path baked in, so `/handoff` works in any Claude Code session started after install.
 2. Runs `bun link` so the `handoff` CLI is on your PATH.
 
 Pass `--no-link` to skip the CLI link and install only the slash command. Re-run after moving the checkout.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ handoff claude #42
 This:
 
 1. Resolves the GitHub issue title + body via `gh issue view 42`.
-2. Creates branch `handoff/claude/42-<slug>` off the repo's default branch.
-3. Adds a worktree as a sibling directory: `<repo-parent>/<repo>-handoff-42-<slug>`.
+2. Creates branch `claude/issue-42` off the repo's default branch.
+3. Adds a worktree as a sibling directory: `<repo-parent>/<repo>-issue-42`.
 4. Writes `PROMPT.md` to the worktree with the issue, the branch, and a workflow contract.
 5. Spawns a new terminal window in that worktree, running `claude "$(cat PROMPT.md)"`.
 
@@ -80,14 +80,14 @@ Three independent worktrees + three terminal windows, in parallel. Each opens it
 handoff codex "tighten error messages in the API client"
 ```
 
-No issue lookup. The text is passed as the task description in `PROMPT.md`. The branch becomes `handoff/codex/<slug>`.
+No issue lookup. The text is passed as the task description in `PROMPT.md`. The branch becomes `codex/<short-slug>` (slug capped at 20 chars).
 
 ### Cleanup
 
 If the wrapper missed cleanup (you closed the terminal before merging the PR, you ran `gh` while offline, etc.):
 
 ```bash
-handoff cleanup handoff/claude/42-fix-login
+handoff cleanup claude/issue-42
 ```
 
 This re-checks the PR state and removes the worktree + branch if merged.

--- a/docs/initial-prompt.md
+++ b/docs/initial-prompt.md
@@ -1,6 +1,6 @@
 # Initial Prompt
 
-> Verbatim (lightly cleaned: fixed copy-paste artifacts like `&#x20;`, `\##`, and stray line breaks). Original lives at `../PROMPT.md`.
+> Verbatim (lightly cleaned: fixed copy-paste artifacts like `&#x20;`, `\##`, and stray line breaks). The original root `PROMPT.md` was removed once this canonical copy landed; runtime `PROMPT.md` files are written into per-handoff worktrees by the CLI.
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -28,8 +28,8 @@
 
 ### F3. Worktree creation
 
-- Branch name: `handoff/<tool>/<N>-<slug>` (issue) or `handoff/<tool>/<slug>` (free-form). Slug is kebab-cased title, max 40 chars.
-- Worktree path: sibling to the repo, `<parent>/<repo>-handoff-<branch-tail>`.
+- Branch name: `<tool>/issue-<N>` (issue), `<tool>/pr-<N>` (PR), or `<tool>/<slug>` (free-form). Slug is kebab-cased description, capped at 20 chars.
+- Worktree path: sibling to the repo, `<parent>/<repo>-<branch-tail>` (e.g. `<repo>-issue-7`, `<repo>-pr-12`, `<repo>-cleanup-readme`).
 - Branch off the repo's default branch (resolved via `gh repo view --json defaultBranchRef`), not the current HEAD.
 - Refuse to create a worktree for a branch that already exists; suggest re-running with `--resume` (post-v0.1.0).
 

--- a/scripts/handoff-runner.ps1
+++ b/scripts/handoff-runner.ps1
@@ -1,8 +1,12 @@
 # Wrapper invoked inside a freshly-spawned PowerShell window.
-# Usage: handoff-runner.ps1 <repo-root> <tool> <branch>
+# Usage: handoff-runner.ps1 <handoff-repo> <tool> <branch>
+#
+# $HandoffRepo is the path to the handoff CLI's checkout (where src/cli.ts
+# lives) — NOT the user's project repo. The cwd of this script is the worktree
+# of the user's project; PROMPT.md sits there.
 
 param(
-  [Parameter(Mandatory = $true)][string]$RepoRoot,
+  [Parameter(Mandatory = $true)][string]$HandoffRepo,
   [Parameter(Mandatory = $true)][ValidateSet('claude', 'codex', 'copilot')][string]$Tool,
   [Parameter(Mandatory = $true)][string]$Branch
 )
@@ -24,7 +28,7 @@ Write-Host '----------------------------------------'
 Write-Host "[handoff] $Tool exited (code $toolExit). Running cleanup for $Branch..."
 Write-Host '----------------------------------------'
 
-& bun "$RepoRoot/src/cli.ts" cleanup $Branch
+& bun "$HandoffRepo/src/cli.ts" cleanup $Branch
 $cleanupExit = $LASTEXITCODE
 
 Write-Host ''

--- a/scripts/handoff-runner.sh
+++ b/scripts/handoff-runner.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 # Wrapper invoked inside a freshly-spawned terminal window.
-# Usage: handoff-runner.sh <repo-root> <tool> <branch>
+# Usage: handoff-runner.sh <handoff-repo> <tool> <branch>
 #
-# Runs the chosen tool with PROMPT.md (in cwd) as the seed prompt, then on
-# exit invokes `bun <repo-root>/src/cli.ts cleanup <branch>` which removes
-# the worktree iff the PR has been merged.
+# <handoff-repo> is the path to the handoff CLI's checkout (where src/cli.ts
+# lives) — NOT the user's project repo. The cwd of this script is the worktree
+# of the user's project; PROMPT.md sits there.
+#
+# Runs the chosen tool with PROMPT.md as the seed prompt, then on exit invokes
+# `bun <handoff-repo>/src/cli.ts cleanup <branch>` which removes the worktree
+# iff the PR has been merged.
 
 set -uo pipefail
 
 if [ "$#" -ne 3 ]; then
-  echo "usage: handoff-runner.sh <repo-root> <tool> <branch>" >&2
+  echo "usage: handoff-runner.sh <handoff-repo> <tool> <branch>" >&2
   exit 64
 fi
 
-REPO_ROOT="$1"
+HANDOFF_REPO="$1"
 TOOL="$2"
 BRANCH="$3"
 
@@ -41,7 +45,7 @@ echo "----------------------------------------"
 echo "[handoff] $TOOL exited (code $TOOL_EXIT). Running cleanup for $BRANCH..."
 echo "----------------------------------------"
 
-bun "$REPO_ROOT/src/cli.ts" cleanup "$BRANCH"
+bun "$HANDOFF_REPO/src/cli.ts" cleanup "$BRANCH"
 CLEANUP_EXIT=$?
 
 echo

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -10,6 +10,7 @@ Re-run this after moving the checkout.
 from __future__ import annotations
 
 import argparse
+import shlex
 import shutil
 import subprocess
 import sys
@@ -20,7 +21,11 @@ SOURCE_CMD = REPO_ROOT / ".claude" / "commands" / "handoff.md"
 TARGET_DIR = Path.home() / ".claude" / "commands"
 TARGET_CMD = TARGET_DIR / "handoff.md"
 
-PLACEHOLDER = "${HANDOFF_REPO:-$(pwd)}"
+# Surrounding double quotes are part of the sentinel so the substitution only
+# hits the bash `--cwd` argument and never the markdown-backticked prose that
+# explains the placeholder. The replacement uses `shlex.quote` (single-quoted)
+# so a checkout path containing `$`, backticks, or whitespace stays inert.
+PLACEHOLDER = '"${HANDOFF_REPO:-$(pwd)}"'
 
 
 def install_command() -> None:
@@ -35,7 +40,7 @@ def install_command() -> None:
         )
 
     repo_path = REPO_ROOT.as_posix()
-    rendered = body.replace(PLACEHOLDER, repo_path)
+    rendered = body.replace(PLACEHOLDER, shlex.quote(repo_path))
 
     TARGET_DIR.mkdir(parents=True, exist_ok=True)
     TARGET_CMD.write_text(rendered, encoding="utf-8")
@@ -43,17 +48,19 @@ def install_command() -> None:
     print(f"          repo path baked in : {repo_path}")
 
 
-def link_bin() -> None:
+def link_bin() -> bool:
     bun = shutil.which("bun")
     if bun is None:
-        print("[install] WARNING: `bun` not found on PATH; skipping `bun link`.")
-        return
+        print("[install] ERROR: `bun` not found on PATH; cannot run `bun link`.")
+        print("          Install bun (https://bun.sh) and re-run, or pass --no-link.")
+        return False
     try:
         subprocess.run([bun, "link"], cwd=REPO_ROOT, check=True)
     except subprocess.CalledProcessError as exc:
-        print(f"[install] WARNING: `bun link` exited {exc.returncode}.")
-        return
+        print(f"[install] ERROR: `bun link` exited {exc.returncode}.")
+        return False
     print("[install] `bun link` succeeded; `handoff` should be on PATH.")
+    return True
 
 
 def main() -> None:
@@ -68,12 +75,23 @@ def main() -> None:
     args = parser.parse_args()
 
     install_command()
+
+    linked = True
     if not args.no_link:
-        link_bin()
+        linked = link_bin()
 
     print()
-    print("Done. Restart Claude Code (slash commands are loaded at session start),")
-    print("then run `/handoff` in any repo.")
+    if linked:
+        print("Done. Restart Claude Code (slash commands are loaded at session start),")
+        if args.no_link:
+            print("then run `/handoff` in any repo. (Skipped `bun link` per --no-link;")
+            print("the `handoff` CLI is not on PATH unless you linked it yourself.)")
+        else:
+            print("then run `/handoff` in any repo.")
+    else:
+        print("Slash command installed, but the `handoff` CLI is NOT on PATH.")
+        print("Fix the `bun link` failure above (or re-run with --no-link to silence it).")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -23,8 +23,9 @@ TARGET_CMD = TARGET_DIR / "handoff.md"
 
 # Surrounding double quotes are part of the sentinel so the substitution only
 # hits the bash `--cwd` argument and never the markdown-backticked prose that
-# explains the placeholder. The replacement uses `shlex.quote` (single-quoted)
-# so a checkout path containing `$`, backticks, or whitespace stays inert.
+# explains the placeholder. The replacement uses `shlex.quote`, which adds
+# single quotes only if the path needs them — so a checkout containing `$`,
+# backticks, or whitespace stays inert and a "boring" path stays unquoted.
 PLACEHOLDER = '"${HANDOFF_REPO:-$(pwd)}"'
 
 

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -3,17 +3,31 @@ import type { Tool } from './args.ts';
 
 export interface BranchInput {
   tool: Tool;
+  /** Issue number → branch tail `issue-<N>`. */
   issueNumber?: number;
-  slug: string;
+  /** PR number → branch tail `pr-<N>`. */
+  prNumber?: number;
+  /** Free-form slug (already slugified). Used when neither issueNumber nor prNumber is set. */
+  slug?: string;
 }
 
-export function branchName({ tool, issueNumber, slug }: BranchInput): string {
-  const tail = issueNumber !== undefined ? `${issueNumber}-${slug}` : slug;
-  return `handoff/${tool}/${tail}`;
+export function branchName({ tool, issueNumber, prNumber, slug }: BranchInput): string {
+  if (issueNumber !== undefined) {
+    return `${tool}/issue-${issueNumber}`;
+  }
+  if (prNumber !== undefined) {
+    return `${tool}/pr-${prNumber}`;
+  }
+  if (!slug) {
+    throw new Error('branchName: must provide issueNumber, prNumber, or slug');
+  }
+  return `${tool}/${slug}`;
 }
 
+/** Tail = everything after the leading `<tool>/` segment. */
 export function branchTail(branch: string): string {
-  return branch.split('/').slice(2).join('/') || branch;
+  const slash = branch.indexOf('/');
+  return slash === -1 ? branch : branch.slice(slash + 1);
 }
 
 export interface WorktreePathInput {
@@ -25,5 +39,5 @@ export function worktreePath({ repoRoot, branch }: WorktreePathInput): string {
   const parent = dirname(repoRoot);
   const repoName = basename(repoRoot);
   const tail = branchTail(branch).replace(/\//g, '-');
-  return join(parent, `${repoName}-handoff-${tail}`);
+  return join(parent, `${repoName}-${tail}`);
 }

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { deleteBranch, removeWorktree } from './git.ts';
+import { branchExists, deleteBranch, removeWorktree } from './git.ts';
 import { branchTail, worktreePath } from './branch.ts';
 import { GhError, prMergedFor } from './github.ts';
 
@@ -33,15 +33,36 @@ export async function cleanup(branch: string, opts: { repoRoot: string }): Promi
     };
   }
 
-  if (existsSync(path)) {
+  const removedWorktree = existsSync(path);
+  if (removedWorktree) {
     await removeWorktree(path);
   }
-  await deleteBranch(branch).catch(() => {
-    // Branch may already be gone if the worktree removal pruned it; ignore.
-  });
+
+  let removedBranch = false;
+  if (await branchExists(branch)) {
+    try {
+      await deleteBranch(branch);
+      removedBranch = true;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return {
+        status: 'unknown',
+        message:
+          `${removedWorktree ? `Removed worktree ${path}, but ` : ''}` +
+          `failed to delete branch ${branch}: ${reason}. ` +
+          `Delete it manually with \`git branch -D ${branch}\`.`,
+      };
+    }
+  }
+
+  const parts: string[] = [];
+  if (removedWorktree) parts.push(`Removed worktree ${path}`);
+  else parts.push(`Worktree ${path} was not present`);
+  if (removedBranch) parts.push(`deleted branch ${branch}`);
+  else parts.push(`branch ${branch} was already gone`);
 
   return {
     status: 'removed',
-    message: `Removed worktree ${path} and deleted branch ${branch} (PR merged). [${branchTail(branch)}]`,
+    message: `${parts.join(' and ')} (PR merged). [${branchTail(branch)}]`,
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,12 +50,21 @@ async function runHandoffs(tool: Tool, refs: Ref[]) {
   const repoRoot = await currentRepoRoot();
   const repo = await repoName();
   const parentBranch = await defaultBranch();
-  const runnerScript = resolveRunnerScript();
+  const handoffRoot = resolveHandoffRoot();
+  const runnerScript = resolveRunnerScript(handoffRoot);
 
   let failures = 0;
   for (const ref of refs) {
     try {
-      await spawnHandoff({ tool, ref, repoRoot, repo, parentBranch, runnerScript });
+      await spawnHandoff({
+        tool,
+        ref,
+        repoRoot,
+        repo,
+        parentBranch,
+        handoffRoot,
+        runnerScript,
+      });
     } catch (err) {
       failures += 1;
       const msg = err instanceof Error ? err.message : String(err);
@@ -71,6 +80,7 @@ interface SpawnInput {
   repoRoot: string;
   repo: string;
   parentBranch: string;
+  handoffRoot: string;
   runnerScript: string;
 }
 
@@ -112,17 +122,19 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
   await openTerminal({
     cwd: path,
     scriptPath: input.runnerScript,
-    args: [input.repoRoot, input.tool, branch],
+    args: [input.handoffRoot, input.tool, branch],
   });
   console.log(`[handoff] terminal launched for ${branch}`);
 }
 
-function resolveRunnerScript(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  // src/cli.ts → repo-root/scripts/handoff-runner.{sh|ps1}
-  const repoRoot = resolve(here, '..');
+function resolveHandoffRoot(): string {
+  // src/cli.ts → handoff-repo-root
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..');
+}
+
+function resolveRunnerScript(handoffRoot: string): string {
   const isWin = platform() === 'win32';
-  const script = join(repoRoot, 'scripts', isWin ? 'handoff-runner.ps1' : 'handoff-runner.sh');
+  const script = join(handoffRoot, 'scripts', isWin ? 'handoff-runner.ps1' : 'handoff-runner.sh');
   if (!existsSync(script)) {
     throw new Error(
       `handoff: runner script not found at ${script}. ` +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { ArgsError, parseInvocation, type Ref, type Tool } from './args.ts';
 import { branchName, worktreePath } from './branch.ts';
 import { cleanup } from './cleanup.ts';
-import { createWorktree, currentRepoRoot, repoName } from './git.ts';
+import { createWorktree, mainRepoRoot, repoName } from './git.ts';
 import { defaultBranch, fetchIssue, type IssueDetails } from './github.ts';
 import { renderPrompt } from './prompt.ts';
 import { slugify } from './slug.ts';
@@ -37,7 +37,7 @@ async function main(argv: readonly string[]): Promise<number> {
   }
 
   if ('command' in invocation) {
-    const repoRoot = await currentRepoRoot();
+    const repoRoot = await mainRepoRoot();
     const result = await cleanup(invocation.branch, { repoRoot });
     console.log(result.message);
     return result.status === 'unknown' ? 1 : 0;
@@ -47,7 +47,7 @@ async function main(argv: readonly string[]): Promise<number> {
 }
 
 async function runHandoffs(tool: Tool, refs: Ref[]) {
-  const repoRoot = await currentRepoRoot();
+  const repoRoot = await mainRepoRoot();
   const repo = await repoName();
   const parentBranch = await defaultBranch();
   const handoffRoot = resolveHandoffRoot();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,20 +86,15 @@ interface SpawnInput {
 
 async function spawnHandoff(input: SpawnInput): Promise<void> {
   let issue: IssueDetails | undefined;
-  let slugSource: string;
+  let branch: string;
   if (input.ref.kind === 'issue') {
     issue = await fetchIssue(input.ref.number);
-    slugSource = issue.title;
+    branch = branchName({ tool: input.tool, issueNumber: issue.number });
   } else {
-    slugSource = input.ref.text;
+    const slug = slugify(input.ref.text, { maxLen: 20 });
+    branch = branchName({ tool: input.tool, slug });
   }
 
-  const slug = slugify(slugSource);
-  const branch = branchName({
-    tool: input.tool,
-    ...(issue ? { issueNumber: issue.number } : {}),
-    slug,
-  });
   const path = worktreePath({ repoRoot: input.repoRoot, branch });
 
   console.log(`[handoff] ${input.tool} → ${branch}`);

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path';
 import { run } from './run.ts';
 
 export class GitError extends Error {
@@ -12,8 +13,21 @@ export async function currentRepoRoot(): Promise<string> {
   return stdout.trim();
 }
 
+/**
+ * Root of the *main* worktree, even when called from inside a linked worktree.
+ * `currentRepoRoot()` returns whatever worktree we happen to be in, which makes
+ * worktree-path computation double up (e.g. `<repo>-issue-64-issue-64`) when
+ * handoff is invoked from inside a previous handoff's worktree.
+ */
+export async function mainRepoRoot(): Promise<string> {
+  const { stdout } = await run('git', ['rev-parse', '--path-format=absolute', '--git-common-dir']);
+  const gitDir = stdout.trim();
+  if (!gitDir) throw new GitError('git rev-parse --git-common-dir returned empty output');
+  return dirname(gitDir);
+}
+
 export async function repoName(): Promise<string> {
-  const root = await currentRepoRoot();
+  const root = await mainRepoRoot();
   const parts = root.replace(/\\/g, '/').split('/');
   const last = parts[parts.length - 1];
   if (!last) throw new GitError(`Could not derive repo name from ${root}`);

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { run } from './run.ts';
 
 export class GitError extends Error {
@@ -20,10 +20,12 @@ export async function currentRepoRoot(): Promise<string> {
  * handoff is invoked from inside a previous handoff's worktree.
  */
 export async function mainRepoRoot(): Promise<string> {
-  const { stdout } = await run('git', ['rev-parse', '--path-format=absolute', '--git-common-dir']);
+  const { stdout } = await run('git', ['rev-parse', '--git-common-dir']);
   const gitDir = stdout.trim();
   if (!gitDir) throw new GitError('git rev-parse --git-common-dir returned empty output');
-  return dirname(gitDir);
+  // Pre-2.31, git returns this relative to cwd; resolve in TS to stay
+  // compatible with the documented `git ≥ 2.20` minimum.
+  return dirname(resolve(process.cwd(), gitDir));
 }
 
 export async function repoName(): Promise<string> {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -32,10 +32,17 @@ off a single, scoped unit of work. Follow this sequence:
 6. **Open the PR.** \`gh pr create --base <parent-branch> --head <branch> --title "..."\`.
    Title should be a concise summary; body should reference the issue (e.g., \`Closes #N\`)
    and summarize the change.
-7. **Exit.** When the PR is open, exit this session normally. The terminal wrapper will
-   detect whether the PR has been merged and clean up the worktree automatically. If you
-   exit before the PR is merged, the worktree is preserved and \`handoff cleanup <branch>\`
-   removes it later.
+7. **Stop.** The moment \`gh pr create\` returns a PR URL, your job is done. Print exactly
+   one line — \`PR opened: <url>\` — and exit the session. Do **not** call any more tools
+   after this point: no extra commits, no \`gh pr edit\`, no \`gh pr view\`, no follow-up
+   verification, no "one more thing" cleanup. The terminal wrapper takes over from here,
+   detects whether the PR has been merged, and cleans up the worktree. If you exit before
+   the PR is merged, the worktree is preserved and \`handoff cleanup <branch>\` removes it
+   later.
+
+   If you find yourself thinking "but I should also..." after the PR is open — stop. File
+   it as a follow-up comment on the PR *only* if it's a real issue you discovered; otherwise
+   leave it alone. The user explicitly does not want you to keep iterating after handoff.
 
 **Boundaries.**
 - Do **not** touch files outside the scope of this task.

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -33,8 +33,8 @@ describe('parseInvocation', () => {
   });
 
   it('parses cleanup subcommand', () => {
-    const out = parseInvocation(['cleanup', 'handoff/claude/1-foo']);
-    expect(out).toEqual({ command: 'cleanup', branch: 'handoff/claude/1-foo' });
+    const out = parseInvocation(['cleanup', 'claude/issue-1']);
+    expect(out).toEqual({ command: 'cleanup', branch: 'claude/issue-1' });
   });
 
   it('rejects unknown tool', () => {

--- a/tests/branch.test.ts
+++ b/tests/branch.test.ts
@@ -2,31 +2,49 @@ import { describe, expect, it } from 'bun:test';
 import { branchName, branchTail, worktreePath } from '../src/branch.ts';
 
 describe('branchName', () => {
-  it('builds an issue branch with number prefix', () => {
-    expect(branchName({ tool: 'claude', issueNumber: 7, slug: 'fix-login' })).toBe(
-      'handoff/claude/7-fix-login',
-    );
+  it('builds an issue branch as <tool>/issue-<N>', () => {
+    expect(branchName({ tool: 'claude', issueNumber: 7 })).toBe('claude/issue-7');
   });
 
-  it('builds a freeform branch without number', () => {
-    expect(branchName({ tool: 'codex', slug: 'cleanup-readme' })).toBe(
-      'handoff/codex/cleanup-readme',
-    );
+  it('builds a PR branch as <tool>/pr-<N>', () => {
+    expect(branchName({ tool: 'codex', prNumber: 12 })).toBe('codex/pr-12');
+  });
+
+  it('builds a free-form branch as <tool>/<slug>', () => {
+    expect(branchName({ tool: 'codex', slug: 'cleanup-readme' })).toBe('codex/cleanup-readme');
+  });
+
+  it('throws when given neither issueNumber nor prNumber nor slug', () => {
+    expect(() => branchName({ tool: 'claude' })).toThrow();
   });
 });
 
 describe('branchTail', () => {
-  it('extracts everything after handoff/<tool>/', () => {
-    expect(branchTail('handoff/claude/7-fix-login')).toBe('7-fix-login');
+  it('extracts everything after the first slash', () => {
+    expect(branchTail('claude/issue-7')).toBe('issue-7');
+    expect(branchTail('codex/pr-12')).toBe('pr-12');
+    expect(branchTail('claude/cleanup-readme')).toBe('cleanup-readme');
+  });
+
+  it('returns the input unchanged when there is no slash', () => {
+    expect(branchTail('rogue')).toBe('rogue');
   });
 });
 
 describe('worktreePath', () => {
-  it('places the worktree as a sibling of the repo', () => {
+  it('places the worktree as a sibling of the repo, named <repo>-<branch-tail>', () => {
     const out = worktreePath({
       repoRoot: '/work/handoff',
-      branch: 'handoff/claude/7-fix-login',
+      branch: 'claude/issue-7',
     });
-    expect(out.replace(/\\/g, '/')).toBe('/work/handoff-handoff-7-fix-login');
+    expect(out.replace(/\\/g, '/')).toBe('/work/handoff-issue-7');
+  });
+
+  it('handles PR branches', () => {
+    const out = worktreePath({
+      repoRoot: '/work/scope',
+      branch: 'codex/pr-12',
+    });
+    expect(out.replace(/\\/g, '/')).toBe('/work/scope-pr-12');
   });
 });

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -6,7 +6,7 @@ describe('renderPrompt', () => {
     const out = renderPrompt({
       tool: 'claude',
       repoName: 'handoff',
-      branch: 'handoff/claude/1-fix-login',
+      branch: 'claude/issue-1',
       parentBranch: 'dev',
       worktreePath: '/work/handoff-handoff-1-fix-login',
       issue: {
@@ -21,7 +21,7 @@ describe('renderPrompt', () => {
     expect(out).toContain('## Issue #1: Fix login redirect');
     expect(out).toContain('After SSO, users are sent to /dashboard');
     expect(out).toContain('Workflow contract');
-    expect(out).toContain('handoff/claude/1-fix-login');
+    expect(out).toContain('claude/issue-1');
     expect(out).toContain('**Labels:** `bug`, `auth`');
   });
 
@@ -29,7 +29,7 @@ describe('renderPrompt', () => {
     const out = renderPrompt({
       tool: 'claude',
       repoName: 'handoff',
-      branch: 'handoff/claude/1-x',
+      branch: 'claude/issue-1',
       parentBranch: 'dev',
       worktreePath: '/tmp/x',
       issue: {
@@ -47,9 +47,9 @@ describe('renderPrompt', () => {
     const out = renderPrompt({
       tool: 'codex',
       repoName: 'handoff',
-      branch: 'handoff/codex/cleanup-readme',
+      branch: 'codex/cleanup-readme',
       parentBranch: 'dev',
-      worktreePath: '/work/handoff-handoff-cleanup-readme',
+      worktreePath: '/work/handoff-cleanup-readme',
       freeformDescription: 'Tidy up the README and add a usage example.',
     });
     expect(out).toContain('## Task');
@@ -61,7 +61,7 @@ describe('renderPrompt', () => {
     const out = renderPrompt({
       tool: 'copilot',
       repoName: 'handoff',
-      branch: 'handoff/copilot/2-noop',
+      branch: 'copilot/issue-2',
       parentBranch: 'dev',
       worktreePath: '/tmp/x',
       issue: {

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -8,7 +8,7 @@ describe('renderPrompt', () => {
       repoName: 'handoff',
       branch: 'claude/issue-1',
       parentBranch: 'dev',
-      worktreePath: '/work/handoff-handoff-1-fix-login',
+      worktreePath: '/work/handoff-issue-1',
       issue: {
         number: 1,
         title: 'Fix login redirect',

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -6,7 +6,7 @@ describe('buildLaunchSpec', () => {
     const spec = buildLaunchSpec('win32', {
       cwd: 'C:\\work\\repo',
       scriptPath: 'C:\\work\\repo\\runner.ps1',
-      args: ['claude', 'handoff/claude/1-foo'],
+      args: ['claude', 'claude/issue-1'],
     });
     expect(spec.command).toBe('wt.exe');
     expect(spec.args).toContain('-d');
@@ -30,7 +30,7 @@ describe('buildLaunchSpec', () => {
     const spec = buildLaunchSpec('linux', {
       cwd: '/work/repo',
       scriptPath: '/work/repo/runner.sh',
-      args: ['codex', 'handoff/codex/foo'],
+      args: ['codex', 'codex/issue-2'],
       terminal: 'gnome-terminal',
     });
     expect(spec.command).toBe('gnome-terminal');
@@ -56,11 +56,11 @@ describe('buildLaunchSpec', () => {
     const spec = buildLaunchSpec('linux', {
       cwd: '/x',
       scriptPath: '/x/r.sh',
-      args: ['claude', 'handoff/claude/foo'],
+      args: ['claude', 'claude/issue-3'],
       terminal: 'xterm',
     });
     expect(spec.command).toBe('xterm');
     // xterm -e expects the program and its args as separate argv items, not a single string.
-    expect(spec.args).toEqual(['-e', 'bash', '/x/r.sh', 'claude', 'handoff/claude/foo']);
+    expect(spec.args).toEqual(['-e', 'bash', '/x/r.sh', 'claude', 'claude/issue-3']);
   });
 });


### PR DESCRIPTION
This pull request introduces significant improvements to the handoff CLI, focusing on branch naming conventions, worktree paths, argument handling, and installation robustness. The changes ensure clearer branch names, safer path handling, better cross-platform support, and more reliable installation and cleanup processes.

**Branch and Worktree Naming Improvements:**
- Standardized branch names to `<tool>/issue-<N>`, `<tool>/pr-<N>`, or `<tool>/<slug>` (with slugs capped at 20 chars for free-form tasks), and updated worktree paths to `<repo>-<branch-tail>` for clarity and consistency. [[1]](diffhunk://#diff-f20e08ee9f2a0a9ca876fd31d69de01b9e23c21de05351466556e7fcf43f3ff6R6-R30) [[2]](diffhunk://#diff-f20e08ee9f2a0a9ca876fd31d69de01b9e23c21de05351466556e7fcf43f3ff6L28-R42) [[3]](diffhunk://#diff-71c6b87612afd48ee2b295f885d377d87f291385b3b5ff796e71947739393994L31-R32) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R64) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R91)

**Cross-platform and Argument Handling Enhancements:**
- Updated runner scripts and CLI invocation to distinguish between the handoff CLI repo and the user's project repo, ensuring correct path resolution and argument quoting on all platforms. [[1]](diffhunk://#diff-97f02412707f78e21adb8c7aee93e110d98a4448a2835f7af39025f85ea1193dL3-R20) [[2]](diffhunk://#diff-97f02412707f78e21adb8c7aee93e110d98a4448a2835f7af39025f85ea1193dL44-R48) [[3]](diffhunk://#diff-682a9c052655323075f33cd10ffb0379fdc71748cf55d151e69bc40b174e9bccL2-R9) [[4]](diffhunk://#diff-682a9c052655323075f33cd10ffb0379fdc71748cf55d151e69bc40b174e9bccL27-R31) [[5]](diffhunk://#diff-42f9803208182bf26b63fd2335b00e9278075b42ffaa8658614539bb4ec8d4f9L10-R10) [[6]](diffhunk://#diff-aea06381e5b0018003a3e1e9a05c66b4171729c1cb06653ac45dcb568800addfL23-R28) [[7]](diffhunk://#diff-aea06381e5b0018003a3e1e9a05c66b4171729c1cb06653ac45dcb568800addfL38-R63) [[8]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL10-R10) [[9]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL40-R40) [[10]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL50-R67) [[11]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR83-L92) [[12]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL115-R132)

**Installation and Error Handling Improvements:**
- Improved `scripts/install.py` to use `shlex.quote` for safe path substitution, provided clearer error messages, and made `bun link` failures explicit, preventing silent misconfiguration. [[1]](diffhunk://#diff-aea06381e5b0018003a3e1e9a05c66b4171729c1cb06653ac45dcb568800addfR13) [[2]](diffhunk://#diff-aea06381e5b0018003a3e1e9a05c66b4171729c1cb06653ac45dcb568800addfL38-R63) [[3]](diffhunk://#diff-aea06381e5b0018003a3e1e9a05c66b4171729c1cb06653ac45dcb568800addfR78-R94) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R45)

**Cleanup Logic Robustness:**
- Enhanced cleanup logic to check for branch existence before deletion, provide detailed status messages, and handle errors more gracefully. [[1]](diffhunk://#diff-00def875f44d042f744ce17ba1e10a92590c2e459229ed8fd1f786698da70ce9L2-R2) [[2]](diffhunk://#diff-00def875f44d042f744ce17ba1e10a92590c2e459229ed8fd1f786698da70ce9L36-R66)

**Documentation Updates:**
- Updated all relevant documentation to reflect the new branch/worktree naming, clarify Python requirements, and explain the improved installation and runtime process. [[1]](diffhunk://#diff-ecabb6d06b39bb0c7262b1ebd1fe5e65c21caf03a4c95ff11fa224835c9aee33L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R45) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R64) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R91) [[6]](diffhunk://#diff-71c6b87612afd48ee2b295f885d377d87f291385b3b5ff796e71947739393994L31-R32)

Let me know if you want a walkthrough of any specific change or have questions about the new conventions!