### PR TITLE
fix(install): preserve caller cwd so gh resolves the right repo

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -7,4 +7,11 @@ allowed-tools: Bash
 Run the handoff CLI with the user's arguments. The CLI creates a worktree, writes
 `PROMPT.md`, and spawns a new terminal window running the chosen tool.
 
-!`xargs bun run --cwd "${HANDOFF_REPO:-$(pwd)}" src/cli.ts <<< "$ARGUMENTS"`
+The CLI **inherits the slash command's cwd** — that is intentional. `gh issue view`,
+`git rev-parse`, and worktree placement all resolve relative to the caller's repo, so
+pinning cwd to the handoff checkout would make every handoff target the wrong repo.
+`scripts/install.py` rewrites `${HANDOFF_CLI:-src/cli.ts}` below to the absolute path
+of `src/cli.ts` in this checkout; locally (un-installed) the fallback assumes you
+ran the slash command from inside the handoff repo.
+
+!`xargs bun run "${HANDOFF_CLI:-src/cli.ts}" <<< "$ARGUMENTS"`

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ python scripts/install.py
 
 This:
 
-1. Renders `.claude/commands/handoff.md` into `~/.claude/commands/handoff.md` with this checkout's absolute path baked in, so `/handoff` works in any Claude Code session started after install.
+1. Renders `.claude/commands/handoff.md` into `~/.claude/commands/handoff.md` with the absolute path to this checkout's `src/cli.ts` baked in, so `/handoff` works in any Claude Code session started after install. The slash command leaves the bun cwd alone so `gh issue view` resolves against the _caller's_ repo, not the handoff checkout.
 2. Runs `bun link` so the `handoff` CLI is on your PATH.
 
-Pass `--no-link` to skip the CLI link and install only the slash command. Re-run after moving the checkout.
+Pass `--no-link` to skip the CLI link and install only the slash command. Re-run after moving the checkout — and re-run if you installed before this `cli.ts`-path layout, since older installs pinned `--cwd` to the handoff repo and resolved issues against the wrong remote.
 
 > **Restart Claude Code after installing.** Slash commands under `~/.claude/commands/` are read at session start, so any sessions that were already open won't see `/handoff` until they're restarted.
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -46,6 +46,18 @@ def install_command() -> None:
         )
 
     cli_path = (REPO_ROOT / "src" / "cli.ts").as_posix()
+    # The slash command body wraps the shell invocation in a Markdown inline-code
+    # span (`!\`...\``), so a literal backtick in the path would terminate the
+    # span and corrupt the rendered command — `shlex.quote` only protects the
+    # shell layer, not the Markdown layer above it. Bail with a clear error
+    # rather than write a silently broken slash command.
+    if "`" in cli_path:
+        sys.exit(
+            f"error: checkout path {cli_path!r} contains a backtick. "
+            "The slash command is wrapped in Markdown inline code, so a literal "
+            "backtick would break the rendered command. Move the checkout to a "
+            "backtick-free path and re-run."
+        )
     rendered = body.replace(PLACEHOLDER, shlex.quote(cli_path))
 
     TARGET_DIR.mkdir(parents=True, exist_ok=True)

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -22,11 +22,16 @@ TARGET_DIR = Path.home() / ".claude" / "commands"
 TARGET_CMD = TARGET_DIR / "handoff.md"
 
 # Surrounding double quotes are part of the sentinel so the substitution only
-# hits the bash `--cwd` argument and never the markdown-backticked prose that
-# explains the placeholder. The replacement uses `shlex.quote`, which adds
-# single quotes only if the path needs them — so a checkout containing `$`,
-# backticks, or whitespace stays inert and a "boring" path stays unquoted.
-PLACEHOLDER = '"${HANDOFF_REPO:-$(pwd)}"'
+# hits the bash arg and never the markdown-backticked prose that explains the
+# placeholder. The replacement uses `shlex.quote`, which adds single quotes
+# only if the path needs them — so a checkout containing `$`, backticks, or
+# whitespace stays inert and a "boring" path stays unquoted.
+#
+# We substitute the absolute path to `src/cli.ts` (not `--cwd`) so the bun
+# process inherits the slash-command cwd. Earlier versions pinned `--cwd` to
+# the handoff checkout, which made `gh issue view` resolve issues against
+# `bminier/handoff` no matter which repo the user invoked `/handoff` from.
+PLACEHOLDER = '"${HANDOFF_CLI:-src/cli.ts}"'
 
 
 def install_command() -> None:
@@ -40,13 +45,13 @@ def install_command() -> None:
             "the install script needs to be updated."
         )
 
-    repo_path = REPO_ROOT.as_posix()
-    rendered = body.replace(PLACEHOLDER, shlex.quote(repo_path))
+    cli_path = (REPO_ROOT / "src" / "cli.ts").as_posix()
+    rendered = body.replace(PLACEHOLDER, shlex.quote(cli_path))
 
     TARGET_DIR.mkdir(parents=True, exist_ok=True)
     TARGET_CMD.write_text(rendered, encoding="utf-8")
     print(f"[install] wrote slash command -> {TARGET_CMD}")
-    print(f"          repo path baked in : {repo_path}")
+    print(f"          cli path baked in  : {cli_path}")
 
 
 def link_bin() -> bool:


### PR DESCRIPTION
## Summary

Found while testing PR #8: invoking `/handoff claude #5` from any repo other than the handoff checkout itself resolved issue #5 against `bminier/handoff` instead of the caller's repo, and dropped the worktree as a sibling of the handoff checkout rather than the caller.

Root cause: `scripts/install.py` was substituting the handoff checkout's path into the slash command's `--cwd` arg, which pinned bun (and therefore `gh` / `git rev-parse`) to the handoff repo no matter where `/handoff` was invoked.

## Fix

- Slash command template (`.claude/commands/handoff.md`) drops `--cwd` entirely. The bun process inherits the caller's cwd, which is what `gh issue view`, `git rev-parse --git-common-dir`, and worktree placement all rely on.
- `scripts/install.py` now substitutes the absolute path to `src/cli.ts` (rather than a `--cwd`), so the slash command's `bun run /abs/path/to/cli.ts` invocation works from anywhere without changing cwd.
- Local dev (running the un-rendered template from inside the handoff checkout) still works via the new `${HANDOFF_CLI:-src/cli.ts}` fallback.
- README updated to call out that existing installs need to re-run `python scripts/install.py` to pick up the fix.

## Test plan

- [x] Smoke-tested `python scripts/install.py --no-link`: rendered command line is `xargs bun run /abs/path/to/src/cli.ts <<< "$ARGUMENTS"` (no `--cwd`).
- [x] `bun test` 40/40, `bun run typecheck`, `bun run lint` all clean.
- [ ] End-to-end: `/handoff claude #N` from a non-handoff repo lands a worktree as a sibling of *that* repo, with the right issue body in PROMPT.md. (User to verify after re-running install.)

## Note for the reviewer

PR #8 (loop mode for #7) was opened first and is still open. This PR is independent and should land first, since #8 isn't actually testable end-to-end until installs pick up the cwd fix.