### PR TITLE
feat(telemetry): opt-in usage stats (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
 | `src/cleanup.ts`             | PR-merged check → remove worktree + branch                                | I/O   |
 | `src/run.ts`                 | `spawn` wrapper with structured errors                                    | I/O   |
 | `src/workspace.ts`           | `.handoff/state.json` read/write + schema-version guard                   | I/O   |
+| `src/telemetry.ts`           | `~/.handoff/config.json`, event constructors, fire-and-forget emit        | mixed |
 | `src/config.ts`              | `VERSION`, `HELP`                                                         | yes   |
 | `scripts/handoff-runner.sh`  | Bash wrapper: run tool, then `bun … cli.ts cleanup <branch>`              | shell |
 | `scripts/handoff-runner.ps1` | PowerShell equivalent for Windows                                         | shell |
@@ -81,6 +82,23 @@ Rules:
 - `.handoff/` is _gitignored at the user-repo level_ (the README tells users to add it to their `.gitignore`). It is removed with the worktree on cleanup.
 - Bump `STATE_VERSION` in `src/workspace.ts` when you change the schema. The reader rejects unknown versions rather than silently mis-parsing.
 - Future features should add files under `.handoff/` (e.g. `REVIEW.md` for #11, `container/` for #25) rather than scattering them across the worktree.
+
+## Telemetry
+
+`src/telemetry.ts` owns opt-in usage stats. The contract is:
+
+- **Off by default.** `handoff telemetry enable [--endpoint <url>]` flips the switch; nothing is sent until both `enabled === true` and `endpoint !== null`.
+- **No PII.** Event constructors (`eventStart`, `eventCleanup`, `eventError`) take typed input — issue titles, branch names, repo paths, and usernames have nowhere to land in their argument types. Tests assert the keyset of each payload; do not add fields without updating those tests and the README table.
+- **Fire-and-forget.** `emit` is async with a 1s timeout. The CLI calls it via `emitFireAndForget` and never awaits — process.exit happens, the fetch is killed, and that is fine. Transport failures are dropped silently.
+- **Debug log.** When `HANDOFF_TELEMETRY_DEBUG=1`, every event is appended to `~/.handoff/telemetry-debug.log` _whether or not telemetry is enabled_. This is the audit trail the user is promised.
+- **Config file.** `~/.handoff/config.json` (separate from the per-worktree `.handoff/state.json`). Bump `CONFIG_VERSION` if the schema changes; `parseConfig` rejects unknown versions for the same reason `workspace.ts` does.
+
+When you add a new event:
+
+1. Add a typed constructor in `src/telemetry.ts`.
+2. Add it to the `Event` union and to the `ALLOWED_KEYS` test table.
+3. Document it in the README's `## Telemetry` table.
+4. Wire `emitFireAndForget(...)` from the right call site in `src/cli.ts`.
 
 ## How to extend the workflow contract in `PROMPT.md`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Rules:
 
 - **Off by default.** `handoff telemetry enable [--endpoint <url>]` flips the switch; nothing is sent until both `enabled === true` and `endpoint !== null`.
 - **No PII.** Event constructors (`eventStart`, `eventCleanup`, `eventError`) take typed input — issue titles, branch names, repo paths, and usernames have nowhere to land in their argument types. Tests assert the keyset of each payload; do not add fields without updating those tests and the README table.
-- **Fire-and-forget.** `emit` is async with a 1s timeout. The CLI calls it via `emitFireAndForget` and never awaits — process.exit happens, the fetch is killed, and that is fine. Transport failures are dropped silently.
+- **Fire-and-forget.** `emit` is async with a 1s `AbortController` timeout. The CLI calls it via `emitFireAndForget`, which discards the returned promise so the user-visible work doesn't wait on a slow endpoint. The CLI sets `process.exitCode` (rather than calling `process.exit`) so any in-flight emits get a bounded chance to drain before the process exits naturally. Don't reintroduce `process.exit(code)` at the bottom of `cli.ts` — it silently drops the last event of every command for opted-in users. Transport failures, non-2xx responses, and timeouts are all dropped silently.
 - **Debug log.** When `HANDOFF_TELEMETRY_DEBUG=1`, every event is appended to `~/.handoff/telemetry-debug.log` _whether or not telemetry is enabled_. This is the audit trail the user is promised.
 - **Config file.** `~/.handoff/config.json` (separate from the per-worktree `.handoff/state.json`). Bump `CONFIG_VERSION` if the schema changes; `parseConfig` rejects unknown versions for the same reason `workspace.ts` does.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ None required. Future versions will support `.handoffrc.json` overrides for `def
 handoff telemetry status                                # show current state + event shapes
 handoff telemetry enable --endpoint https://you.test/t  # turn on, point at your aggregator
 handoff telemetry disable                               # turn off
-handoff telemetry log                                   # tail the local debug log
+handoff telemetry log                                   # print the local debug log
 ```
 
 What we collect (and only this — by construction):
@@ -174,7 +174,7 @@ What we collect (and only this — by construction):
 
 `refType` is `issue` or `freeform`; `outcome` is `merged` / `retained` / `failed`; `sessionId` is a per-handoff random UUID. There is **no PII**: no issue titles, branch names, repo paths, or usernames are ever transmitted. Event delivery is async fire-and-forget with a 1s timeout — a slow or down endpoint never blocks the CLI, and failures are dropped silently.
 
-Trust through transparency: set `HANDOFF_TELEMETRY_DEBUG=1` in your environment to capture every event you would have sent to `~/.handoff/telemetry-debug.log`. The log is written **whether or not telemetry is enabled**, so you can audit what the tool would send before turning it on. `handoff telemetry log` tails the file.
+Trust through transparency: set `HANDOFF_TELEMETRY_DEBUG=1` in your environment to capture every event you would have sent to `~/.handoff/telemetry-debug.log`. The log is written **whether or not telemetry is enabled**, so you can audit what the tool would send before turning it on. `handoff telemetry log` prints the file.
 
 Configuration lives at `~/.handoff/config.json`.
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ src/
 ├── terminal.ts   — cross-platform window spawn
 ├── cleanup.ts    — PR-merged check + worktree teardown
 ├── workspace.ts  — .handoff/state.json read/write
+├── telemetry.ts  — opt-in usage stats (off by default)
 ├── config.ts     — VERSION, HELP
 └── run.ts        — typed spawn helper
 scripts/
@@ -151,6 +152,31 @@ It's session metadata, not source — **add `.handoff/` to your repo's `.gitigno
 ## Configuration
 
 None required. Future versions will support `.handoffrc.json` overrides for `defaultBranch`, `worktreeDir`, `terminalCommand`, and `promptTemplate`.
+
+## Telemetry
+
+`handoff` ships with opt-in usage telemetry. **It is off by default and stays off until you flip a switch.** Nothing is sent over the network unless you both (a) enable telemetry and (b) point it at an endpoint URL.
+
+```bash
+handoff telemetry status                                # show current state + event shapes
+handoff telemetry enable --endpoint https://you.test/t  # turn on, point at your aggregator
+handoff telemetry disable                               # turn off
+handoff telemetry log                                   # tail the local debug log
+```
+
+What we collect (and only this — by construction):
+
+| Event             | Payload                                     |
+| ----------------- | ------------------------------------------- |
+| `handoff.start`   | `{ tool, refType, fleet, loop, sessionId }` |
+| `handoff.cleanup` | `{ tool, outcome, durationMs }`             |
+| `handoff.error`   | `{ code, module, exitCode }`                |
+
+`refType` is `issue` or `freeform`; `outcome` is `merged` / `retained` / `failed`; `sessionId` is a per-handoff random UUID. There is **no PII**: no issue titles, branch names, repo paths, or usernames are ever transmitted. Event delivery is async fire-and-forget with a 1s timeout — a slow or down endpoint never blocks the CLI, and failures are dropped silently.
+
+Trust through transparency: set `HANDOFF_TELEMETRY_DEBUG=1` in your environment to capture every event you would have sent to `~/.handoff/telemetry-debug.log`. The log is written **whether or not telemetry is enabled**, so you can audit what the tool would send before turning it on. `handoff telemetry log` tails the file.
+
+Configuration lives at `~/.handoff/config.json`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ What we collect (and only this — by construction):
 | `handoff.cleanup` | `{ tool, outcome, durationMs }`             |
 | `handoff.error`   | `{ code, module, exitCode }`                |
 
-`refType` is `issue` or `freeform`; `outcome` is `merged` / `retained` / `failed`; `sessionId` is a per-handoff random UUID. There is **no PII**: no issue titles, branch names, repo paths, or usernames are ever transmitted. Event delivery is async fire-and-forget with a 1s timeout — a slow or down endpoint never blocks the CLI, and failures are dropped silently.
+`refType` is `issue` or `freeform`; `outcome` is `merged` / `retained` / `failed`; `sessionId` is a per-handoff random UUID. There is **no PII**: no issue titles, branch names, repo paths, or usernames are ever transmitted. Event delivery is async fire-and-forget: the CLI never awaits a send at the call site, so a slow or down endpoint doesn't gate user-visible work. The process does wait briefly on exit for any in-flight requests to drain, bounded by a 1s `AbortController` timeout per request. Failures (transport errors, non-2xx, timeout) are dropped silently.
 
 Trust through transparency: set `HANDOFF_TELEMETRY_DEBUG=1` in your environment to capture every event you would have sent to `~/.handoff/telemetry-debug.log`. The log is written **whether or not telemetry is enabled**, so you can audit what the tool would send before turning it on. `handoff telemetry log` prints the file.
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -24,7 +24,16 @@ export interface CleanupArgs {
   branch: string;
 }
 
-export type CliInvocation = ParsedArgs | CleanupArgs;
+export const TELEMETRY_SUBCOMMANDS = ['enable', 'disable', 'status', 'log'] as const;
+export type TelemetrySubcommand = (typeof TELEMETRY_SUBCOMMANDS)[number];
+
+export type TelemetryArgs =
+  | { command: 'telemetry'; sub: 'enable'; endpoint?: string }
+  | { command: 'telemetry'; sub: 'disable' }
+  | { command: 'telemetry'; sub: 'status' }
+  | { command: 'telemetry'; sub: 'log' };
+
+export type CliInvocation = ParsedArgs | CleanupArgs | TelemetryArgs;
 
 export class ArgsError extends Error {
   constructor(message: string) {
@@ -84,9 +93,13 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     return { command: 'cleanup', branch };
   }
 
+  if (head === 'telemetry') {
+    return parseTelemetry(argv.slice(1));
+  }
+
   if (!isTool(head)) {
     throw new ArgsError(
-      `Unknown tool '${head}'. Expected one of: ${TOOLS.join(', ')}, or 'cleanup'.`,
+      `Unknown tool '${head}'. Expected one of: ${TOOLS.join(', ')}, 'cleanup', or 'telemetry'.`,
     );
   }
 
@@ -143,4 +156,60 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
   }
 
   return { tool: head, refs, loop };
+}
+
+function isTelemetrySubcommand(value: string): value is TelemetrySubcommand {
+  return (TELEMETRY_SUBCOMMANDS as readonly string[]).includes(value);
+}
+
+function parseTelemetry(rest: readonly string[]): TelemetryArgs {
+  const sub = rest[0];
+  if (sub === undefined || sub.trim() === '') {
+    throw new ArgsError(
+      `Usage: handoff telemetry <${TELEMETRY_SUBCOMMANDS.join('|')}> [--endpoint <url>]`,
+    );
+  }
+  if (!isTelemetrySubcommand(sub)) {
+    throw new ArgsError(
+      `Unknown telemetry subcommand '${sub}'. Expected one of: ${TELEMETRY_SUBCOMMANDS.join(', ')}.`,
+    );
+  }
+
+  if (sub === 'enable') {
+    let endpoint: string | undefined;
+    let i = 1;
+    while (i < rest.length) {
+      const tok = rest[i];
+      if (tok === '--endpoint') {
+        const value = rest[i + 1];
+        if (value === undefined || value.trim() === '') {
+          throw new ArgsError('--endpoint requires a URL argument.');
+        }
+        endpoint = value;
+        i += 2;
+        continue;
+      }
+      if (tok !== undefined && tok.startsWith('--endpoint=')) {
+        const value = tok.slice('--endpoint='.length);
+        if (value.trim() === '') {
+          throw new ArgsError('--endpoint requires a URL argument.');
+        }
+        endpoint = value;
+        i += 1;
+        continue;
+      }
+      throw new ArgsError(
+        `Unexpected argument '${tok}' to 'handoff telemetry enable'. ` +
+          `Only '--endpoint <url>' is supported.`,
+      );
+    }
+    return endpoint === undefined
+      ? { command: 'telemetry', sub: 'enable' }
+      : { command: 'telemetry', sub: 'enable', endpoint };
+  }
+
+  if (rest.length > 1) {
+    throw new ArgsError(`'handoff telemetry ${sub}' takes no arguments.`);
+  }
+  return { command: 'telemetry', sub };
 }

--- a/src/args.ts
+++ b/src/args.ts
@@ -166,7 +166,8 @@ function parseTelemetry(rest: readonly string[]): TelemetryArgs {
   const sub = rest[0];
   if (sub === undefined || sub.trim() === '') {
     throw new ArgsError(
-      `Usage: handoff telemetry <${TELEMETRY_SUBCOMMANDS.join('|')}> [--endpoint <url>]`,
+      `Usage: handoff telemetry <${TELEMETRY_SUBCOMMANDS.join('|')}> ` +
+        `('enable' additionally accepts '--endpoint <url>').`,
     );
   }
   if (!isTelemetrySubcommand(sub)) {
@@ -200,7 +201,7 @@ function parseTelemetry(rest: readonly string[]): TelemetryArgs {
       }
       throw new ArgsError(
         `Unexpected argument '${tok}' to 'handoff telemetry enable'. ` +
-          `Only '--endpoint <url>' is supported.`,
+          `Only '--endpoint <url>' (or '--endpoint=<url>') is supported.`,
       );
     }
     return endpoint === undefined

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,8 @@ import {
   newSessionId,
   readDebugLog,
   setEnabled,
+  TelemetryConfigError,
+  configPath,
   type CleanupOutcome,
 } from './telemetry.ts';
 
@@ -106,6 +108,21 @@ function safeReadState(path: string) {
 }
 
 async function runTelemetry(invocation: TelemetryArgs): Promise<number> {
+  try {
+    return await runTelemetryInner(invocation);
+  } catch (err) {
+    if (err instanceof TelemetryConfigError) {
+      console.error(`error: ${err.message}`);
+      console.error(
+        `       If the file is corrupt, remove ${configPath()} and re-run this command.`,
+      );
+      return 1;
+    }
+    throw err;
+  }
+}
+
+async function runTelemetryInner(invocation: TelemetryArgs): Promise<number> {
   switch (invocation.sub) {
     case 'enable': {
       const patch = invocation.endpoint === undefined ? {} : { endpoint: invocation.endpoint };
@@ -318,5 +335,8 @@ function emitFireAndForget(...args: Parameters<typeof emit>): void {
   void emit(...args).catch(() => {});
 }
 
-const code = await main(process.argv.slice(2));
-process.exit(code);
+// Use process.exitCode (not process.exit) so any in-flight `emit` fetches get
+// a chance to drain — they're already bounded by AbortController(EMIT_TIMEOUT_MS),
+// so the worst-case extra wall time is one timeout window. process.exit would
+// abort them immediately, which silently lost telemetry for users who'd opted in.
+process.exitCode = await main(process.argv.slice(2));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,16 +4,31 @@ import { dirname, join, resolve } from 'node:path';
 import { platform } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-import { ArgsError, parseInvocation, type Ref, type Tool } from './args.ts';
+import { ArgsError, parseInvocation, type Ref, type Tool, type TelemetryArgs } from './args.ts';
 import { branchName, worktreePath } from './branch.ts';
-import { cleanup } from './cleanup.ts';
+import { cleanup, type CleanupResult } from './cleanup.ts';
 import { createWorktree, mainRepoRoot, repoName } from './git.ts';
 import { defaultBranch, fetchIssue, type IssueDetails } from './github.ts';
 import { renderPrompt } from './prompt.ts';
 import { slugify } from './slug.ts';
 import { openTerminal } from './terminal.ts';
 import { HELP, VERSION } from './config.ts';
-import { STATE_VERSION, writeState, type RefRecord } from './workspace.ts';
+import { readState, STATE_VERSION, writeState, type RefRecord } from './workspace.ts';
+import {
+  bannerText,
+  buildStatusReport,
+  emit,
+  eventCleanup,
+  eventError,
+  eventStart,
+  formatStatusReport,
+  loadConfig,
+  markBannerSeen,
+  newSessionId,
+  readDebugLog,
+  setEnabled,
+  type CleanupOutcome,
+} from './telemetry.ts';
 
 async function main(argv: readonly string[]): Promise<number> {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
@@ -38,13 +53,113 @@ async function main(argv: readonly string[]): Promise<number> {
   }
 
   if ('command' in invocation) {
-    const repoRoot = await mainRepoRoot();
-    const result = await cleanup(invocation.branch, { repoRoot });
-    console.log(result.message);
-    return result.status === 'unknown' ? 1 : 0;
+    if (invocation.command === 'telemetry') {
+      return await runTelemetry(invocation);
+    }
+    showFirstRunBanner();
+    return await runCleanup(invocation.branch);
   }
 
+  showFirstRunBanner();
   return await runHandoffs(invocation.tool, invocation.refs, invocation.loop);
+}
+
+async function runCleanup(branch: string): Promise<number> {
+  const repoRoot = await mainRepoRoot();
+  const path = worktreePath({ repoRoot, branch });
+  const state = safeReadState(path);
+  const startedAt = state?.createdAt ? Date.parse(state.createdAt) : NaN;
+
+  const t0 = Date.now();
+  const result = await cleanup(branch, { repoRoot });
+  console.log(result.message);
+
+  const durationMs = Number.isFinite(startedAt) ? Date.now() - startedAt : Date.now() - t0;
+  emitFireAndForget(
+    eventCleanup({
+      tool: state?.tool ?? 'unknown',
+      outcome: cleanupOutcome(result),
+      durationMs,
+    }),
+  );
+
+  return result.status === 'unknown' ? 1 : 0;
+}
+
+function cleanupOutcome(result: CleanupResult): CleanupOutcome {
+  switch (result.status) {
+    case 'removed':
+      return 'merged';
+    case 'retained':
+      return 'retained';
+    case 'unknown':
+      return 'failed';
+  }
+}
+
+function safeReadState(path: string) {
+  try {
+    return readState(path);
+  } catch {
+    return null;
+  }
+}
+
+async function runTelemetry(invocation: TelemetryArgs): Promise<number> {
+  switch (invocation.sub) {
+    case 'enable': {
+      const patch = invocation.endpoint === undefined ? {} : { endpoint: invocation.endpoint };
+      const config = setEnabled(true, patch);
+      console.log('telemetry: enabled');
+      console.log(
+        `endpoint:  ${config.telemetry.endpoint ?? '(none — set with --endpoint <url>)'}`,
+      );
+      if (!config.telemetry.endpoint) {
+        console.log(
+          'note:      no endpoint configured, so events will be logged for debug only ' +
+            '(set HANDOFF_TELEMETRY_DEBUG=1) until an endpoint is set.',
+        );
+      }
+      return 0;
+    }
+    case 'disable': {
+      setEnabled(false);
+      console.log('telemetry: disabled');
+      return 0;
+    }
+    case 'status': {
+      console.log(formatStatusReport(buildStatusReport()));
+      return 0;
+    }
+    case 'log': {
+      const body = readDebugLog();
+      if (body.length === 0) {
+        console.log(
+          '(no telemetry debug log entries yet — set HANDOFF_TELEMETRY_DEBUG=1 ' +
+            'in your environment to start capturing events to disk).',
+        );
+        return 0;
+      }
+      process.stdout.write(body);
+      return 0;
+    }
+  }
+}
+
+function showFirstRunBanner(): void {
+  let config;
+  try {
+    config = loadConfig();
+  } catch {
+    return;
+  }
+  if (config.firstRunBannerSeen) return;
+  console.error(bannerText());
+  try {
+    markBannerSeen();
+  } catch {
+    /* if we can't persist the flag, just don't crash; we'll show the banner again next time. */
+  }
 }
 
 async function runHandoffs(tool: Tool, refs: Ref[], loop: boolean) {
@@ -66,12 +181,16 @@ async function runHandoffs(tool: Tool, refs: Ref[], loop: boolean) {
         handoffRoot,
         runnerScript,
         loop,
+        fleet: refs.length,
       });
       console.log(`[handoff] OK ${describeRef(ref)}`);
     } catch (err) {
       failures += 1;
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[handoff] FAILED for ${describeRef(ref)}: ${msg}`);
+      emitFireAndForget(
+        eventError({ code: errorCode(err), module: 'cli.spawnHandoff', exitCode: 1 }),
+      );
     }
   }
   if (refs.length > 1) {
@@ -92,6 +211,7 @@ interface SpawnInput {
   handoffRoot: string;
   runnerScript: string;
   loop: boolean;
+  fleet: number;
 }
 
 async function spawnHandoff(input: SpawnInput): Promise<void> {
@@ -142,6 +262,16 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
     args: [input.handoffRoot, input.tool, branch],
   });
   console.log(`[handoff] terminal launched for ${branch}`);
+
+  emitFireAndForget(
+    eventStart({
+      tool: input.tool,
+      refType: input.ref.kind === 'issue' ? 'issue' : 'freeform',
+      fleet: input.fleet,
+      loop: input.loop,
+      sessionId: newSessionId(),
+    }),
+  );
 }
 
 function resolveHandoffRoot(): string {
@@ -170,6 +300,22 @@ function refRecord(ref: Ref, issue: IssueDetails | undefined): RefRecord {
     return { type: 'issue', number: issue?.number ?? ref.number };
   }
   return { type: 'freeform', text: ref.text };
+}
+
+function errorCode(err: unknown): string {
+  if (err && typeof err === 'object' && 'name' in err && typeof err.name === 'string') {
+    return err.name;
+  }
+  return 'Error';
+}
+
+/**
+ * Detach the network round-trip from the CLI's promise chain so a slow or
+ * misconfigured endpoint never blocks the user. Errors are dropped — the
+ * debug log (if enabled) is the audit trail.
+ */
+function emitFireAndForget(...args: Parameters<typeof emit>): void {
+  void emit(...args).catch(() => {});
 }
 
 const code = await main(process.argv.slice(2));

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,7 @@ TELEMETRY
   handoff telemetry disable                     turn off
   handoff telemetry status                      show current state and event
                                                 shapes
-  handoff telemetry log                         tail the local debug log (set
+  handoff telemetry log                         print the local debug log (set
                                                 HANDOFF_TELEMETRY_DEBUG=1 to
                                                 populate it)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ USAGE
   handoff <tool> <ref...>          spawn a worktree per ref and launch <tool>
   handoff claude [--loop] <ref...> claude only: stay resident through review (see FLAGS)
   handoff cleanup <branch>         remove a worktree if its PR has merged
+  handoff telemetry <subcommand>   manage opt-in usage telemetry (see TELEMETRY)
   handoff --help                   show this message
   handoff --version                show version
 
@@ -24,6 +25,21 @@ FLAGS
   --loop         (claude only) keep the agent resident after \`gh pr create\`
                  to triage review feedback and CI, push fixes, and iterate
                  until the PR is merged (or a bail condition trips).
+
+TELEMETRY
+  Off by default. Nothing is sent until both telemetry is enabled and an
+  endpoint URL is configured. No PII (no issue titles, branch names, repo
+  paths, or usernames) is ever transmitted; see \`handoff telemetry status\`
+  for the exact event payloads.
+
+  handoff telemetry enable [--endpoint <url>]   turn on, optionally pointing
+                                                at a self-hosted aggregator
+  handoff telemetry disable                     turn off
+  handoff telemetry status                      show current state and event
+                                                shapes
+  handoff telemetry log                         tail the local debug log (set
+                                                HANDOFF_TELEMETRY_DEBUG=1 to
+                                                populate it)
 
 EXAMPLES
   handoff codex #1

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -215,14 +215,19 @@ export interface EmitOptions extends IoOptions {
 }
 
 /**
- * Async fire-and-forget. Resolves once we've decided what to do with the event;
- * the network round-trip is detached and allowed to fail silently.
+ * Attempts to deliver one event. Resolves when the send attempt has finished,
+ * been aborted by the timeout, or been short-circuited by config. Never
+ * rejects — transport errors are swallowed.
+ *
+ * Detachment from the CLI is the *caller's* job: `cli.ts` invokes this via
+ * `emitFireAndForget`, which discards the returned promise so a slow endpoint
+ * doesn't gate the user-visible work.
  *
  * - Always writes a debug log line if `HANDOFF_TELEMETRY_DEBUG=1` (or the
  *   `debug` opt is true), even if telemetry is disabled — so the user can
  *   audit exactly what *would* be sent before flipping the switch.
  * - Sends to the endpoint only when both `enabled` and `endpoint` are set.
- * - Drops silently on transport failure or timeout.
+ * - Drops silently on transport failure, non-2xx, or timeout.
  */
 export async function emit(event: Event, opts: EmitOptions = {}): Promise<void> {
   const home = opts.home ?? homedir();

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -65,7 +65,7 @@ export function parseConfig(raw: unknown): TelemetryConfig {
   if (r.version !== CONFIG_VERSION) {
     throw new TelemetryConfigError(
       `unsupported config version ${JSON.stringify(r.version)} (expected ${CONFIG_VERSION}). ` +
-        `Upgrade handoff or delete ${CONFIG_FILENAME}.`,
+        `Upgrade handoff or delete ${configPath()}.`,
     );
   }
   const t =

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,359 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import type { Tool } from './args.ts';
+
+export const HOME_DIRNAME = '.handoff';
+export const CONFIG_FILENAME = 'config.json';
+export const DEBUG_LOG_FILENAME = 'telemetry-debug.log';
+export const CONFIG_VERSION = 1;
+export const EMIT_TIMEOUT_MS = 1000;
+export const DEBUG_ENV_VAR = 'HANDOFF_TELEMETRY_DEBUG';
+
+export interface TelemetryConfig {
+  version: typeof CONFIG_VERSION;
+  telemetry: {
+    enabled: boolean;
+    endpoint: string | null;
+    lastSentAt: string | null;
+  };
+  firstRunBannerSeen: boolean;
+}
+
+export class TelemetryConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TelemetryConfigError';
+  }
+}
+
+// ---------- pure: paths, defaults, parsing ----------
+
+export function homeRoot(home: string = homedir()): string {
+  return join(home, HOME_DIRNAME);
+}
+
+export function configPath(home: string = homedir()): string {
+  return join(homeRoot(home), CONFIG_FILENAME);
+}
+
+export function debugLogPath(home: string = homedir()): string {
+  return join(homeRoot(home), DEBUG_LOG_FILENAME);
+}
+
+export function defaultConfig(): TelemetryConfig {
+  return {
+    version: CONFIG_VERSION,
+    telemetry: { enabled: false, endpoint: null, lastSentAt: null },
+    firstRunBannerSeen: false,
+  };
+}
+
+/**
+ * Validates and normalizes parsed JSON into a TelemetryConfig. Missing fields
+ * fall back to defaults so a half-written config from a future bug doesn't
+ * brick the CLI; an unsupported `version` does throw, since silently reading
+ * a v2 file as v1 would risk losing user-set fields.
+ */
+export function parseConfig(raw: unknown): TelemetryConfig {
+  if (!raw || typeof raw !== 'object') {
+    throw new TelemetryConfigError('config must be a JSON object');
+  }
+  const r = raw as { version?: unknown; telemetry?: unknown; firstRunBannerSeen?: unknown };
+  if (r.version !== CONFIG_VERSION) {
+    throw new TelemetryConfigError(
+      `unsupported config version ${JSON.stringify(r.version)} (expected ${CONFIG_VERSION}). ` +
+        `Upgrade handoff or delete ${CONFIG_FILENAME}.`,
+    );
+  }
+  const t =
+    r.telemetry && typeof r.telemetry === 'object'
+      ? (r.telemetry as { enabled?: unknown; endpoint?: unknown; lastSentAt?: unknown })
+      : {};
+  return {
+    version: CONFIG_VERSION,
+    telemetry: {
+      enabled: t.enabled === true,
+      endpoint: typeof t.endpoint === 'string' && t.endpoint.length > 0 ? t.endpoint : null,
+      lastSentAt: typeof t.lastSentAt === 'string' ? t.lastSentAt : null,
+    },
+    firstRunBannerSeen: r.firstRunBannerSeen === true,
+  };
+}
+
+export function serializeConfig(config: TelemetryConfig): string {
+  return JSON.stringify(config, null, 2) + '\n';
+}
+
+// ---------- pure: events ----------
+
+export type RefType = 'issue' | 'freeform';
+export type CleanupOutcome = 'merged' | 'retained' | 'failed';
+
+export interface StartEvent {
+  name: 'handoff.start';
+  payload: {
+    tool: Tool;
+    refType: RefType;
+    fleet: number;
+    loop: boolean;
+    sessionId: string;
+  };
+}
+
+export interface CleanupEvent {
+  name: 'handoff.cleanup';
+  payload: {
+    tool: Tool | 'unknown';
+    outcome: CleanupOutcome;
+    durationMs: number;
+  };
+}
+
+export interface ErrorEvent {
+  name: 'handoff.error';
+  payload: {
+    code: string;
+    module: string;
+    exitCode: number;
+  };
+}
+
+export type Event = StartEvent | CleanupEvent | ErrorEvent;
+
+export function newSessionId(): string {
+  return randomUUID();
+}
+
+/**
+ * Pure event constructors. Each accepts only the allowlisted fields; anything
+ * else the caller might be holding (issue title, branch name, repo path, etc.)
+ * has nowhere to land. The opt-in invariant lives in `emit`; the no-PII
+ * invariant lives here.
+ */
+export function eventStart(input: {
+  tool: Tool;
+  refType: RefType;
+  fleet: number;
+  loop: boolean;
+  sessionId: string;
+}): StartEvent {
+  return {
+    name: 'handoff.start',
+    payload: {
+      tool: input.tool,
+      refType: input.refType,
+      fleet: input.fleet,
+      loop: input.loop,
+      sessionId: input.sessionId,
+    },
+  };
+}
+
+export function eventCleanup(input: {
+  tool: Tool | 'unknown';
+  outcome: CleanupOutcome;
+  durationMs: number;
+}): CleanupEvent {
+  return {
+    name: 'handoff.cleanup',
+    payload: { tool: input.tool, outcome: input.outcome, durationMs: input.durationMs },
+  };
+}
+
+export function eventError(input: { code: string; module: string; exitCode: number }): ErrorEvent {
+  return {
+    name: 'handoff.error',
+    payload: { code: input.code, module: input.module, exitCode: input.exitCode },
+  };
+}
+
+// ---------- I/O: config load/save ----------
+
+export interface IoOptions {
+  home?: string;
+}
+
+export function loadConfig(opts: IoOptions = {}): TelemetryConfig {
+  const home = opts.home ?? homedir();
+  const p = configPath(home);
+  if (!existsSync(p)) return defaultConfig();
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(p, 'utf8'));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new TelemetryConfigError(`failed to read ${p}: ${reason}`);
+  }
+  return parseConfig(raw);
+}
+
+export function saveConfig(config: TelemetryConfig, opts: IoOptions = {}): void {
+  const home = opts.home ?? homedir();
+  const p = configPath(home);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, serializeConfig(config), 'utf8');
+}
+
+// ---------- I/O: emit ----------
+
+export interface EmitOptions extends IoOptions {
+  fetchImpl?: typeof fetch;
+  /** Override env-var debug detection. Used by tests. */
+  debug?: boolean;
+  /** Override the configured timeout (test hook). */
+  timeoutMs?: number;
+  /** Used in the debug log line; defaults to `new Date().toISOString()`. */
+  now?: () => string;
+}
+
+/**
+ * Async fire-and-forget. Resolves once we've decided what to do with the event;
+ * the network round-trip is detached and allowed to fail silently.
+ *
+ * - Always writes a debug log line if `HANDOFF_TELEMETRY_DEBUG=1` (or the
+ *   `debug` opt is true), even if telemetry is disabled — so the user can
+ *   audit exactly what *would* be sent before flipping the switch.
+ * - Sends to the endpoint only when both `enabled` and `endpoint` are set.
+ * - Drops silently on transport failure or timeout.
+ */
+export async function emit(event: Event, opts: EmitOptions = {}): Promise<void> {
+  const home = opts.home ?? homedir();
+  const debug = opts.debug ?? process.env[DEBUG_ENV_VAR] === '1';
+  const now = opts.now ?? (() => new Date().toISOString());
+
+  if (debug) {
+    try {
+      appendDebugLog(event, now(), home);
+    } catch {
+      // Debug log is best-effort. Never let it bubble.
+    }
+  }
+
+  let config: TelemetryConfig;
+  try {
+    config = loadConfig({ home });
+  } catch {
+    // A corrupt config should not block the user's actual command.
+    return;
+  }
+
+  if (!config.telemetry.enabled || !config.telemetry.endpoint) return;
+
+  const endpoint = config.telemetry.endpoint;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? EMIT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(event),
+      signal: controller.signal,
+    });
+    // Best-effort lastSent stamp; failure is fine.
+    try {
+      const fresh = loadConfig({ home });
+      fresh.telemetry.lastSentAt = now();
+      saveConfig(fresh, { home });
+    } catch {
+      /* noop */
+    }
+  } catch {
+    // Drop silently — the contract says we never block or surface transport
+    // errors. The debug log already captured the event for the user to see.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function appendDebugLog(event: Event, ts: string, home: string): void {
+  const p = debugLogPath(home);
+  mkdirSync(dirname(p), { recursive: true });
+  appendFileSync(p, JSON.stringify({ ts, ...event }) + '\n', 'utf8');
+}
+
+// ---------- subcommand helpers ----------
+
+export interface StatusReport {
+  enabled: boolean;
+  endpoint: string | null;
+  lastSentAt: string | null;
+  configPath: string;
+  debugLogPath: string;
+  debugLogExists: boolean;
+}
+
+export function buildStatusReport(opts: IoOptions = {}): StatusReport {
+  const home = opts.home ?? homedir();
+  const config = loadConfig({ home });
+  const dlp = debugLogPath(home);
+  return {
+    enabled: config.telemetry.enabled,
+    endpoint: config.telemetry.endpoint,
+    lastSentAt: config.telemetry.lastSentAt,
+    configPath: configPath(home),
+    debugLogPath: dlp,
+    debugLogExists: existsSync(dlp),
+  };
+}
+
+export function formatStatusReport(report: StatusReport): string {
+  const lines = [
+    `enabled:        ${report.enabled ? 'yes' : 'no'}`,
+    `endpoint:       ${report.endpoint ?? '(none)'}`,
+    `last sent:      ${report.lastSentAt ?? '(never)'}`,
+    `config:         ${report.configPath}`,
+    `debug log:      ${report.debugLogPath}${report.debugLogExists ? '' : ' (no entries yet)'}`,
+    '',
+    'events that would be sent (when enabled + endpoint set):',
+    '  handoff.start   { tool, refType, fleet, loop, sessionId }',
+    '  handoff.cleanup { tool, outcome, durationMs }',
+    '  handoff.error   { code, module, exitCode }',
+    '',
+    'no PII: no issue titles, branch names, repo paths, or usernames are ever transmitted.',
+  ];
+  return lines.join('\n');
+}
+
+export function readDebugLog(opts: IoOptions = {}): string {
+  const home = opts.home ?? homedir();
+  const p = debugLogPath(home);
+  if (!existsSync(p)) return '';
+  return readFileSync(p, 'utf8');
+}
+
+export function setEnabled(
+  enabled: boolean,
+  patch: { endpoint?: string | null } = {},
+  opts: IoOptions = {},
+): TelemetryConfig {
+  const home = opts.home ?? homedir();
+  const config = loadConfig({ home });
+  config.telemetry.enabled = enabled;
+  if ('endpoint' in patch && patch.endpoint !== undefined) {
+    config.telemetry.endpoint = patch.endpoint;
+  }
+  saveConfig(config, { home });
+  return config;
+}
+
+export function markBannerSeen(opts: IoOptions = {}): void {
+  const home = opts.home ?? homedir();
+  const config = loadConfig({ home });
+  if (config.firstRunBannerSeen) return;
+  config.firstRunBannerSeen = true;
+  saveConfig(config, { home });
+}
+
+export function bannerText(): string {
+  return [
+    '[handoff] telemetry is opt-in. Run `handoff telemetry enable --endpoint <url>` to share',
+    '[handoff] anonymous usage stats with your own aggregator. See `handoff telemetry status`',
+    '[handoff] for the exact event shapes. This message is shown once.',
+  ].join('\n');
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -72,11 +72,16 @@ export function parseConfig(raw: unknown): TelemetryConfig {
     r.telemetry && typeof r.telemetry === 'object'
       ? (r.telemetry as { enabled?: unknown; endpoint?: unknown; lastSentAt?: unknown })
       : {};
+  // Whitespace-only endpoints would fail at send time and silently drop
+  // every event — coerce to null so `status` is honest and the no-endpoint
+  // short-circuit in `emit` kicks in.
+  const trimmedEndpoint =
+    typeof t.endpoint === 'string' && t.endpoint.trim().length > 0 ? t.endpoint.trim() : null;
   return {
     version: CONFIG_VERSION,
     telemetry: {
       enabled: t.enabled === true,
-      endpoint: typeof t.endpoint === 'string' && t.endpoint.length > 0 ? t.endpoint : null,
+      endpoint: trimmedEndpoint,
       lastSentAt: typeof t.lastSentAt === 'string' ? t.lastSentAt : null,
     },
     firstRunBannerSeen: r.firstRunBannerSeen === true,
@@ -249,19 +254,23 @@ export async function emit(event: Event, opts: EmitOptions = {}): Promise<void> 
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    await fetchImpl(endpoint, {
+    const res = await fetchImpl(endpoint, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(event),
       signal: controller.signal,
     });
-    // Best-effort lastSent stamp; failure is fine.
-    try {
-      const fresh = loadConfig({ home });
-      fresh.telemetry.lastSentAt = now();
-      saveConfig(fresh, { home });
-    } catch {
-      /* noop */
+    // Only stamp lastSentAt on a 2xx. fetch resolves on 4xx/5xx too; an
+    // endpoint rejecting our event is a dropped delivery, same as a network
+    // error from the user's perspective.
+    if (res.ok) {
+      try {
+        const fresh = loadConfig({ home });
+        fresh.telemetry.lastSentAt = now();
+        saveConfig(fresh, { home });
+      } catch {
+        /* noop */
+      }
     }
   } catch {
     // Drop silently — the contract says we never block or surface transport
@@ -336,7 +345,8 @@ export function setEnabled(
   const config = loadConfig({ home });
   config.telemetry.enabled = enabled;
   if ('endpoint' in patch && patch.endpoint !== undefined) {
-    config.telemetry.endpoint = patch.endpoint;
+    const trimmed = patch.endpoint === null ? null : patch.endpoint.trim();
+    config.telemetry.endpoint = trimmed && trimmed.length > 0 ? trimmed : null;
   }
   saveConfig(config, { home });
   return config;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -63,9 +63,11 @@ export function parseConfig(raw: unknown): TelemetryConfig {
   }
   const r = raw as { version?: unknown; telemetry?: unknown; firstRunBannerSeen?: unknown };
   if (r.version !== CONFIG_VERSION) {
+    // Don't reference a file path here — `parseConfig` is pure and may be
+    // called with arbitrary JSON. `loadConfig` knows the real `p` and
+    // re-throws with that path appended (see below).
     throw new TelemetryConfigError(
-      `unsupported config version ${JSON.stringify(r.version)} (expected ${CONFIG_VERSION}). ` +
-        `Upgrade handoff or delete ${configPath()}.`,
+      `unsupported config version ${JSON.stringify(r.version)} (expected ${CONFIG_VERSION})`,
     );
   }
   const t =
@@ -192,7 +194,19 @@ export function loadConfig(opts: IoOptions = {}): TelemetryConfig {
     const reason = err instanceof Error ? err.message : String(err);
     throw new TelemetryConfigError(`failed to read ${p}: ${reason}`);
   }
-  return parseConfig(raw);
+  // Re-throw shape/version errors with the actual file path so the user
+  // knows which file to fix. `parseConfig` is pure and intentionally
+  // doesn't know `p`.
+  try {
+    return parseConfig(raw);
+  } catch (err) {
+    if (err instanceof TelemetryConfigError) {
+      throw new TelemetryConfigError(
+        `${err.message} (at ${p}). Upgrade handoff or delete the file.`,
+      );
+    }
+    throw err;
+  }
 }
 
 export function saveConfig(config: TelemetryConfig, opts: IoOptions = {}): void {

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -132,4 +132,70 @@ describe('parseInvocation', () => {
   it('rejects cleanup with no branch', () => {
     expect(() => parseInvocation(['cleanup'])).toThrow(ArgsError);
   });
+
+  describe('telemetry subcommand', () => {
+    it('parses enable with no endpoint', () => {
+      expect(parseInvocation(['telemetry', 'enable'])).toEqual({
+        command: 'telemetry',
+        sub: 'enable',
+      });
+    });
+
+    it('parses enable --endpoint <url> (two-token form)', () => {
+      expect(parseInvocation(['telemetry', 'enable', '--endpoint', 'https://x.test/t'])).toEqual({
+        command: 'telemetry',
+        sub: 'enable',
+        endpoint: 'https://x.test/t',
+      });
+    });
+
+    it('parses enable --endpoint=<url> (single-token form)', () => {
+      expect(parseInvocation(['telemetry', 'enable', '--endpoint=https://x.test/t'])).toEqual({
+        command: 'telemetry',
+        sub: 'enable',
+        endpoint: 'https://x.test/t',
+      });
+    });
+
+    it('parses disable / status / log with no args', () => {
+      expect(parseInvocation(['telemetry', 'disable'])).toEqual({
+        command: 'telemetry',
+        sub: 'disable',
+      });
+      expect(parseInvocation(['telemetry', 'status'])).toEqual({
+        command: 'telemetry',
+        sub: 'status',
+      });
+      expect(parseInvocation(['telemetry', 'log'])).toEqual({
+        command: 'telemetry',
+        sub: 'log',
+      });
+    });
+
+    it('rejects unknown subcommand', () => {
+      expect(() => parseInvocation(['telemetry', 'turnitup'])).toThrow(/Unknown telemetry/);
+    });
+
+    it('rejects missing subcommand', () => {
+      expect(() => parseInvocation(['telemetry'])).toThrow(ArgsError);
+    });
+
+    it('rejects --endpoint with no URL', () => {
+      expect(() => parseInvocation(['telemetry', 'enable', '--endpoint'])).toThrow(
+        /--endpoint requires/,
+      );
+    });
+
+    it('rejects extra args on disable / status / log', () => {
+      expect(() => parseInvocation(['telemetry', 'disable', 'extra'])).toThrow(
+        /takes no arguments/,
+      );
+    });
+
+    it('rejects unknown flags on enable', () => {
+      expect(() => parseInvocation(['telemetry', 'enable', '--noisy'])).toThrow(
+        /Unexpected argument/,
+      );
+    });
+  });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -82,6 +82,22 @@ describe('parseConfig schema-version guard', () => {
     expect(out.firstRunBannerSeen).toBe(true);
   });
 
+  it('coerces whitespace-only endpoint to null and trims surrounding whitespace', () => {
+    const blank = parseConfig({
+      version: CONFIG_VERSION,
+      telemetry: { enabled: true, endpoint: '   ' },
+      firstRunBannerSeen: false,
+    });
+    expect(blank.telemetry.endpoint).toBeNull();
+
+    const padded = parseConfig({
+      version: CONFIG_VERSION,
+      telemetry: { enabled: true, endpoint: '  https://x.test/t  ' },
+      firstRunBannerSeen: false,
+    });
+    expect(padded.telemetry.endpoint).toBe('https://x.test/t');
+  });
+
   it('treats truthy non-boolean enabled as disabled', () => {
     const out = parseConfig({
       version: CONFIG_VERSION,
@@ -292,6 +308,25 @@ describe('emit — opt-in default-off invariant', () => {
     const fresh = loadConfig({ home });
     expect(fresh.telemetry.lastSentAt).toBe('2026-04-28T15:00:00.000Z');
   });
+
+  it('does NOT update lastSentAt when the endpoint returns 4xx/5xx', async () => {
+    // fetch resolves on 500s — only `res.ok` distinguishes a real send from
+    // a server reject. Stamping lastSentAt on a 500 would lie to the user.
+    saveConfig(
+      {
+        ...defaultConfig(),
+        telemetry: { enabled: true, endpoint: 'https://example.test/t', lastSentAt: null },
+      },
+      { home },
+    );
+    const fetchImpl = (async () =>
+      new Response('boom', { status: 500 })) as unknown as typeof fetch;
+    await emit(
+      eventStart({ tool: 'claude', refType: 'issue', fleet: 1, loop: false, sessionId: 'x' }),
+      { home, fetchImpl, now: () => '2026-04-28T15:00:00.000Z' },
+    );
+    expect(loadConfig({ home }).telemetry.lastSentAt).toBeNull();
+  });
 });
 
 describe('emit — debug log', () => {
@@ -348,6 +383,14 @@ describe('setEnabled / markBannerSeen', () => {
     const c = setEnabled(false, {}, { home });
     expect(c.telemetry.enabled).toBe(false);
     expect(c.telemetry.endpoint).toBe('https://example.test/x');
+  });
+
+  it('trims whitespace from the endpoint and rejects whitespace-only input', () => {
+    const padded = setEnabled(true, { endpoint: '  https://x.test/t  ' }, { home });
+    expect(padded.telemetry.endpoint).toBe('https://x.test/t');
+
+    const blank = setEnabled(true, { endpoint: '   ' }, { home });
+    expect(blank.telemetry.endpoint).toBeNull();
   });
 
   it('markBannerSeen persists the flag', () => {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -131,6 +131,27 @@ describe('saveConfig / loadConfig', () => {
     writeFileSync(configPath(home), '{not valid json', 'utf8');
     expect(() => loadConfig({ home })).toThrow(TelemetryConfigError);
   });
+
+  it('augments parseConfig errors with the actual home-scoped file path', () => {
+    // Regression: parseConfig is pure and doesn't know the file path; it
+    // used to call configPath() with no args, which meant tests (and any
+    // future caller with a non-default home) saw the wrong path in the
+    // error. loadConfig should append the path it actually read from.
+    mkdirSync(homeRoot(home), { recursive: true });
+    writeFileSync(
+      configPath(home),
+      JSON.stringify({ version: 999, telemetry: {}, firstRunBannerSeen: false }),
+      'utf8',
+    );
+    try {
+      loadConfig({ home });
+      throw new Error('expected loadConfig to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TelemetryConfigError);
+      expect((err as Error).message).toContain(configPath(home));
+      expect((err as Error).message).toContain('unsupported config version 999');
+    }
+  });
 });
 
 describe('event constructors — no-PII shape', () => {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  CONFIG_VERSION,
+  TelemetryConfigError,
+  bannerText,
+  buildStatusReport,
+  configPath,
+  debugLogPath,
+  defaultConfig,
+  emit,
+  eventCleanup,
+  eventError,
+  eventStart,
+  formatStatusReport,
+  homeRoot,
+  loadConfig,
+  markBannerSeen,
+  newSessionId,
+  parseConfig,
+  readDebugLog,
+  saveConfig,
+  serializeConfig,
+  setEnabled,
+  type Event,
+} from '../src/telemetry.ts';
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'handoff-telemetry-'));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('paths', () => {
+  it('places config and debug log under <home>/.handoff/', () => {
+    expect(homeRoot(home)).toBe(join(home, '.handoff'));
+    expect(configPath(home)).toBe(join(home, '.handoff', 'config.json'));
+    expect(debugLogPath(home)).toBe(join(home, '.handoff', 'telemetry-debug.log'));
+  });
+});
+
+describe('default config — opt-in invariant', () => {
+  it('returns telemetry disabled by default', () => {
+    const c = defaultConfig();
+    expect(c.telemetry.enabled).toBe(false);
+    expect(c.telemetry.endpoint).toBeNull();
+    expect(c.firstRunBannerSeen).toBe(false);
+  });
+
+  it('loadConfig returns defaults when no file exists', () => {
+    expect(loadConfig({ home })).toEqual(defaultConfig());
+  });
+});
+
+describe('parseConfig schema-version guard', () => {
+  it('round-trips through serialize/parse', () => {
+    const c = defaultConfig();
+    expect(parseConfig(JSON.parse(serializeConfig(c)))).toEqual(c);
+  });
+
+  it('throws on unsupported version', () => {
+    expect(() => parseConfig({ version: 999, telemetry: {}, firstRunBannerSeen: false })).toThrow(
+      TelemetryConfigError,
+    );
+  });
+
+  it('throws when not an object', () => {
+    expect(() => parseConfig('not an object')).toThrow(TelemetryConfigError);
+  });
+
+  it('coerces partial telemetry block to safe defaults', () => {
+    const out = parseConfig({ version: CONFIG_VERSION, telemetry: {}, firstRunBannerSeen: true });
+    expect(out.telemetry.enabled).toBe(false);
+    expect(out.telemetry.endpoint).toBeNull();
+    expect(out.firstRunBannerSeen).toBe(true);
+  });
+
+  it('treats truthy non-boolean enabled as disabled', () => {
+    const out = parseConfig({
+      version: CONFIG_VERSION,
+      telemetry: { enabled: 'yes' },
+      firstRunBannerSeen: false,
+    });
+    expect(out.telemetry.enabled).toBe(false);
+  });
+});
+
+describe('saveConfig / loadConfig', () => {
+  it('round-trips a config through disk', () => {
+    const c = defaultConfig();
+    c.telemetry.enabled = true;
+    c.telemetry.endpoint = 'https://example.test/telemetry';
+    saveConfig(c, { home });
+
+    const onDisk = JSON.parse(readFileSync(configPath(home), 'utf8'));
+    expect(onDisk).toEqual(c);
+    expect(loadConfig({ home })).toEqual(c);
+  });
+
+  it('creates ~/.handoff/ if it does not exist', () => {
+    expect(existsSync(homeRoot(home))).toBe(false);
+    saveConfig(defaultConfig(), { home });
+    expect(existsSync(homeRoot(home))).toBe(true);
+  });
+
+  it('wraps JSON parse errors in TelemetryConfigError', () => {
+    mkdirSync(homeRoot(home), { recursive: true });
+    writeFileSync(configPath(home), '{not valid json', 'utf8');
+    expect(() => loadConfig({ home })).toThrow(TelemetryConfigError);
+  });
+});
+
+describe('event constructors — no-PII shape', () => {
+  // The contract is "no issue titles, no branch names, no repo paths, no
+  // usernames." The constructors take typed input so a misuse caller can't
+  // pass those fields by accident, but verify the *shape* of the output to
+  // catch any future drift.
+  const ALLOWED_KEYS: Record<Event['name'], string[]> = {
+    'handoff.start': ['tool', 'refType', 'fleet', 'loop', 'sessionId'],
+    'handoff.cleanup': ['tool', 'outcome', 'durationMs'],
+    'handoff.error': ['code', 'module', 'exitCode'],
+  };
+
+  it('handoff.start emits exactly the allowlisted keys', () => {
+    const ev = eventStart({
+      tool: 'claude',
+      refType: 'issue',
+      fleet: 3,
+      loop: true,
+      sessionId: 'abc',
+    });
+    expect(ev.name).toBe('handoff.start');
+    expect(Object.keys(ev.payload).sort()).toEqual([...ALLOWED_KEYS['handoff.start']].sort());
+  });
+
+  it('handoff.cleanup emits exactly the allowlisted keys', () => {
+    const ev = eventCleanup({ tool: 'codex', outcome: 'merged', durationMs: 12345 });
+    expect(ev.name).toBe('handoff.cleanup');
+    expect(Object.keys(ev.payload).sort()).toEqual([...ALLOWED_KEYS['handoff.cleanup']].sort());
+  });
+
+  it('handoff.error emits exactly the allowlisted keys', () => {
+    const ev = eventError({ code: 'GhError', module: 'cleanup', exitCode: 1 });
+    expect(ev.name).toBe('handoff.error');
+    expect(Object.keys(ev.payload).sort()).toEqual([...ALLOWED_KEYS['handoff.error']].sort());
+  });
+
+  it('cleanup tool may be "unknown" when state.json was missing', () => {
+    const ev = eventCleanup({ tool: 'unknown', outcome: 'failed', durationMs: 0 });
+    expect(ev.payload.tool).toBe('unknown');
+  });
+
+  it('newSessionId returns a UUID, not a user-derived value', () => {
+    const id = newSessionId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(newSessionId()).not.toBe(id);
+  });
+});
+
+describe('emit — opt-in default-off invariant', () => {
+  it('does not call fetch when no config exists (default off)', async () => {
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response();
+    }) as unknown as typeof fetch;
+
+    await emit(
+      eventStart({ tool: 'claude', refType: 'issue', fleet: 1, loop: false, sessionId: 'x' }),
+      {
+        home,
+        fetchImpl,
+      },
+    );
+    expect(called).toBe(false);
+  });
+
+  it('does not call fetch when enabled but endpoint is null', async () => {
+    saveConfig(
+      { ...defaultConfig(), telemetry: { enabled: true, endpoint: null, lastSentAt: null } },
+      { home },
+    );
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response();
+    }) as unknown as typeof fetch;
+
+    await emit(
+      eventStart({ tool: 'claude', refType: 'issue', fleet: 1, loop: false, sessionId: 'x' }),
+      {
+        home,
+        fetchImpl,
+      },
+    );
+    expect(called).toBe(false);
+  });
+
+  it('calls fetch with the event JSON when both enabled and endpoint set', async () => {
+    saveConfig(
+      {
+        ...defaultConfig(),
+        telemetry: { enabled: true, endpoint: 'https://example.test/t', lastSentAt: null },
+      },
+      { home },
+    );
+
+    let seenUrl: string | URL | Request | undefined;
+    let seenBody: string | undefined;
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      seenUrl = url;
+      seenBody = init?.body as string | undefined;
+      return new Response(null, { status: 204 });
+    }) as unknown as typeof fetch;
+
+    const ev = eventStart({
+      tool: 'claude',
+      refType: 'freeform',
+      fleet: 2,
+      loop: false,
+      sessionId: 'sid-1',
+    });
+    await emit(ev, { home, fetchImpl });
+    expect(seenUrl).toBe('https://example.test/t');
+    expect(JSON.parse(seenBody ?? '{}')).toEqual(ev);
+  });
+
+  it('drops silently when fetch rejects', async () => {
+    saveConfig(
+      {
+        ...defaultConfig(),
+        telemetry: { enabled: true, endpoint: 'https://example.test/t', lastSentAt: null },
+      },
+      { home },
+    );
+    const fetchImpl = (async () => {
+      throw new Error('connection refused');
+    }) as unknown as typeof fetch;
+    await expect(
+      emit(
+        eventStart({ tool: 'claude', refType: 'issue', fleet: 1, loop: false, sessionId: 'x' }),
+        {
+          home,
+          fetchImpl,
+        },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('drops silently when fetch hangs past the timeout', async () => {
+    saveConfig(
+      {
+        ...defaultConfig(),
+        telemetry: { enabled: true, endpoint: 'https://example.test/t', lastSentAt: null },
+      },
+      { home },
+    );
+    const fetchImpl = ((_url: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        // Wire up the abort signal so the timeout actually fails the fetch.
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      })) as unknown as typeof fetch;
+
+    await expect(
+      emit(
+        eventStart({ tool: 'claude', refType: 'issue', fleet: 1, loop: false, sessionId: 'x' }),
+        { home, fetchImpl, timeoutMs: 5 },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('updates lastSentAt on success', async () => {
+    saveConfig(
+      {
+        ...defaultConfig(),
+        telemetry: { enabled: true, endpoint: 'https://example.test/t', lastSentAt: null },
+      },
+      { home },
+    );
+    const fetchImpl = (async () => new Response(null, { status: 204 })) as unknown as typeof fetch;
+    await emit(
+      eventStart({ tool: 'claude', refType: 'issue', fleet: 1, loop: false, sessionId: 'x' }),
+      { home, fetchImpl, now: () => '2026-04-28T15:00:00.000Z' },
+    );
+    const fresh = loadConfig({ home });
+    expect(fresh.telemetry.lastSentAt).toBe('2026-04-28T15:00:00.000Z');
+  });
+});
+
+describe('emit — debug log', () => {
+  it('writes a debug line when debug=true even with telemetry disabled', async () => {
+    const ev = eventStart({
+      tool: 'claude',
+      refType: 'issue',
+      fleet: 1,
+      loop: false,
+      sessionId: 'sid',
+    });
+    await emit(ev, { home, debug: true, now: () => '2026-04-28T15:00:00.000Z' });
+
+    const log = readDebugLog({ home });
+    expect(log.trim().split('\n')).toHaveLength(1);
+    const line = JSON.parse(log.trim());
+    expect(line).toEqual({ ts: '2026-04-28T15:00:00.000Z', ...ev });
+  });
+
+  it('does not write a debug line when debug=false', async () => {
+    await emit(
+      eventStart({ tool: 'claude', refType: 'issue', fleet: 1, loop: false, sessionId: 'sid' }),
+      { home, debug: false },
+    );
+    expect(readDebugLog({ home })).toBe('');
+  });
+
+  it('appends multiple lines without truncating prior entries', async () => {
+    const ev1 = eventStart({
+      tool: 'claude',
+      refType: 'issue',
+      fleet: 1,
+      loop: false,
+      sessionId: 'a',
+    });
+    const ev2 = eventCleanup({ tool: 'claude', outcome: 'merged', durationMs: 42 });
+    await emit(ev1, { home, debug: true, now: () => '2026-04-28T15:00:00.000Z' });
+    await emit(ev2, { home, debug: true, now: () => '2026-04-28T15:00:01.000Z' });
+    const lines = readDebugLog({ home }).trim().split('\n');
+    expect(lines).toHaveLength(2);
+  });
+});
+
+describe('setEnabled / markBannerSeen', () => {
+  it('flips telemetry on with an endpoint', () => {
+    const c = setEnabled(true, { endpoint: 'https://example.test/x' }, { home });
+    expect(c.telemetry.enabled).toBe(true);
+    expect(c.telemetry.endpoint).toBe('https://example.test/x');
+    expect(loadConfig({ home }).telemetry.enabled).toBe(true);
+  });
+
+  it('flips telemetry off without touching the endpoint', () => {
+    setEnabled(true, { endpoint: 'https://example.test/x' }, { home });
+    const c = setEnabled(false, {}, { home });
+    expect(c.telemetry.enabled).toBe(false);
+    expect(c.telemetry.endpoint).toBe('https://example.test/x');
+  });
+
+  it('markBannerSeen persists the flag', () => {
+    expect(loadConfig({ home }).firstRunBannerSeen).toBe(false);
+    markBannerSeen({ home });
+    expect(loadConfig({ home }).firstRunBannerSeen).toBe(true);
+    // idempotent
+    markBannerSeen({ home });
+    expect(loadConfig({ home }).firstRunBannerSeen).toBe(true);
+  });
+});
+
+describe('status report', () => {
+  it('includes the event shapes so the user can audit', () => {
+    const text = formatStatusReport(buildStatusReport({ home }));
+    expect(text).toContain('handoff.start');
+    expect(text).toContain('handoff.cleanup');
+    expect(text).toContain('handoff.error');
+    expect(text).toContain('no PII');
+  });
+
+  it('reports enabled=false when no config exists', () => {
+    const r = buildStatusReport({ home });
+    expect(r.enabled).toBe(false);
+    expect(r.endpoint).toBeNull();
+  });
+});
+
+describe('banner text', () => {
+  it('mentions the enable command and the status command', () => {
+    const text = bannerText();
+    expect(text).toContain('handoff telemetry enable');
+    expect(text).toContain('handoff telemetry status');
+  });
+});


### PR DESCRIPTION
Closes #30.

## Summary

- Adds `handoff telemetry <enable|disable|status|log>` and three events (`handoff.start`, `handoff.cleanup`, `handoff.error`) wired to the existing CLI call sites.
- Off by default. Nothing is sent unless both `enabled` and `endpoint` are set in `~/.handoff/config.json`.
- No-PII by construction — event constructors take typed input, so issue titles, branch names, repo paths, and usernames have nowhere to land. Tests assert the exact keyset of every event.
- Async fire-and-forget with a 1s `AbortController` timeout. A slow or down endpoint never blocks the CLI; failures are dropped silently.
- `HANDOFF_TELEMETRY_DEBUG=1` appends every event to `~/.handoff/telemetry-debug.log` regardless of enabled state, so users can audit what would be sent before turning it on.
- First-run banner is shown once on the first non-`telemetry` invocation, then suppressed via a persisted flag.

`handoff.upgrade` from the issue is intentionally deferred: there is no upgrade flow yet to instrument.

## Acceptance criteria

- [x] `handoff telemetry` subcommands work as described.
- [x] First-run banner shown once, then suppressed.
- [x] No event sent unless explicitly enabled and endpoint configured.
- [x] Debug log always written when `HANDOFF_TELEMETRY_DEBUG=1` regardless of enabled state.
- [x] Graceful no-op on endpoint failure (transport error or timeout).
- [x] Tests cover the off-by-default invariant, opt-in flip, and the no-PII shape of every event.
- [x] README has a dedicated \"Telemetry\" section linked from the install instructions.

## Test plan

- [x] \`bun test\` — 101 pass, 0 fail
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [x] Smoke-tested \`handoff telemetry status / enable --endpoint <url> / status / log / disable\` end to end on Windows (bun 1.3, Git Bash). Cross-platform paths go through \`node:os.homedir()\`, no platform-specific code added.