### PR TITLE
chore(workspace): define .handoff/ workspace convention (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,9 @@ Every worktree carries a small per-session metadata directory at its root:
   "version": 1,
   "tool": "claude" | "codex" | "copilot",
   "ref": { "type": "issue", "number": 7 } |
-         { "type": "pr",    "number": 12 } |
          { "type": "freeform", "text": "..." },
+  // A `{ "type": "pr", "number": 12 }` variant will be added when #10 lands
+  // first-class PR handoffs end-to-end.
   "branch": "claude/issue-7",
   "loop": false,
   "createdAt": "2026-04-28T12:00:00.000Z",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@
 | `src/terminal.ts`            | Platform-aware terminal spawn (`buildLaunchSpec` is pure)                 | mixed |
 | `src/cleanup.ts`             | PR-merged check → remove worktree + branch                                | I/O   |
 | `src/run.ts`                 | `spawn` wrapper with structured errors                                    | I/O   |
+| `src/workspace.ts`           | `.handoff/state.json` read/write + schema-version guard                   | I/O   |
 | `src/config.ts`              | `VERSION`, `HELP`                                                         | yes   |
 | `scripts/handoff-runner.sh`  | Bash wrapper: run tool, then `bun … cli.ts cleanup <branch>`              | shell |
 | `scripts/handoff-runner.ps1` | PowerShell equivalent for Windows                                         | shell |
@@ -45,6 +46,40 @@ Tests live in `tests/` and cover the **pure** modules. I/O modules are smoke-tes
 2. Add the tool name to the `case` in `scripts/handoff-runner.sh` and the `ValidateSet` in `scripts/handoff-runner.ps1` (the runner scripts invoke the tool binary directly — currently the tool name == binary name).
 3. Update `README.md` requirements list.
 4. Add a test for the new tool path in `tests/args.test.ts`.
+
+## The `.handoff/` workspace directory
+
+Every worktree carries a small per-session metadata directory at its root:
+
+```
+<worktree-root>/
+  PROMPT.md          # initial prompt for the agent (root, not under .handoff/)
+  .handoff/
+    state.json       # session metadata (see src/workspace.ts)
+```
+
+`state.json` is written by `src/cli.ts` on every handoff. Schema:
+
+```jsonc
+{
+  "version": 1,
+  "tool": "claude" | "codex" | "copilot",
+  "ref": { "type": "issue", "number": 7 } |
+         { "type": "pr",    "number": 12 } |
+         { "type": "freeform", "text": "..." },
+  "branch": "claude/issue-7",
+  "loop": false,
+  "createdAt": "2026-04-28T12:00:00.000Z",
+  "updatedAt": "2026-04-28T12:00:00.000Z"
+}
+```
+
+Rules:
+
+- `PROMPT.md` stays at the worktree root for runner-script back-compat. New session artifacts go inside `.handoff/`.
+- `.handoff/` is _gitignored at the user-repo level_ (the README tells users to add it to their `.gitignore`). It is removed with the worktree on cleanup.
+- Bump `STATE_VERSION` in `src/workspace.ts` when you change the schema. The reader rejects unknown versions rather than silently mis-parsing.
+- Future features should add files under `.handoff/` (e.g. `REVIEW.md` for #11, `container/` for #25) rather than scattering them across the worktree.
 
 ## How to extend the workflow contract in `PROMPT.md`
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ src/
 ├── git.ts        — git worktree wrappers
 ├── terminal.ts   — cross-platform window spawn
 ├── cleanup.ts    — PR-merged check + worktree teardown
+├── workspace.ts  — .handoff/state.json read/write
 ├── config.ts     — VERSION, HELP
 └── run.ts        — typed spawn helper
 scripts/
@@ -133,6 +134,19 @@ scripts/
 ```
 
 A handoff is one PR. Cleanup is conditional on `gh pr list --head <branch> --state merged` returning a result; nothing else will trigger worktree removal.
+
+### The `.handoff/` workspace directory
+
+Every handoff worktree carries a small metadata directory at its root:
+
+```
+<worktree-root>/
+  PROMPT.md          # initial prompt for the agent
+  .handoff/
+    state.json       # tool, ref, branch, loop, timestamps
+```
+
+It's session metadata, not source — **add `.handoff/` to your repo's `.gitignore`**. The directory is removed along with the worktree when the PR merges. Future features (pre-commit reviews, container metadata, `--resume` state) will live under the same prefix.
 
 ## Configuration
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { renderPrompt } from './prompt.ts';
 import { slugify } from './slug.ts';
 import { openTerminal } from './terminal.ts';
 import { HELP, VERSION } from './config.ts';
+import { STATE_VERSION, writeState, type RefRecord } from './workspace.ts';
 
 async function main(argv: readonly string[]): Promise<number> {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
@@ -124,6 +125,17 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
   const promptBody = renderPrompt(promptCtx);
   writeFileSync(join(path, 'PROMPT.md'), promptBody, 'utf8');
 
+  const now = new Date().toISOString();
+  writeState(path, {
+    version: STATE_VERSION,
+    tool: input.tool,
+    ref: refRecord(input.ref, issue),
+    branch,
+    loop: input.loop,
+    createdAt: now,
+    updatedAt: now,
+  });
+
   await openTerminal({
     cwd: path,
     scriptPath: input.runnerScript,
@@ -151,6 +163,13 @@ function resolveRunnerScript(handoffRoot: string): string {
 
 function describeRef(ref: Ref): string {
   return ref.kind === 'issue' ? `#${ref.number}` : `"${ref.text.slice(0, 40)}"`;
+}
+
+function refRecord(ref: Ref, issue: IssueDetails | undefined): RefRecord {
+  if (ref.kind === 'issue') {
+    return { type: 'issue', number: issue?.number ?? ref.number };
+  }
+  return { type: 'freeform', text: ref.text };
 }
 
 const code = await main(process.argv.slice(2));

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,72 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { Tool } from './args.ts';
+
+export const WORKSPACE_DIRNAME = '.handoff';
+export const STATE_FILENAME = 'state.json';
+export const STATE_VERSION = 1;
+
+export type IssueRefRecord = { type: 'issue'; number: number };
+export type PrRefRecord = { type: 'pr'; number: number };
+export type FreeformRefRecord = { type: 'freeform'; text: string };
+export type RefRecord = IssueRefRecord | PrRefRecord | FreeformRefRecord;
+
+export interface WorkspaceState {
+  version: typeof STATE_VERSION;
+  tool: Tool;
+  ref: RefRecord;
+  branch: string;
+  loop: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class WorkspaceStateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkspaceStateError';
+  }
+}
+
+export function workspacePath(worktreeRoot: string): string {
+  return join(worktreeRoot, WORKSPACE_DIRNAME);
+}
+
+export function statePath(worktreeRoot: string): string {
+  return join(workspacePath(worktreeRoot), STATE_FILENAME);
+}
+
+export function readState(worktreeRoot: string): WorkspaceState | null {
+  const p = statePath(worktreeRoot);
+  if (!existsSync(p)) return null;
+  const parsed: unknown = JSON.parse(readFileSync(p, 'utf8'));
+  return assertState(parsed);
+}
+
+export function writeState(worktreeRoot: string, state: WorkspaceState): void {
+  assertState(state);
+  mkdirSync(workspacePath(worktreeRoot), { recursive: true });
+  writeFileSync(statePath(worktreeRoot), JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export function clearState(worktreeRoot: string): void {
+  const dir = workspacePath(worktreeRoot);
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+}
+
+function assertState(value: unknown): WorkspaceState {
+  if (!value || typeof value !== 'object') {
+    throw new WorkspaceStateError('workspace state must be an object');
+  }
+  const v = value as { version?: unknown };
+  // Forward-compat guard: if a future handoff writes version 2 and an older
+  // CLI reads it, refuse rather than silently mis-parsing.
+  if (v.version !== STATE_VERSION) {
+    throw new WorkspaceStateError(
+      `unsupported workspace state version ${JSON.stringify(v.version)} ` +
+        `(expected ${STATE_VERSION}). Upgrade or remove the .handoff/ directory.`,
+    );
+  }
+  return value as WorkspaceState;
+}

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -8,9 +8,11 @@ export const STATE_FILENAME = 'state.json';
 export const STATE_VERSION = 1;
 
 export type IssueRefRecord = { type: 'issue'; number: number };
-export type PrRefRecord = { type: 'pr'; number: number };
 export type FreeformRefRecord = { type: 'freeform'; text: string };
-export type RefRecord = IssueRefRecord | PrRefRecord | FreeformRefRecord;
+// Note: a PrRefRecord variant will be added when first-class PR handoffs land
+// (#10). Until then, only the variants the CLI actually emits live in the
+// union, so the schema and the writer can't drift.
+export type RefRecord = IssueRefRecord | FreeformRefRecord;
 
 export interface WorkspaceState {
   version: typeof STATE_VERSION;
@@ -40,28 +42,44 @@ export function statePath(worktreeRoot: string): string {
 export function readState(worktreeRoot: string): WorkspaceState | null {
   const p = statePath(worktreeRoot);
   if (!existsSync(p)) return null;
-  const parsed: unknown = JSON.parse(readFileSync(p, 'utf8'));
-  return assertState(parsed);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(p, 'utf8'));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new WorkspaceStateError(`failed to read workspace state from ${p}: ${reason}`);
+  }
+  return assertStateVersion(parsed);
 }
 
 export function writeState(worktreeRoot: string, state: WorkspaceState): void {
-  assertState(state);
+  assertStateVersion(state);
   mkdirSync(workspacePath(worktreeRoot), { recursive: true });
   writeFileSync(statePath(worktreeRoot), JSON.stringify(state, null, 2) + '\n', 'utf8');
 }
 
-export function clearState(worktreeRoot: string): void {
+/**
+ * Removes the entire `.handoff/` directory. Used on cleanup. Not appropriate
+ * for "just forget the state.json" — once #11 lands `REVIEW.md` etc. under
+ * the same prefix, callers should reach for individual file deletions.
+ */
+export function removeWorkspace(worktreeRoot: string): void {
   const dir = workspacePath(worktreeRoot);
   if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
 }
 
-function assertState(value: unknown): WorkspaceState {
+/**
+ * Validates the part of the state contract this module owns: that the value
+ * is an object and that its `version` matches what we know how to read.
+ * Field-level validation is deliberately skipped — `state.json` is written
+ * only by this CLI, not by users, so a malformed inner shape is a bug we
+ * want to surface as a normal TypeError, not paper over with a custom check.
+ */
+function assertStateVersion(value: unknown): WorkspaceState {
   if (!value || typeof value !== 'object') {
     throw new WorkspaceStateError('workspace state must be an object');
   }
   const v = value as { version?: unknown };
-  // Forward-compat guard: if a future handoff writes version 2 and an older
-  // CLI reads it, refuse rather than silently mis-parsing.
   if (v.version !== STATE_VERSION) {
     throw new WorkspaceStateError(
       `unsupported workspace state version ${JSON.stringify(v.version)} ` +

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import * as realFsNs from 'node:fs';
+
+// Capture a plain-object snapshot of node:fs *before* mock.module runs.
+// Bun's mock.module is process-global and mutates the same namespace, so a
+// live `realFsNs.existsSync` reference inside the factory would recurse into
+// the mock itself.
+const realFs = { ...realFsNs };
 
 let mergedReturn: boolean | Error = false;
 let branchExistsReturn = true;
@@ -13,8 +20,17 @@ const calls = {
   deleteBranch: [] as string[],
 };
 
+// Bun's mock.module is process-global, so this overrides node:fs for every
+// other test file too. Pass non-fs exports through, and for existsSync only
+// stub paths under the synthetic "/work/" repoRoot the cleanup tests use —
+// real OS paths (workspace.test.ts uses tmpdir) fall through.
 mock.module('node:fs', () => ({
-  existsSync: (_p: string) => worktreeOnDisk,
+  ...realFs,
+  existsSync: (p: string) => {
+    const norm = String(p).replace(/\\/g, '/');
+    if (norm.startsWith('/work/')) return worktreeOnDisk;
+    return realFs.existsSync(p);
+  },
 }));
 
 mock.module('../src/github.ts', () => ({

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  STATE_VERSION,
+  WORKSPACE_DIRNAME,
+  WorkspaceStateError,
+  clearState,
+  readState,
+  statePath,
+  workspacePath,
+  writeState,
+  type WorkspaceState,
+} from '../src/workspace.ts';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'handoff-workspace-'));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const sample = (): WorkspaceState => ({
+  version: STATE_VERSION,
+  tool: 'claude',
+  ref: { type: 'issue', number: 7 },
+  branch: 'claude/issue-7',
+  loop: true,
+  createdAt: '2026-04-28T12:00:00.000Z',
+  updatedAt: '2026-04-28T12:00:00.000Z',
+});
+
+describe('workspacePath / statePath', () => {
+  it('places metadata under .handoff/state.json inside the worktree', () => {
+    expect(workspacePath(root)).toBe(join(root, WORKSPACE_DIRNAME));
+    expect(statePath(root)).toBe(join(root, WORKSPACE_DIRNAME, 'state.json'));
+  });
+});
+
+describe('writeState / readState', () => {
+  it('round-trips a workspace state through disk', () => {
+    const state = sample();
+    writeState(root, state);
+
+    const onDisk = JSON.parse(readFileSync(statePath(root), 'utf8'));
+    expect(onDisk).toEqual(state);
+
+    expect(readState(root)).toEqual(state);
+  });
+
+  it('creates the .handoff/ directory if it does not exist', () => {
+    expect(existsSync(workspacePath(root))).toBe(false);
+    writeState(root, sample());
+    expect(existsSync(workspacePath(root))).toBe(true);
+  });
+
+  it('overwrites an existing state file', () => {
+    writeState(root, sample());
+    const updated: WorkspaceState = {
+      ...sample(),
+      loop: false,
+      updatedAt: '2026-04-28T13:00:00.000Z',
+    };
+    writeState(root, updated);
+    expect(readState(root)).toEqual(updated);
+  });
+
+  it('returns null when there is no state file', () => {
+    expect(readState(root)).toBeNull();
+  });
+});
+
+describe('readState schema-version guard', () => {
+  it('throws WorkspaceStateError on a state with a future version', () => {
+    writeState(root, sample());
+    const future = { ...sample(), version: 2 };
+    writeFileSync(statePath(root), JSON.stringify(future), 'utf8');
+
+    expect(() => readState(root)).toThrow(WorkspaceStateError);
+  });
+
+  it('throws when the file is not an object', () => {
+    writeState(root, sample());
+    writeFileSync(statePath(root), JSON.stringify('not an object'), 'utf8');
+    expect(() => readState(root)).toThrow(WorkspaceStateError);
+  });
+});
+
+describe('clearState', () => {
+  it('removes the .handoff/ directory entirely', () => {
+    writeState(root, sample());
+    expect(existsSync(workspacePath(root))).toBe(true);
+
+    clearState(root);
+    expect(existsSync(workspacePath(root))).toBe(false);
+  });
+
+  it('is a no-op when .handoff/ does not exist', () => {
+    expect(() => clearState(root)).not.toThrow();
+  });
+});

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -7,7 +7,7 @@ import {
   STATE_VERSION,
   WORKSPACE_DIRNAME,
   WorkspaceStateError,
-  clearState,
+  removeWorkspace,
   readState,
   statePath,
   workspacePath,
@@ -91,16 +91,25 @@ describe('readState schema-version guard', () => {
   });
 });
 
-describe('clearState', () => {
+describe('removeWorkspace', () => {
   it('removes the .handoff/ directory entirely', () => {
     writeState(root, sample());
     expect(existsSync(workspacePath(root))).toBe(true);
 
-    clearState(root);
+    removeWorkspace(root);
     expect(existsSync(workspacePath(root))).toBe(false);
   });
 
   it('is a no-op when .handoff/ does not exist', () => {
-    expect(() => clearState(root)).not.toThrow();
+    expect(() => removeWorkspace(root)).not.toThrow();
+  });
+});
+
+describe('readState corrupted-file handling', () => {
+  it('wraps JSON parse errors in WorkspaceStateError', () => {
+    writeState(root, sample());
+    writeFileSync(statePath(root), '{not valid json', 'utf8');
+
+    expect(() => readState(root)).toThrow(WorkspaceStateError);
   });
 });


### PR DESCRIPTION
## Summary

- New `src/workspace.ts` with `workspacePath`, `readState`, `writeState`, `clearState`, plus a `STATE_VERSION` guard that rejects unknown versions instead of silently mis-parsing.
- CLI now writes `.handoff/state.json` on every handoff (issue + freeform), giving #11, #18, #19, and #25 a single canonical place to land per-session metadata.
- `PROMPT.md` stays at the worktree root for back-compat with the runner scripts and the existing `--loop` flow — only new files go under `.handoff/`.
- Documents the layout + recommended `.gitignore` entry in CLAUDE.md and README.

## Drive-by fix

`tests/cleanup.test.ts` mocked `node:fs` to only export `existsSync`. Bun's `mock.module` is process-global, so the next test file to import `readFileSync` (the new `workspace.test.ts`) blew up at module load. Now snapshots `node:fs` *before* the mock fires and only overrides `existsSync` for synthetic `/work/*` paths the cleanup tests use — real OS paths fall through, so `workspace.test.ts` (which uses real `tmpdir()`) interleaves cleanly.

## Test plan
- [x] `bun test` — 60 pass (9 new in `workspace.test.ts`)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] Smoke-tested on Windows; macOS/Linux untested (no behavior change expected — the new write goes through `node:fs` only)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)