### PR TITLE
feat(claude): --loop mode for self-driving PR review cycles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 | File                         | Responsibility                                                            | Pure? |
 | ---------------------------- | ------------------------------------------------------------------------- | ----- |
 | `src/cli.ts`                 | Entrypoint. Parses argv, fans out to subcommands, isolates per-ref errors | no    |
-| `src/args.ts`                | Argv → `{ tool, refs[] } \| { command: 'cleanup', branch }`               | yes   |
+| `src/args.ts`                | Argv → `{ tool, refs[], loop } \| { command: 'cleanup', branch }`         | yes   |
 | `src/slug.ts`                | Title → kebab-case slug                                                   | yes   |
 | `src/branch.ts`              | Branch + worktree path naming                                             | yes   |
 | `src/prompt.ts`              | `PROMPT.md` template renderer                                             | yes   |
@@ -49,6 +49,8 @@ Tests live in `tests/` and cover the **pure** modules. I/O modules are smoke-tes
 ## How to extend the workflow contract in `PROMPT.md`
 
 Edit the `WORKFLOW_CONTRACT` constant in `src/prompt.ts`. The template is intentionally one big string so it's reviewable as a unit — don't split it into per-tool variants without a strong reason.
+
+There is a second constant, `WORKFLOW_CONTRACT_LOOP`, used when `--loop` is passed (claude only). Keep both as full strings rather than splicing — easier to review the agent's instructions for each mode in one place.
 
 ## Out of scope until later
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ handoff codex "tighten error messages in the API client"
 
 No issue lookup. The text is passed as the task description in `PROMPT.md`. The branch becomes `codex/<short-slug>` (slug capped at 20 chars).
 
+### Loop mode (`--loop`, claude only)
+
+```bash
+handoff claude --loop #7
+```
+
+By default the agent stops the moment `gh pr create` returns. With `--loop`, the prompt instructs Claude Code to **stay resident** after the PR is open and self-drive the review cycle:
+
+- Poll the PR (`gh pr view`, `gh pr checks`) on a 60–180s cadence.
+- Triage CI failures and fix them at the source.
+- Triage review comments. **Bot reviewers (Copilot, Codex, github-actions) are default-deny** — the agent reads each comment, decides if there's a real underlying problem, and fixes at the source rather than blindly applying suggested patches.
+- Commit and push fixes per round.
+- Bail with a `[handoff loop] bailing` PR comment if it hits 5 rounds, an unresolvable CI failure, or a merge conflict.
+
+The agent does **not** merge — that's still your call. Once you (or repo automation) merge, it exits and the wrapper cleans up the worktree as usual.
+
+`--loop` is rejected for `codex` and `copilot`: those CLIs run as ephemeral sessions in their own windows and don't have a natural "stay resident and poll" model.
+
 ### Cleanup
 
 If the wrapper missed cleanup (you closed the terminal before merging the PR, you ran `gh` while offline, etc.):

--- a/src/args.ts
+++ b/src/args.ts
@@ -90,19 +90,39 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     );
   }
 
-  // Pull out flags before ref parsing so they can appear anywhere after the tool.
-  // Stop flag-extraction at the first non-flag token so flag-looking free-form
-  // text (rare) still parses as the start of a description.
-  const rest: string[] = [];
+  const rest = argv.slice(1);
+  if (rest.length === 0) {
+    throw new ArgsError(`Missing issue reference. Usage: handoff ${head} <ref...>`);
+  }
+
+  // Walk tokens once. While we're still in "flag-or-ref" mode, `--loop` is the
+  // flag and may appear anywhere among the issue refs (before, between, after).
+  // The first token that is neither a flag nor an issue-ref pattern flips us
+  // into free-form mode, and from there everything (including a literal
+  // `--loop`) becomes part of the description.
   let loop = false;
-  let sawNonFlag = false;
-  for (const tok of argv.slice(1)) {
-    if (!sawNonFlag && tok === '--loop') {
+  const refs: Ref[] = [];
+  let i = 0;
+  while (i < rest.length) {
+    const tok = rest[i];
+    if (tok === '--loop') {
       loop = true;
+      i += 1;
       continue;
     }
-    sawNonFlag = true;
-    rest.push(tok);
+    const issue = parseIssueToken(rest, i);
+    if (issue) {
+      refs.push(issue.ref);
+      i += issue.consumed;
+      continue;
+    }
+    // Free-form description: collect all remaining tokens verbatim.
+    const text = rest.slice(i).join(' ').trim();
+    if (text.length === 0) {
+      throw new ArgsError('Empty free-form description.');
+    }
+    refs.push({ kind: 'freeform', text });
+    break;
   }
 
   if (loop && head !== 'claude') {
@@ -112,26 +132,8 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     );
   }
 
-  if (rest.length === 0) {
+  if (refs.length === 0) {
     throw new ArgsError(`Missing issue reference. Usage: handoff ${head} <ref...>`);
-  }
-
-  const refs: Ref[] = [];
-  let i = 0;
-  while (i < rest.length) {
-    const issue = parseIssueToken(rest, i);
-    if (issue) {
-      refs.push(issue.ref);
-      i += issue.consumed;
-      continue;
-    }
-    // Anything else: collect remaining tokens as a single free-form description.
-    const text = rest.slice(i).join(' ').trim();
-    if (text.length === 0) {
-      throw new ArgsError('Empty free-form description.');
-    }
-    refs.push({ kind: 'freeform', text });
-    break;
   }
 
   return { tool: head, refs, loop };

--- a/src/args.ts
+++ b/src/args.ts
@@ -92,7 +92,10 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
 
   const rest = argv.slice(1);
   if (rest.length === 0) {
-    throw new ArgsError(`Missing issue reference. Usage: handoff ${head} <ref...>`);
+    throw new ArgsError(
+      `Missing reference. Usage: handoff ${head} <ref...> ` +
+        `(<ref> = #N, "Issue #N", or a free-form task description).`,
+    );
   }
 
   // Walk tokens once. While we're still in "flag-or-ref" mode, `--loop` is the
@@ -133,7 +136,10 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
   }
 
   if (refs.length === 0) {
-    throw new ArgsError(`Missing issue reference. Usage: handoff ${head} <ref...>`);
+    throw new ArgsError(
+      `Missing reference. Usage: handoff ${head} <ref...> ` +
+        `(<ref> = #N, "Issue #N", or a free-form task description).`,
+    );
   }
 
   return { tool: head, refs, loop };

--- a/src/args.ts
+++ b/src/args.ts
@@ -16,6 +16,7 @@ export type Ref = IssueRef | FreeFormRef;
 export interface ParsedArgs {
   tool: Tool;
   refs: Ref[];
+  loop: boolean;
 }
 
 export interface CleanupArgs {
@@ -89,7 +90,28 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     );
   }
 
-  const rest = argv.slice(1);
+  // Pull out flags before ref parsing so they can appear anywhere after the tool.
+  // Stop flag-extraction at the first non-flag token so flag-looking free-form
+  // text (rare) still parses as the start of a description.
+  const rest: string[] = [];
+  let loop = false;
+  let sawNonFlag = false;
+  for (const tok of argv.slice(1)) {
+    if (!sawNonFlag && tok === '--loop') {
+      loop = true;
+      continue;
+    }
+    sawNonFlag = true;
+    rest.push(tok);
+  }
+
+  if (loop && head !== 'claude') {
+    throw new ArgsError(
+      `--loop is only supported for the 'claude' tool (got '${head}'). ` +
+        `codex and copilot run as ephemeral sessions and don't support staying resident for review cycles.`,
+    );
+  }
+
   if (rest.length === 0) {
     throw new ArgsError(`Missing issue reference. Usage: handoff ${head} <ref...>`);
   }
@@ -112,5 +134,5 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     break;
   }
 
-  return { tool: head, refs };
+  return { tool: head, refs, loop };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,10 +43,10 @@ async function main(argv: readonly string[]): Promise<number> {
     return result.status === 'unknown' ? 1 : 0;
   }
 
-  return await runHandoffs(invocation.tool, invocation.refs);
+  return await runHandoffs(invocation.tool, invocation.refs, invocation.loop);
 }
 
-async function runHandoffs(tool: Tool, refs: Ref[]) {
+async function runHandoffs(tool: Tool, refs: Ref[], loop: boolean) {
   const repoRoot = await mainRepoRoot();
   const repo = await repoName();
   const parentBranch = await defaultBranch();
@@ -64,6 +64,7 @@ async function runHandoffs(tool: Tool, refs: Ref[]) {
         parentBranch,
         handoffRoot,
         runnerScript,
+        loop,
       });
       console.log(`[handoff] OK ${describeRef(ref)}`);
     } catch (err) {
@@ -89,6 +90,7 @@ interface SpawnInput {
   parentBranch: string;
   handoffRoot: string;
   runnerScript: string;
+  loop: boolean;
 }
 
 async function spawnHandoff(input: SpawnInput): Promise<void> {
@@ -115,6 +117,7 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
     branch,
     parentBranch: input.parentBranch,
     worktreePath: path,
+    loop: input.loop,
     ...(issue ? { issue } : {}),
     ...(input.ref.kind === 'freeform' ? { freeformDescription: input.ref.text } : {}),
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export const VERSION = '0.1.0';
 export const HELP = `handoff v${VERSION}
 
 USAGE
-  handoff <tool> <ref...>          spawn a worktree per ref and launch <tool>
+  handoff <tool> [--loop] <ref...> spawn a worktree per ref and launch <tool>
   handoff cleanup <branch>         remove a worktree if its PR has merged
   handoff --help                   show this message
   handoff --version                show version
@@ -19,10 +19,16 @@ REFS
   Issue #N       same as #N
   <free text>    a free-form task description (no issue created)
 
+FLAGS
+  --loop         (claude only) keep the agent resident after \`gh pr create\`
+                 to triage review feedback and CI, push fixes, and iterate
+                 until the PR is merged (or a bail condition trips).
+
 EXAMPLES
   handoff codex #1
   handoff copilot Issue #2
   handoff claude #1 #2 #3                    # fleet: 3 parallel worktrees
+  handoff claude --loop #7                   # implement and self-drive review
   handoff claude "tidy up the README"
 
 REQUIREMENTS

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,8 @@ export const VERSION = '0.1.0';
 export const HELP = `handoff v${VERSION}
 
 USAGE
-  handoff <tool> [--loop] <ref...> spawn a worktree per ref and launch <tool>
+  handoff <tool> <ref...>          spawn a worktree per ref and launch <tool>
+  handoff claude [--loop] <ref...> claude only: stay resident through review (see FLAGS)
   handoff cleanup <branch>         remove a worktree if its PR has merged
   handoff --help                   show this message
   handoff --version                show version

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -6,6 +6,7 @@ export interface PromptContext {
   branch: string;
   worktreePath: string;
   parentBranch: string;
+  loop?: boolean;
   issue?: {
     number: number;
     title: string;
@@ -52,6 +53,72 @@ off a single, scoped unit of work. Follow this sequence:
   in the PR description (or in a comment if the PR isn't open yet), and exit.
 `;
 
+const WORKFLOW_CONTRACT_LOOP = `## Workflow contract (loop mode)
+
+You are working in a dedicated git worktree on the branch shown above. The user has handed
+off a single, scoped unit of work and asked you to **stay resident** through the review
+cycle until the PR merges. Follow this sequence:
+
+1. **Understand the task.** Re-read the issue or description above. If the task is ambiguous,
+   ask the user (in this terminal) one focused question before starting.
+2. **Implement.** Make the smallest set of changes that satisfies the task. Keep the diff
+   focused — do not refactor unrelated code, do not introduce new abstractions.
+3. **Verify.** Run the project's test suite, type checker, and linter. Fix anything you broke.
+4. **Commit.** Use Conventional Commits style. One logical commit per concern; small enough
+   to review.
+5. **Push.** \`git push -u origin <branch>\`.
+6. **Open the PR.** \`gh pr create --base <parent-branch> --head <branch> --title "..."\`.
+   Title should be a concise summary; body should reference the issue (e.g., \`Closes #N\`)
+   and summarize the change.
+7. **Enter the review loop.** Once the PR is open, do **not** exit. Iterate up to **5 rounds**
+   of: poll → triage → fix → push. Each round:
+   - **Poll.** Wait 60–180 seconds, then check PR state with
+     \`gh pr view <number> --json state,mergeable,mergeStateStatus,statusCheckRollup,reviews,comments\`
+     and \`gh pr checks <number>\`.
+   - **Exit if merged.** If \`state == "MERGED"\`, print \`PR merged: <url>\` and exit. The
+     wrapper will clean up the worktree.
+   - **Triage CI.** If checks failed, read the failing logs (\`gh run view --log-failed\`) and
+     fix the underlying issue. Don't paper over a flaky test by retrying — investigate.
+   - **Triage comments.** Fetch new review comments with
+     \`gh api repos/{owner}/{repo}/pulls/<n>/comments\` and \`gh pr view <n> --json reviews\`.
+     For each unresolved comment:
+     - **Bot reviewers (\`Copilot\`, \`copilot-pull-request-reviewer\`, \`github-actions\`, etc.)
+       are default-deny.** Do not apply suggested patches verbatim. Read the comment, decide
+       if there is a *real* underlying problem, and if so fix it at the source. If the
+       comment is noise (style nit you disagree with, false positive, hallucinated reference),
+       leave a brief reply explaining why you're not acting on it and move on.
+     - **Human reviewers** get the benefit of the doubt — address their concerns directly,
+       but still implement at the source rather than copy-pasting suggestions blindly.
+   - **Commit and push.** New commits per round, conventional style. Do **not** force-push
+     unless a reviewer explicitly asked you to rebase.
+   - **Re-request review.** If you pushed fixes addressing a specific reviewer, ping them
+     with \`gh pr review --request <login>\` or a brief comment.
+8. **Bail conditions.** Exit the loop (and the session) with a status comment on the PR
+   explaining what's blocking, in any of these cases:
+   - Iteration cap reached (5 rounds without merging).
+   - CI failing for a reason you can't resolve (e.g., infra outage, secrets you don't have,
+     a test that needs human judgment).
+   - Merge conflict you can't cleanly resolve.
+   - \`mergeable: false\` after a round, indicating divergence the human needs to settle.
+   - Reviewer asks for a change that contradicts the issue spec — surface the conflict, ask
+     the user, then exit.
+   When bailing, leave a single comment on the PR titled \`[handoff loop] bailing\` with the
+   reason and what you tried, then exit. Do **not** close the PR.
+
+**You do not merge the PR.** The human or repo automation merges. Your job is to keep the
+branch in a mergeable state and respond to feedback. Once the merge happens, the cleanup
+hook removes the worktree.
+
+**Boundaries.**
+- Do **not** touch files outside the scope of this task.
+- Do **not** delete or rewrite the worktree yourself — the wrapper handles that.
+- Do **not** open multiple PRs. One handoff = one PR.
+- Do **not** \`gh pr merge\` — the human merges. You only iterate until they do.
+- Do **not** apply Copilot/Codex/bot suggestions without analyzing the underlying problem.
+- If you cannot complete the task, leave the branch in a clean state, document what's left
+  in a PR comment, and exit.
+`;
+
 export function renderPrompt(ctx: PromptContext): string {
   const lines: string[] = [];
   lines.push(`# Handoff: ${ctx.repoName}`);
@@ -80,7 +147,7 @@ export function renderPrompt(ctx: PromptContext): string {
     lines.push('');
   }
 
-  lines.push(WORKFLOW_CONTRACT);
+  lines.push(ctx.loop ? WORKFLOW_CONTRACT_LOOP : WORKFLOW_CONTRACT);
 
   return lines.join('\n');
 }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -82,7 +82,7 @@ cycle until the PR merges. Follow this sequence:
    - **Triage comments.** Track the latest \`updated_at\` you've already triaged and only
      look at comments newer than that — the REST endpoints below don't expose thread
      resolution state, so re-scanning everything every round will burn cycles re-deciding
-     the same comments. The two relevant feeds:
+     the same comments. The three relevant feeds:
      - Line/review comments: \`gh api repos/{owner}/{repo}/pulls/<n>/comments?since=<iso8601>\`
      - Top-level discussion comments: \`gh api repos/{owner}/{repo}/issues/<n>/comments?since=<iso8601>\`
      - Review summaries (approve / request-changes bodies): \`gh pr view <n> --json reviews\`

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -91,15 +91,19 @@ cycle until the PR merges. Follow this sequence:
        but still implement at the source rather than copy-pasting suggestions blindly.
    - **Commit and push.** New commits per round, conventional style. Do **not** force-push
      unless a reviewer explicitly asked you to rebase.
-   - **Re-request review.** If you pushed fixes addressing a specific reviewer, ping them
-     with \`gh pr review --request <login>\` or a brief comment.
+   - **Re-request review.** If you pushed fixes addressing a specific reviewer, re-request
+     them with \`gh pr edit <number> --add-reviewer <login>\`, or leave a brief comment
+     summarising what changed.
 8. **Bail conditions.** Exit the loop (and the session) with a status comment on the PR
    explaining what's blocking, in any of these cases:
    - Iteration cap reached (5 rounds without merging).
    - CI failing for a reason you can't resolve (e.g., infra outage, secrets you don't have,
      a test that needs human judgment).
    - Merge conflict you can't cleanly resolve.
-   - \`mergeable: false\` after a round, indicating divergence the human needs to settle.
+   - GitHub reports the PR is non-mergeable after a round — \`mergeable\` is the string
+     \`"CONFLICTING"\` (or \`"UNKNOWN"\` that doesn't clear on the next poll), or
+     \`mergeStateStatus\` is \`"DIRTY"\` / \`"BEHIND"\` / \`"BLOCKED"\` for reasons you can't
+     resolve. (\`mergeable\` is a tri-state enum, not a boolean — don't compare to \`false\`.)
    - Reviewer asks for a change that contradicts the issue spec — surface the conflict, ask
      the user, then exit.
    When bailing, leave a single comment on the PR titled \`[handoff loop] bailing\` with the

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -79,9 +79,14 @@ cycle until the PR merges. Follow this sequence:
      wrapper will clean up the worktree.
    - **Triage CI.** If checks failed, read the failing logs (\`gh run view --log-failed\`) and
      fix the underlying issue. Don't paper over a flaky test by retrying — investigate.
-   - **Triage comments.** Fetch new review comments with
-     \`gh api repos/{owner}/{repo}/pulls/<n>/comments\` and \`gh pr view <n> --json reviews\`.
-     For each unresolved comment:
+   - **Triage comments.** Track the latest \`updated_at\` you've already triaged and only
+     look at comments newer than that — the REST endpoints below don't expose thread
+     resolution state, so re-scanning everything every round will burn cycles re-deciding
+     the same comments. The two relevant feeds:
+     - Line/review comments: \`gh api repos/{owner}/{repo}/pulls/<n>/comments?since=<iso8601>\`
+     - Top-level discussion comments: \`gh api repos/{owner}/{repo}/issues/<n>/comments?since=<iso8601>\`
+     - Review summaries (approve / request-changes bodies): \`gh pr view <n> --json reviews\`
+     For each new comment:
      - **Bot reviewers (\`Copilot\`, \`copilot-pull-request-reviewer\`, \`github-actions\`, etc.)
        are default-deny.** Do not apply suggested patches verbatim. Read the comment, decide
        if there is a *real* underlying problem, and if so fix it at the source. If the
@@ -89,6 +94,8 @@ cycle until the PR merges. Follow this sequence:
        leave a brief reply explaining why you're not acting on it and move on.
      - **Human reviewers** get the benefit of the doubt — address their concerns directly,
        but still implement at the source rather than copy-pasting suggestions blindly.
+     - If you genuinely need thread-resolution state (rare), fall back to the GraphQL
+       \`reviewThreads\` connection — REST doesn't surface it.
    - **Commit and push.** New commits per round, conventional style. Do **not** force-push
      unless a reviewer explicitly asked you to rebase.
    - **Re-request review.** If you pushed fixes addressing a specific reviewer, re-request
@@ -106,8 +113,10 @@ cycle until the PR merges. Follow this sequence:
      resolve. (\`mergeable\` is a tri-state enum, not a boolean — don't compare to \`false\`.)
    - Reviewer asks for a change that contradicts the issue spec — surface the conflict, ask
      the user, then exit.
-   When bailing, leave a single comment on the PR titled \`[handoff loop] bailing\` with the
-   reason and what you tried, then exit. Do **not** close the PR.
+   When bailing, leave a single comment on the PR whose first line is
+   \`[handoff loop] bailing\` (PR comments don't have titles — the marker has to live in
+   the body so it's searchable). Below that, give the reason and what you tried, then
+   exit. Do **not** close the PR.
 
 **You do not merge the PR.** The human or repo automation merges. Your job is to keep the
 branch in a mergeable state and respond to feedback. Once the merge happens, the cleanup

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -55,6 +55,29 @@ describe('parseInvocation', () => {
     });
   });
 
+  it('parses --loop after refs', () => {
+    // Common typo: flag trails the ref. Should still set loop, not create a
+    // phantom freeform handoff with text "--loop".
+    const out = parseInvocation(['claude', '#1', '--loop']);
+    expect(out).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'issue', number: 1 }],
+      loop: true,
+    });
+  });
+
+  it('parses --loop interleaved with refs', () => {
+    const out = parseInvocation(['claude', '#1', '--loop', '#2']);
+    expect(out).toEqual({
+      tool: 'claude',
+      refs: [
+        { kind: 'issue', number: 1 },
+        { kind: 'issue', number: 2 },
+      ],
+      loop: true,
+    });
+  });
+
   it('rejects --loop for codex', () => {
     expect(() => parseInvocation(['codex', '--loop', '#1'])).toThrow(/--loop is only supported/);
   });

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -4,12 +4,12 @@ import { ArgsError, parseInvocation } from '../src/args.ts';
 describe('parseInvocation', () => {
   it('parses a single #N reference', () => {
     const out = parseInvocation(['claude', '#1']);
-    expect(out).toEqual({ tool: 'claude', refs: [{ kind: 'issue', number: 1 }] });
+    expect(out).toEqual({ tool: 'claude', refs: [{ kind: 'issue', number: 1 }], loop: false });
   });
 
   it('parses "Issue #N" two-token form', () => {
     const out = parseInvocation(['copilot', 'Issue', '#2']);
-    expect(out).toEqual({ tool: 'copilot', refs: [{ kind: 'issue', number: 2 }] });
+    expect(out).toEqual({ tool: 'copilot', refs: [{ kind: 'issue', number: 2 }], loop: false });
   });
 
   it('parses fleet (multiple #N)', () => {
@@ -21,6 +21,7 @@ describe('parseInvocation', () => {
         { kind: 'issue', number: 2 },
         { kind: 'issue', number: 3 },
       ],
+      loop: false,
     });
   });
 
@@ -29,6 +30,46 @@ describe('parseInvocation', () => {
     expect(out).toEqual({
       tool: 'codex',
       refs: [{ kind: 'freeform', text: 'fix login redirect bug' }],
+      loop: false,
+    });
+  });
+
+  it('parses --loop for claude', () => {
+    const out = parseInvocation(['claude', '--loop', '#7']);
+    expect(out).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'issue', number: 7 }],
+      loop: true,
+    });
+  });
+
+  it('parses --loop with a fleet of refs', () => {
+    const out = parseInvocation(['claude', '--loop', '#1', '#2']);
+    expect(out).toEqual({
+      tool: 'claude',
+      refs: [
+        { kind: 'issue', number: 1 },
+        { kind: 'issue', number: 2 },
+      ],
+      loop: true,
+    });
+  });
+
+  it('rejects --loop for codex', () => {
+    expect(() => parseInvocation(['codex', '--loop', '#1'])).toThrow(/--loop is only supported/);
+  });
+
+  it('rejects --loop for copilot', () => {
+    expect(() => parseInvocation(['copilot', '--loop', '#1'])).toThrow(/--loop is only supported/);
+  });
+
+  it('keeps --loop literal once free-form text has started', () => {
+    // Once a non-flag token appears, later tokens are part of the description verbatim.
+    const out = parseInvocation(['claude', 'fix', '--loop', 'edge', 'case']);
+    expect(out).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'freeform', text: 'fix --loop edge case' }],
+      loop: false,
     });
   });
 

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -113,6 +113,22 @@ describe('parseInvocation', () => {
     expect(() => parseInvocation(['claude'])).toThrow(ArgsError);
   });
 
+  it('rejects --loop with no refs', () => {
+    // `claude --loop` extracts the flag but leaves zero refs; should still error.
+    expect(() => parseInvocation(['claude', '--loop'])).toThrow(/Missing reference/);
+  });
+
+  it('error message names all ref forms, not just issues', () => {
+    // Free-form is also a valid ref shape; the error shouldn't imply only #N is accepted.
+    try {
+      parseInvocation(['claude']);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ArgsError);
+      expect((err as Error).message).toMatch(/Missing reference/);
+      expect((err as Error).message).not.toMatch(/Missing issue reference/);
+    }
+  });
+
   it('rejects cleanup with no branch', () => {
     expect(() => parseInvocation(['cleanup'])).toThrow(ArgsError);
   });

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -110,6 +110,13 @@ describe('renderPrompt', () => {
     expect(out).not.toContain('mergeable: false');
     // Bot reviewers explicitly named.
     expect(out).toContain('Copilot');
+    // Comment-triage instruction must use the `since=` filter (REST endpoints don't
+    // surface thread resolution, so re-scanning everything every poll is wrong).
+    expect(out).toContain('?since=');
+    expect(out).not.toContain('For each unresolved comment');
+    // PR comments don't have titles — the bail marker has to live in the body.
+    expect(out).toContain('first line is');
+    expect(out).not.toContain('titled `[handoff loop] bailing`');
   });
 
   it('handles an empty issue body gracefully', () => {

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -101,6 +101,13 @@ describe('renderPrompt', () => {
     // Bail and merge-policy guards.
     expect(out).toContain('[handoff loop] bailing');
     expect(out).toContain('You do not merge the PR');
+    // Real gh commands — `gh pr review --request` doesn't exist; reviewer
+    // re-requests go through `gh pr edit --add-reviewer`. Don't regress.
+    expect(out).toContain('gh pr edit <number> --add-reviewer');
+    expect(out).not.toContain('gh pr review --request');
+    // `mergeable` is a tri-state enum (MERGEABLE/CONFLICTING/UNKNOWN), not a boolean.
+    expect(out).toContain('CONFLICTING');
+    expect(out).not.toContain('mergeable: false');
     // Bot reviewers explicitly named.
     expect(out).toContain('Copilot');
   });

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -57,6 +57,54 @@ describe('renderPrompt', () => {
     expect(out).not.toContain('## Issue');
   });
 
+  it('renders the default workflow contract when loop is false/absent', () => {
+    const out = renderPrompt({
+      tool: 'claude',
+      repoName: 'handoff',
+      branch: 'claude/issue-1',
+      parentBranch: 'dev',
+      worktreePath: '/tmp/x',
+      issue: {
+        number: 1,
+        title: 'X',
+        body: 'body',
+        url: 'https://github.com/x/y/issues/1',
+      },
+    });
+    expect(out).toContain('Workflow contract');
+    expect(out).not.toContain('Workflow contract (loop mode)');
+    // Default contract terminates after PR creation.
+    expect(out).toContain('your job is done');
+    expect(out).not.toContain('Enter the review loop');
+  });
+
+  it('renders the loop workflow contract when loop is true', () => {
+    const out = renderPrompt({
+      tool: 'claude',
+      repoName: 'handoff',
+      branch: 'claude/issue-7',
+      parentBranch: 'dev',
+      worktreePath: '/tmp/x',
+      loop: true,
+      issue: {
+        number: 7,
+        title: 'Self-driving review cycle',
+        body: 'body',
+        url: 'https://github.com/x/y/issues/7',
+      },
+    });
+    expect(out).toContain('Workflow contract (loop mode)');
+    expect(out).toContain('Enter the review loop');
+    expect(out).toContain('default-deny');
+    expect(out).toContain('5 rounds');
+    expect(out).toContain('do **not** exit');
+    // Bail and merge-policy guards.
+    expect(out).toContain('[handoff loop] bailing');
+    expect(out).toContain('You do not merge the PR');
+    // Bot reviewers explicitly named.
+    expect(out).toContain('Copilot');
+  });
+
   it('handles an empty issue body gracefully', () => {
     const out = renderPrompt({
       tool: 'copilot',


### PR DESCRIPTION
## Summary

Closes #7.

- Adds an optional `--loop` flag (claude-only) parsed in `src/args.ts`. Position-agnostic before refs; rejected with a clear error for `codex`/`copilot`.
- Adds a second workflow contract `WORKFLOW_CONTRACT_LOOP` in `src/prompt.ts`, selected when `loop: true`. It instructs Claude Code to stay resident after `gh pr create`, poll the PR (`gh pr view` / `gh pr checks`), triage CI failures, triage review comments with **default-deny on bot reviewers** (Copilot/Codex/github-actions) per CLAUDE.md, push fixes, and iterate up to **5 rounds** until merged. Bails with a `[handoff loop] bailing` PR comment on iteration cap, unresolvable CI, or merge conflict.
- Agent does **not** merge; humans/repo automation still own the merge. The existing runner-script cleanup runs on exit as before — no changes to `cleanup.ts` or the runner shells.
- HELP, README, CLAUDE.md updated to document the flag and the second contract constant.

## Design choices (from issue's open questions)

1. **Comment filtering**: default-deny on bots; address human reviewers but still implement at the source.
2. **Exit conditions**: 5 iterations max, plus CI/conflict/spec-conflict bails — all instructions to the agent, not enforced from TS.
3. **Merge strategy**: agent never merges. Simplest, safest, defers the merge-policy question to humans.
4. **Polling**: 60–180s cadence suggested in the prompt; agent decides.
5. **Bot-only PRs**: addressed by default-deny — if bots are the only reviewers and CI is green, the agent will keep iterating until the human merges or the cap trips.
6. **Cost**: hard cap at 5 iterations baked into the prompt.

## Test plan

- [x] `bun test` — 47 pass (added 6 new tests: 4 args, 2 prompt).
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean.
- [x] Manual sanity: rendered prompt for loop mode reviewed end-to-end.
- [ ] Smoke test: `handoff claude --loop #<some-issue>` end-to-end on a throwaway issue (deferred — needs a real Claude Code session and a PR to merge against; suggest doing this on a real follow-up issue).