### PR TITLE
test(infra): scriptedSpawn + tempRepo fixtures for I/O module tests (#13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,7 @@ jobs:
         run: bun run typecheck
 
       - name: Test
-        run: bun test
+        # Go through the package.json script so the --max-concurrency=1
+        # flag (pinning the helpers' single-threaded assumption) is honoured
+        # in CI exactly the way it is locally.
+        run: bun run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Tests live in `tests/`. Pure modules are covered directly with `bun:test`. I/O m
 
 1. Read `docs/requirements.md` and `docs/implementation-plan.v0.1.0.md` first.
 2. Add tests for any pure-function change.
-3. Run `bun test && bun run typecheck && bun run lint` before committing.
+3. Run `bun run test && bun run typecheck && bun run lint` before committing. Use `bun run test` (not bare `bun test`) so the package.json `--max-concurrency=1` pin applies — the I/O-test fixtures rely on it.
 4. Cross-platform changes (terminal spawn, runner scripts, paths) need a note in the PR about which platforms you smoke-tested.
 
 ## How to add a new adapter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 | `scripts/handoff-runner.sh`  | Bash wrapper: run tool, then `bun … cli.ts cleanup <branch>`              | shell |
 | `scripts/handoff-runner.ps1` | PowerShell equivalent for Windows                                         | shell |
 
-Tests live in `tests/` and cover the **pure** modules. I/O modules are smoke-tested manually for v0.1.0; integration tests are out of scope.
+Tests live in `tests/`. Pure modules are covered directly with `bun:test`. I/O modules use one of three fixtures — `scriptedSpawn`, `tempRepo`, or per-module dependency injection. See [tests/README.md](./tests/README.md) for which to pick when, and why `mock.module(...)` on `src/*.ts` is off-limits (Bun's mock.module is process-global and pollutes cross-file).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -188,9 +188,11 @@ bun run lint
 bun run format
 ```
 
-The `test` script pins `--max-concurrency=1` because the I/O-test fixtures
-(`tests/helpers/`) lean on Bun's default single-threaded execution; bare
-`bun test` would bypass that pin. See `tests/README.md` for the rationale.
+Use `bun run test`, not bare `bun test`. The script pins
+`--max-concurrency=1` so a future `test.concurrent()` marker (or a `bun
+test --concurrent` invocation) can't race the I/O-test fixtures in
+`tests/helpers/`, which depend on process-global state. See
+`tests/README.md` for the full rationale.
 
 Pre-commit runs prettier + eslint via husky + lint-staged.
 

--- a/README.md
+++ b/README.md
@@ -182,11 +182,15 @@ Configuration lives at `~/.handoff/config.json`.
 
 ```bash
 bun install
-bun test
+bun run test
 bun run typecheck
 bun run lint
 bun run format
 ```
+
+The `test` script pins `--max-concurrency=1` because the I/O-test fixtures
+(`tests/helpers/`) lean on Bun's default single-threaded execution; bare
+`bun test` would bypass that pin. See `tests/README.md` for the rationale.
 
 Pre-commit runs prettier + eslint via husky + lint-staged.
 

--- a/docs/implementation-plan.v0.1.0.md
+++ b/docs/implementation-plan.v0.1.0.md
@@ -40,7 +40,7 @@ One PR into `dev` lands all of v0.1.0. Commits below are the intended sequence i
 
 - `src/github.ts` — `fetchIssue(n)`, `defaultBranch()`, `prMergedFor(branch)`. Each shells out to `gh` and parses JSON; throws typed errors on auth/network failure.
 - `src/git.ts` — `currentRepoRoot()`, `createWorktree({ branch, path, base })`, `removeWorktree(path)`, `deleteBranch(branch)`. Wraps `git` with `execa`-style child_process.
-- Smoke-tested manually; no unit tests (effectful).
+- I/O is unit-tested via the `tests/helpers/` fixtures (`scriptedSpawn` for `run`/`github`, `tempRepo` for `git`, dependency injection for modules with multiple collaborators). Per-module `git`/`github`/`terminal` test files are in flight under #14; cross-CLI integration coverage is tracked in #15. See `tests/README.md` for the fixture-selection guide.
 
 ## Phase 4 — Terminal launcher
 
@@ -86,7 +86,7 @@ One PR into `dev` lands all of v0.1.0. Commits below are the intended sequence i
 
 **Commit:** `ci: github actions (lint, typecheck, test)`
 
-- `.github/workflows/ci.yml` — Ubuntu, `oven-sh/setup-bun`, runs `bun install`, `bun run lint`, `bun run typecheck`, `bun test`. Triggers on push to `dev` / `prerelease/**` / `release/**` and PRs into the same.
+- `.github/workflows/ci.yml` — matrix of `ubuntu-latest`, `macos-latest`, `windows-latest` via `oven-sh/setup-bun`. Each runner does `bun install`, `bun run typecheck`, and `bun run test` (the script pins `--max-concurrency=1` so the I/O fixtures' single-threaded assumption holds — see `tests/README.md`). Format-check and lint are gated to the ubuntu runner since their output is invariant. Triggers on push to `dev` / `prerelease/**` / `release/**` and PRs into the same.
 - `CHANGELOG.md` with v0.1.0 entry.
 - Bump version in `package.json` to `0.1.0`.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -69,7 +69,7 @@
 
 - **Language**: TypeScript, run via `bun`. No transpile step for the CLI; published as source + `package.json#bin` entry running `bun src/cli.ts`.
 - **Cross-platform**: must work on Windows, macOS, Linux. CI runs on Ubuntu only for v0.1.0 (Windows-specific paths covered by unit tests, not E2E).
-- **Tests**: pure functions (slug, args, prompt rendering, branch naming) covered directly with `bun:test`; I/O modules (`run`, `git`, `github`, `cleanup`, `terminal` spawn) covered via the fixtures under `tests/helpers/` (see `tests/README.md`). Run the suite with `bun run test` (the `--max-concurrency=1` pin matters — see that README for why). Cross-CLI integration tests are still out of scope until #15.
+- **Tests**: pure functions (slug, args, prompt rendering, branch naming) covered directly with `bun:test`. I/O modules have fixtures available under `tests/helpers/` (see `tests/README.md`); `cleanup` and `run` are wired up, the per-module tests for `git`/`github`/`terminal` spawn are in flight (#14). Cross-CLI integration tests still out of scope until #15. Run the suite with `bun run test` — the `--max-concurrency=1` pin matters; see `tests/README.md` for why.
 - **Performance**: a single handoff completes its setup in under 5 seconds (excluding `gh` network latency).
 - **Security**:
   - Never write secrets into PROMPT.md or branch names.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -69,7 +69,7 @@
 
 - **Language**: TypeScript, run via `bun`. No transpile step for the CLI; published as source + `package.json#bin` entry running `bun src/cli.ts`.
 - **Cross-platform**: must work on Windows, macOS, Linux. CI runs on Ubuntu only for v0.1.0 (Windows-specific paths covered by unit tests, not E2E).
-- **Tests**: pure functions (slug, args, prompt rendering, branch naming) covered by `bun test`. Integration tests for git/gh/terminal are out of scope for v0.1.0.
+- **Tests**: pure functions (slug, args, prompt rendering, branch naming) covered directly with `bun:test`; I/O modules (`run`, `git`, `github`, `cleanup`, `terminal` spawn) covered via the fixtures under `tests/helpers/` (see `tests/README.md`). Run the suite with `bun run test` (the `--max-concurrency=1` pin matters — see that README for why). Cross-CLI integration tests are still out of scope until #15.
 - **Performance**: a single handoff completes its setup in under 5 seconds (excluding `gh` network latency).
 - **Security**:
   - Never write secrets into PROMPT.md or branch names.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -68,7 +68,7 @@
 ## Non-functional requirements
 
 - **Language**: TypeScript, run via `bun`. No transpile step for the CLI; published as source + `package.json#bin` entry running `bun src/cli.ts`.
-- **Cross-platform**: must work on Windows, macOS, Linux. CI runs on Ubuntu only for v0.1.0 (Windows-specific paths covered by unit tests, not E2E).
+- **Cross-platform**: must work on Windows, macOS, Linux. CI runs the lint/typecheck/test gauntlet on `ubuntu-latest`, `macos-latest`, and `windows-latest`; format-check and lint are gated to ubuntu since their output is invariant. Windows-specific path handling is exercised by unit tests on the Windows runner, not by E2E.
 - **Tests**: pure functions (slug, args, prompt rendering, branch naming) covered directly with `bun:test`. I/O modules have fixtures available under `tests/helpers/` (see `tests/README.md`); `cleanup` and `run` are wired up, the per-module tests for `git`/`github`/`terminal` spawn are in flight (#14). Cross-CLI integration tests still out of scope until #15. Run the suite with `bun run test` — the `--max-concurrency=1` pin matters; see `tests/README.md` for why.
 - **Performance**: a single handoff completes its setup in under 5 seconds (excluding `gh` network latency).
 - **Security**:
@@ -84,7 +84,6 @@
 - Codex Cloud / Copilot remote agents (only local CLIs).
 - Auto-detecting tool capability and routing (e.g., "give to whichever agent is idle").
 - Containerized / VM-isolated worktrees.
-- Windows CI.
 
 ## Answer to the open question
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -68,7 +68,7 @@
 ## Non-functional requirements
 
 - **Language**: TypeScript, run via `bun`. No transpile step for the CLI; published as source + `package.json#bin` entry running `bun src/cli.ts`.
-- **Cross-platform**: must work on Windows, macOS, Linux. CI runs the lint/typecheck/test gauntlet on `ubuntu-latest`, `macos-latest`, and `windows-latest`; format-check and lint are gated to ubuntu since their output is invariant. Windows-specific path handling is exercised by unit tests on the Windows runner, not by E2E.
+- **Cross-platform**: must work on Windows, macOS, Linux. CI runs typecheck and the test suite on `ubuntu-latest`, `macos-latest`, and `windows-latest`; format-check and lint are gated to ubuntu since their output is invariant across platforms. Windows-specific path handling is exercised by unit tests on the Windows runner, not by E2E.
 - **Tests**: pure functions (slug, args, prompt rendering, branch naming) covered directly with `bun:test`. I/O modules have fixtures available under `tests/helpers/` (see `tests/README.md`); `cleanup` and `run` are wired up, the per-module tests for `git`/`github`/`terminal` spawn are in flight (#14). Cross-CLI integration tests still out of scope until #15. Run the suite with `bun run test` — the `--max-concurrency=1` pin matters; see `tests/README.md` for why.
 - **Performance**: a single handoff completes its setup in under 5 seconds (excluding `gh` network latency).
 - **Security**:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "bun test",
+    "test": "bun test --max-concurrency=1",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -20,13 +20,25 @@ export interface CleanupDeps {
   existsSync: (path: string) => boolean;
 }
 
-const defaultDeps: CleanupDeps = {
-  prMergedFor: ghPrMergedFor,
-  branchExists: gitBranchExists,
-  removeWorktree: gitRemoveWorktree,
-  deleteBranch: gitDeleteBranch,
-  existsSync: fsExistsSync,
-};
+/**
+ * Build the production deps wired to run from `repoRoot`.
+ *
+ * The runner scripts launch `handoff cleanup` with cwd set to the worktree
+ * being removed. Without pinning cwd, `git worktree remove --force <path>`
+ * is invoked from inside that doomed worktree (and `git branch -D <branch>`
+ * targets a branch that's still checked out there) — both fail. Bind the
+ * git/gh wrappers to `repoRoot` so production cleanup runs from outside
+ * the worktree it's deleting.
+ */
+function buildDefaultDeps(repoRoot: string): CleanupDeps {
+  return {
+    prMergedFor: (branch) => ghPrMergedFor(branch, { cwd: repoRoot }),
+    branchExists: (branch) => gitBranchExists(branch, { cwd: repoRoot }),
+    removeWorktree: (path) => gitRemoveWorktree(path, { cwd: repoRoot }),
+    deleteBranch: (branch) => gitDeleteBranch(branch, { cwd: repoRoot }),
+    existsSync: fsExistsSync,
+  };
+}
 
 export interface CleanupOpts {
   repoRoot: string;
@@ -40,7 +52,7 @@ export interface CleanupOpts {
 }
 
 export async function cleanup(branch: string, opts: CleanupOpts): Promise<CleanupResult> {
-  const deps: CleanupDeps = opts.deps ?? defaultDeps;
+  const deps: CleanupDeps = opts.deps ?? buildDefaultDeps(opts.repoRoot);
   const path = worktreePath({ repoRoot: opts.repoRoot, branch });
 
   let merged: boolean;

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -32,13 +32,15 @@ export interface CleanupOpts {
   repoRoot: string;
   /**
    * @internal Test-only injection seam. Production callers should rely on the
-   * default deps wired to `git.ts` / `github.ts` / `node:fs`.
+   * default deps wired to `git.ts` / `github.ts` / `node:fs`. All-or-nothing
+   * by design: a partial set used to silently fall back to the real impls,
+   * which let a forgotten fake mutate the developer's actual repo.
    */
-  deps?: Partial<CleanupDeps>;
+  deps?: CleanupDeps;
 }
 
 export async function cleanup(branch: string, opts: CleanupOpts): Promise<CleanupResult> {
-  const deps: CleanupDeps = { ...defaultDeps, ...opts.deps };
+  const deps: CleanupDeps = opts.deps ?? defaultDeps;
   const path = worktreePath({ repoRoot: opts.repoRoot, branch });
 
   let merged: boolean;

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,19 +1,49 @@
-import { existsSync } from 'node:fs';
-import { branchExists, deleteBranch, removeWorktree } from './git.ts';
+import { existsSync as fsExistsSync } from 'node:fs';
+import {
+  branchExists as gitBranchExists,
+  deleteBranch as gitDeleteBranch,
+  removeWorktree as gitRemoveWorktree,
+} from './git.ts';
 import { branchTail, worktreePath } from './branch.ts';
-import { GhError, prMergedFor } from './github.ts';
+import { GhError, prMergedFor as ghPrMergedFor } from './github.ts';
 
 export interface CleanupResult {
   status: 'removed' | 'retained' | 'unknown';
   message: string;
 }
 
-export async function cleanup(branch: string, opts: { repoRoot: string }): Promise<CleanupResult> {
+export interface CleanupDeps {
+  prMergedFor: (branch: string) => Promise<boolean>;
+  branchExists: (branch: string) => Promise<boolean>;
+  removeWorktree: (path: string) => Promise<void>;
+  deleteBranch: (branch: string) => Promise<void>;
+  existsSync: (path: string) => boolean;
+}
+
+const defaultDeps: CleanupDeps = {
+  prMergedFor: ghPrMergedFor,
+  branchExists: gitBranchExists,
+  removeWorktree: gitRemoveWorktree,
+  deleteBranch: gitDeleteBranch,
+  existsSync: fsExistsSync,
+};
+
+export interface CleanupOpts {
+  repoRoot: string;
+  /**
+   * @internal Test-only injection seam. Production callers should rely on the
+   * default deps wired to `git.ts` / `github.ts` / `node:fs`.
+   */
+  deps?: Partial<CleanupDeps>;
+}
+
+export async function cleanup(branch: string, opts: CleanupOpts): Promise<CleanupResult> {
+  const deps: CleanupDeps = { ...defaultDeps, ...opts.deps };
   const path = worktreePath({ repoRoot: opts.repoRoot, branch });
 
   let merged: boolean;
   try {
-    merged = await prMergedFor(branch);
+    merged = await deps.prMergedFor(branch);
   } catch (err) {
     const reason = err instanceof GhError ? err.message : String(err);
     return {
@@ -33,10 +63,10 @@ export async function cleanup(branch: string, opts: { repoRoot: string }): Promi
     };
   }
 
-  const worktreeExisted = existsSync(path);
+  const worktreeExisted = deps.existsSync(path);
   if (worktreeExisted) {
     try {
-      await removeWorktree(path);
+      await deps.removeWorktree(path);
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       return {
@@ -50,9 +80,9 @@ export async function cleanup(branch: string, opts: { repoRoot: string }): Promi
   }
 
   let removedBranch = false;
-  if (await branchExists(branch)) {
+  if (await deps.branchExists(branch)) {
     try {
-      await deleteBranch(branch);
+      await deps.deleteBranch(branch);
       removedBranch = true;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,11 +1,25 @@
 import { dirname, resolve } from 'node:path';
-import { run } from './run.ts';
+import { run, type RunOpts } from './run.ts';
 
 export class GitError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'GitError';
   }
+}
+
+/**
+ * Optional cwd for git invocations. Cleanup runs from inside the worktree
+ * being removed, where `git worktree remove` and `git branch -D` would fail
+ * against the current repo state — the caller pins cwd to the main repo
+ * root so those operations target the correct worktree from outside it.
+ */
+export interface GitOpts {
+  cwd?: string;
+}
+
+function cwdOpts(opts: GitOpts): RunOpts {
+  return opts.cwd === undefined ? {} : { cwd: opts.cwd };
 }
 
 export async function currentRepoRoot(): Promise<string> {
@@ -36,9 +50,9 @@ export async function repoName(): Promise<string> {
   return last;
 }
 
-export async function branchExists(branch: string): Promise<boolean> {
+export async function branchExists(branch: string, opts: GitOpts = {}): Promise<boolean> {
   try {
-    await run('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`]);
+    await run('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`], cwdOpts(opts));
     return true;
   } catch {
     return false;
@@ -61,10 +75,10 @@ export async function createWorktree(input: CreateWorktreeInput): Promise<void> 
   await run('git', ['worktree', 'add', '-b', input.branch, input.path, input.base]);
 }
 
-export async function removeWorktree(path: string): Promise<void> {
-  await run('git', ['worktree', 'remove', '--force', path]);
+export async function removeWorktree(path: string, opts: GitOpts = {}): Promise<void> {
+  await run('git', ['worktree', 'remove', '--force', path], cwdOpts(opts));
 }
 
-export async function deleteBranch(branch: string): Promise<void> {
-  await run('git', ['branch', '-D', branch]);
+export async function deleteBranch(branch: string, opts: GitOpts = {}): Promise<void> {
+  await run('git', ['branch', '-D', branch], cwdOpts(opts));
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -15,9 +15,13 @@ export interface IssueDetails {
   labels: string[];
 }
 
-async function gh(args: readonly string[]): Promise<string> {
+export interface GhOpts {
+  cwd?: string;
+}
+
+async function gh(args: readonly string[], opts: GhOpts = {}): Promise<string> {
   try {
-    const { stdout } = await run('gh', args);
+    const { stdout } = await run('gh', args, opts.cwd === undefined ? {} : { cwd: opts.cwd });
     return stdout;
   } catch (err) {
     if (err instanceof RunError) {
@@ -77,19 +81,11 @@ export async function defaultBranch(): Promise<string> {
   return name;
 }
 
-export async function prMergedFor(branch: string): Promise<boolean> {
-  const stdout = await gh([
-    'pr',
-    'list',
-    '--head',
-    branch,
-    '--state',
-    'merged',
-    '--json',
-    'number',
-    '--limit',
-    '1',
-  ]);
+export async function prMergedFor(branch: string, opts: GhOpts = {}): Promise<boolean> {
+  const stdout = await gh(
+    ['pr', 'list', '--head', branch, '--state', 'merged', '--json', 'number', '--limit', '1'],
+    opts,
+  );
   const parsed = JSON.parse(stdout) as Array<{ number: number }>;
   return Array.isArray(parsed) && parsed.length > 0;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,10 +9,12 @@ export interface RunResult {
 
 /**
  * `run()` always launches with `stdio: ['ignore', 'pipe', 'pipe']`, so both
- * stdout and stderr are guaranteed at runtime. Surface that in the type so
- * scripted-spawn fakes have to provide piped streams (compile error, not a
- * mid-test `TypeError` on `.on('data', ...)`) and `run()` itself can drop
- * the non-null assertions.
+ * stdout and stderr are guaranteed at runtime. Surfacing that in the type
+ * lets `run()` drop its non-null assertions and signals to test-fake authors
+ * that piped streams are part of the contract — though TypeScript can't
+ * fully enforce this, since a fake can launder the type via
+ * `as unknown as PipedChildProcess`. The benefit is the cast is then
+ * explicit at the seam, not silently absorbed by `!` inside `run()`.
  */
 export type PipedChildProcess = Omit<ChildProcess, 'stdout' | 'stderr'> & {
   stdout: Readable;

--- a/src/run.ts
+++ b/src/run.ts
@@ -11,12 +11,22 @@ type SpawnFn = (command: string, args: readonly string[], options: SpawnOptions)
 let spawnImpl: SpawnFn = nodeSpawn;
 
 /**
- * @internal Test-only injection seam. Replace the spawn used by `run()` with
- * a scripted implementation, then pass `null` to restore the real `spawn`.
- * Production code must not call this — see `tests/README.md`.
+ * @internal Test-only injection seam. Replaces the spawn used by `run()` and
+ * returns a restore function that puts back whatever impl was active before
+ * this call — *not* unconditionally `nodeSpawn`. That lets nested fixtures
+ * (or sibling tests in the same process) stack installs without clobbering
+ * each other when uninstalled in LIFO order. Production code must not call
+ * this — see `tests/README.md`.
  */
-export function __setSpawnForTesting(impl: SpawnFn | null): void {
-  spawnImpl = impl ?? nodeSpawn;
+export function __setSpawnForTesting(impl: SpawnFn): () => void {
+  const previous = spawnImpl;
+  spawnImpl = impl;
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    spawnImpl = previous;
+  };
 }
 
 export class RunError extends Error {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import type { Readable } from 'node:stream';
 
 export interface RunResult {
   stdout: string;
@@ -6,9 +7,32 @@ export interface RunResult {
   exitCode: number;
 }
 
-type SpawnFn = (command: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
+/**
+ * `run()` always launches with `stdio: ['ignore', 'pipe', 'pipe']`, so both
+ * stdout and stderr are guaranteed at runtime. Surface that in the type so
+ * scripted-spawn fakes have to provide piped streams (compile error, not a
+ * mid-test `TypeError` on `.on('data', ...)`) and `run()` itself can drop
+ * the non-null assertions.
+ */
+export type PipedChildProcess = Omit<ChildProcess, 'stdout' | 'stderr'> & {
+  stdout: Readable;
+  stderr: Readable;
+};
 
-let spawnImpl: SpawnFn = nodeSpawn;
+type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => PipedChildProcess;
+
+const pipedNodeSpawn: SpawnFn = (command, args, options) => {
+  // Narrow `node:child_process.spawn`'s nullable streams at the boundary —
+  // we always pass `stdio: ['ignore', 'pipe', 'pipe']` below, so the cast
+  // is safe at runtime.
+  return nodeSpawn(command, args, options) as PipedChildProcess;
+};
+
+let spawnImpl: SpawnFn = pipedNodeSpawn;
 
 /**
  * @internal Test-only injection seam. Replaces the spawn used by `run()` and
@@ -68,14 +92,10 @@ export function run(
 
     let stdout = '';
     let stderr = '';
-    // stdio: ['ignore', 'pipe', 'pipe'] guarantees both streams are present at
-    // runtime. The injectable SpawnFn typing widens to ChildProcess, where
-    // stdout/stderr are nullable, so assert here rather than every test fake
-    // having to retype the return.
-    child.stdout!.on('data', (chunk: Buffer) => {
+    child.stdout.on('data', (chunk: Buffer) => {
       stdout += chunk.toString('utf8');
     });
-    child.stderr!.on('data', (chunk: Buffer) => {
+    child.stderr.on('data', (chunk: Buffer) => {
       stderr += chunk.toString('utf8');
     });
     child.on('error', reject);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,9 +1,22 @@
-import { spawn } from 'node:child_process';
+import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
 
 export interface RunResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+}
+
+type SpawnFn = (command: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
+
+let spawnImpl: SpawnFn = nodeSpawn;
+
+/**
+ * @internal Test-only injection seam. Replace the spawn used by `run()` with
+ * a scripted implementation, then pass `null` to restore the real `spawn`.
+ * Production code must not call this — see `tests/README.md`.
+ */
+export function __setSpawnForTesting(impl: SpawnFn | null): void {
+  spawnImpl = impl ?? nodeSpawn;
 }
 
 export class RunError extends Error {
@@ -36,7 +49,7 @@ export function run(
   opts: RunOpts = {},
 ): Promise<RunResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = spawnImpl(command, args, {
       cwd: opts.cwd,
       env: opts.env ?? process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -45,10 +58,14 @@ export function run(
 
     let stdout = '';
     let stderr = '';
-    child.stdout.on('data', (chunk: Buffer) => {
+    // stdio: ['ignore', 'pipe', 'pipe'] guarantees both streams are present at
+    // runtime. The injectable SpawnFn typing widens to ChildProcess, where
+    // stdout/stderr are nullable, so assert here rather than every test fake
+    // having to retype the return.
+    child.stdout!.on('data', (chunk: Buffer) => {
       stdout += chunk.toString('utf8');
     });
-    child.stderr.on('data', (chunk: Buffer) => {
+    child.stderr!.on('data', (chunk: Buffer) => {
       stderr += chunk.toString('utf8');
     });
     child.on('error', reject);

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,7 +12,7 @@ directly with `bun:test`. I/O modules (`run`, `git`, `github`, `cleanup`,
 | `run.ts`, `github.ts`                                        | **`scriptedSpawn`**      | The contract is the argv we hand to the subprocess. Fake the spawn, assert call shape and parsing of canned stdout.                                                                                   |
 | `git.ts` (worktree create/remove, branch ops)                | **`tempRepo`**           | The contract is git's actual behaviour. Spinning up a real throwaway repo costs ~50 ms and catches divergence a hand-rolled fake would miss.                                                          |
 | A module with multiple I/O collaborators (e.g. `cleanup.ts`) | **dependency injection** | If a module depends on several I/O wrappers, give it an optional `deps?` param and pass plain in-memory fakes. See `src/cleanup.ts` + `tests/cleanup.test.ts`.                                        |
-| `terminal.ts` spawn path                                     | **dependency injection** | `openTerminal` shells out via its own `spawnDetached` (not `run.ts`), so `scriptedSpawn` doesn't reach it. The terminal-test issue (#16) will add a `spawn?` param on `openTerminal` and pass a fake. |
+| `terminal.ts` spawn path                                     | **dependency injection** | `openTerminal` shells out via its own `spawnDetached` (not `run.ts`), so `scriptedSpawn` doesn't reach it. The terminal-test issue (#14) will add a `spawn?` param on `openTerminal` and pass a fake. |
 
 Don't reach for `mock.module(...)` to fake `git.ts`/`github.ts`/`run.ts`. Bun's
 `mock.module` is **process-global** for the whole `bun test` run, so any other

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,113 @@
+# Test infra
+
+Tests live next to `src/` in `tests/`. Pure modules (`args`, `slug`, `branch`,
+`prompt`, `workspace`, parts of `terminal` and `telemetry`) are tested
+directly with `bun:test`. I/O modules (`run`, `git`, `github`, `cleanup`,
+`terminal` spawn) need a fixture — pick one of the three below.
+
+## Picking a fixture
+
+| You're testing…                                              | Use                      | Why                                                                                                                                                            |
+| ------------------------------------------------------------ | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run.ts`, `github.ts`, `terminal.ts` (the spawn path)        | **`scriptedSpawn`**      | The contract is the argv we hand to the subprocess. Fake the spawn, assert call shape and parsing of canned stdout.                                            |
+| `git.ts` (worktree create/remove, branch ops)                | **`tempRepo`**           | The contract is git's actual behaviour. Spinning up a real throwaway repo costs ~50 ms and catches divergence a hand-rolled fake would miss.                   |
+| A module with multiple I/O collaborators (e.g. `cleanup.ts`) | **dependency injection** | If a module depends on several I/O wrappers, give it an optional `deps?` param and pass plain in-memory fakes. See `src/cleanup.ts` + `tests/cleanup.test.ts`. |
+
+Don't reach for `mock.module(...)` to fake `git.ts`/`github.ts`/`run.ts`. Bun's
+`mock.module` is **process-global** for the whole `bun test` run, so any other
+test file that imports the real module gets the mocked version too — there's
+no test-scoped restore. Use one of the three patterns above instead.
+
+## `tests/helpers/scriptedSpawn.ts`
+
+Replaces the spawn used by `src/run.ts` with one that returns canned
+stdout/stderr/exitCode keyed by exact `(command, argv)` pairs. Records every
+call so tests can assert which subprocesses were spawned.
+
+```ts
+import { afterEach, beforeEach, expect, it } from 'bun:test';
+import { fetchIssue } from '../src/github.ts';
+import { createScriptedSpawn, type ScriptedSpawn } from './helpers/scriptedSpawn.ts';
+
+let spawn: ScriptedSpawn;
+beforeEach(() => {
+  spawn = createScriptedSpawn();
+  spawn.install();
+});
+afterEach(() => spawn.uninstall());
+
+it('parses an issue payload', async () => {
+  spawn.expectGh(['issue', 'view', '7', '--json', 'number,title,body,labels,url'], {
+    number: 7,
+    title: 'x',
+    body: '',
+    url: 'https://example.test/7',
+    labels: [],
+  });
+  const issue = await fetchIssue(7);
+  expect(issue.number).toBe(7);
+});
+```
+
+`expectGh(argv, jsonBody)` is shorthand for the common case of a `gh` call that
+returns JSON on stdout. Use `expect({ command, argv, response })` for anything
+else — non-zero exit codes (`response.exitCode = 1`) reject through `RunError`.
+
+If a call doesn't match any registered expectation, the spawn emits an
+`error` event so the test fails loudly rather than silently hanging.
+
+The seam itself is `__setSpawnForTesting` in `src/run.ts`. The `__` prefix and
+`@internal` JSDoc tag keep production code from reaching for it. Tests should
+go through `createScriptedSpawn()`.
+
+## `tests/helpers/tempRepo.ts`
+
+Creates a real throwaway repo in `os.tmpdir()` and runs the real `git`. Cheap
+enough to run in `beforeEach`, fast enough to stay in the regular test suite
+(no env-var gating today; revisit if Windows CI gets slow).
+
+```ts
+import { afterEach, beforeEach, expect, it } from 'bun:test';
+import { branchExists } from '../src/git.ts';
+import { createTempRepo, type TempRepo } from './helpers/tempRepo.ts';
+
+let repo: TempRepo;
+let originalCwd: string;
+
+beforeEach(() => {
+  repo = createTempRepo({
+    branches: ['feature/x'],
+    remotes: { origin: 'https://example.invalid/r.git' },
+  });
+  originalCwd = process.cwd();
+});
+afterEach(() => {
+  process.chdir(originalCwd);
+  repo.cleanup();
+});
+
+it('reports an existing branch', async () => {
+  process.chdir(repo.path);
+  expect(await branchExists('feature/x')).toBe(true);
+});
+```
+
+Most of `git.ts` doesn't take a `cwd` — it shells out via `run()` which
+defaults to `process.cwd()`. The `process.chdir` + restore pattern above is
+the wiring the per-module tests should follow. Keep `originalCwd`
+restoration in `afterEach` so a thrown test doesn't leak the cwd into later
+files.
+
+`tempRepo` defaults `initialBranch` to `'dev'` to match this repo's
+convention. Override it for tests that care about HEAD on a different ref.
+The helper uses `git symbolic-ref HEAD refs/heads/<name>` (works on `git ≥
+2.20`, our documented minimum) rather than `git init -b` (which needs 2.28+).
+
+## Mixing fixtures
+
+`scriptedSpawn` and `tempRepo` should not be installed in the same test.
+`scriptedSpawn.install()` replaces the spawn `run()` uses, and `tempRepo`
+needs the real one to drive `git`. If a test needs both — for example,
+fake-`gh` plus real-`git` — that's a sign the module under test is doing
+two different I/O things; consider splitting it before reaching for a
+hybrid harness.

--- a/tests/README.md
+++ b/tests/README.md
@@ -131,13 +131,19 @@ the `tempRepo` pattern) and the module-level `spawnImpl` in `src/run.ts`
 are both process-global, and a sibling test running concurrently would
 observe the wrong cwd or the wrong spawn.
 
-That assumption is pinned in `package.json`: the `test` script runs
-`bun test --max-concurrency=1`, which caps even `test.concurrent()`
-markers at one in-flight test. CI invokes `bun run test` so the flag
-applies there too. **Run `bun run test` locally rather than bare `bun
-test`** — the bare form falls back to Bun's default (currently 20
-concurrent) and would bypass the pin if a future contributor adds
-`test.concurrent()`.
+Bun is serial by default — a bare `bun test` with no `test.concurrent()`
+markers and no `--concurrent` flag runs one test at a time. The risk is
+forward-only: a contributor later adds `test.concurrent()` to a test that
+happens to use `chdir` or `spawnImpl`, or someone passes `--concurrent`,
+and Bun then schedules up to 20 in-flight tests (its default
+`--max-concurrency` cap) that race the global state.
+
+`package.json`'s `test` script pins the cap to 1
+(`bun test --max-concurrency=1`), so even those future opt-ins still
+serialize. CI invokes `bun run test` so the flag applies there too. **Run
+`bun run test` locally rather than bare `bun test`** — bare doesn't pick
+up the pin, and if any test in the suite gets marked concurrent, your
+local run can hit a flake CI never sees.
 
 If we ever want real concurrency, the fix is structural: thread `cwd`
 through every `git.ts` function (it already accepts `cwd` at the `run()`

--- a/tests/README.md
+++ b/tests/README.md
@@ -148,9 +148,9 @@ serialize. CI invokes `bun run test` so the flag applies there too. **Run
 up the pin, and if any test in the suite gets marked concurrent, your
 local run can hit a flake CI never sees.
 
-If we ever want real concurrency, the fix is structural: thread `cwd`
-through every `git.ts` function (it already accepts `cwd` at the `run()`
-boundary, so this is propagation, not new plumbing) and lift the spawn
-seam onto a per-fixture context instead of a module global. Out of scope
-for this PR — flagged here so the future flip isn't a silent-flake
-landmine.
+If we ever want real concurrency, the fix is structural and not small:
+add a `cwd` parameter to every `git.ts` function and thread it through
+to the `run()` call (which already takes `cwd` at its boundary), update
+every caller to pass it, and lift the spawn seam onto a per-fixture
+context instead of a module global. Out of scope for this PR — flagged
+here so the future flip isn't a silent-flake landmine.

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,9 +57,11 @@ else — non-zero exit codes (`response.exitCode = 1`) reject through `RunError`
 If a call doesn't match any registered expectation, the spawn emits an
 `error` event so the test fails loudly rather than silently hanging.
 
-The seam itself is `__setSpawnForTesting` in `src/run.ts`. The `__` prefix and
-`@internal` JSDoc tag keep production code from reaching for it. Tests should
-go through `createScriptedSpawn()`.
+The seam itself is `__setSpawnForTesting` in `src/run.ts`. The `__` prefix
+and `@internal` JSDoc tag are conventional markers — neither is enforced
+(no `stripInternal`, source files are executed directly), so production
+code _could_ import it. Don't. Tests go through `createScriptedSpawn()`;
+the seam exists for that fixture, not for general use.
 
 ## `tests/helpers/tempRepo.ts`
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,7 +55,10 @@ returns JSON on stdout. Use `expect({ command, argv, response })` for anything
 else — non-zero exit codes (`response.exitCode = 1`) reject through `RunError`.
 
 If a call doesn't match any registered expectation, the spawn emits an
-`error` event so the test fails loudly rather than silently hanging.
+`error` event so an awaiting test fails fast. `uninstall()` also throws
+if any call went unmatched — that catches the case where the code under
+test catches the error and would otherwise let the unsanctioned spawn
+slip through silently.
 
 The seam itself is `__setSpawnForTesting` in `src/run.ts`. The `__` prefix
 and `@internal` JSDoc tag are conventional markers — neither is enforced

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,17 +126,22 @@ using the strict matcher.
 
 ## Concurrency assumption
 
-These fixtures lean on Bun running tests serially by default — within a
-file and across files. `process.chdir` (in the `tempRepo` pattern) and
-the module-level `spawnImpl` in `src/run.ts` are both process-global,
-and a sibling test running concurrently would observe the wrong cwd or
-the wrong spawn. None of that fires today because `bun test` is serial
-unless someone passes `--concurrent` / `--max-concurrency` or marks
-individual tests `test.concurrent()`.
+These fixtures lean on Bun running tests serially. `process.chdir` (in
+the `tempRepo` pattern) and the module-level `spawnImpl` in `src/run.ts`
+are both process-global, and a sibling test running concurrently would
+observe the wrong cwd or the wrong spawn.
 
-If we ever opt in to concurrency, the fix is structural: thread `cwd`
+That assumption is pinned in `package.json`: the `test` script runs
+`bun test --max-concurrency=1`, which caps even `test.concurrent()`
+markers at one in-flight test. CI invokes `bun run test` so the flag
+applies there too. **Run `bun run test` locally rather than bare `bun
+test`** — the bare form falls back to Bun's default (currently 20
+concurrent) and would bypass the pin if a future contributor adds
+`test.concurrent()`.
+
+If we ever want real concurrency, the fix is structural: thread `cwd`
 through every `git.ts` function (it already accepts `cwd` at the `run()`
 boundary, so this is propagation, not new plumbing) and lift the spawn
-seam onto a per-fixture context instead of a module global. That's out
-of scope for this PR — flagged here so the future flip isn't a
-silent-flake landmine.
+seam onto a per-fixture context instead of a module global. Out of scope
+for this PR — flagged here so the future flip isn't a silent-flake
+landmine.

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,11 +7,12 @@ directly with `bun:test`. I/O modules (`run`, `git`, `github`, `cleanup`,
 
 ## Picking a fixture
 
-| You're testing…                                              | Use                      | Why                                                                                                                                                            |
-| ------------------------------------------------------------ | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `run.ts`, `github.ts`, `terminal.ts` (the spawn path)        | **`scriptedSpawn`**      | The contract is the argv we hand to the subprocess. Fake the spawn, assert call shape and parsing of canned stdout.                                            |
-| `git.ts` (worktree create/remove, branch ops)                | **`tempRepo`**           | The contract is git's actual behaviour. Spinning up a real throwaway repo costs ~50 ms and catches divergence a hand-rolled fake would miss.                   |
-| A module with multiple I/O collaborators (e.g. `cleanup.ts`) | **dependency injection** | If a module depends on several I/O wrappers, give it an optional `deps?` param and pass plain in-memory fakes. See `src/cleanup.ts` + `tests/cleanup.test.ts`. |
+| You're testing…                                              | Use                      | Why                                                                                                                                                                                                   |
+| ------------------------------------------------------------ | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run.ts`, `github.ts`                                        | **`scriptedSpawn`**      | The contract is the argv we hand to the subprocess. Fake the spawn, assert call shape and parsing of canned stdout.                                                                                   |
+| `git.ts` (worktree create/remove, branch ops)                | **`tempRepo`**           | The contract is git's actual behaviour. Spinning up a real throwaway repo costs ~50 ms and catches divergence a hand-rolled fake would miss.                                                          |
+| A module with multiple I/O collaborators (e.g. `cleanup.ts`) | **dependency injection** | If a module depends on several I/O wrappers, give it an optional `deps?` param and pass plain in-memory fakes. See `src/cleanup.ts` + `tests/cleanup.test.ts`.                                        |
+| `terminal.ts` spawn path                                     | **dependency injection** | `openTerminal` shells out via its own `spawnDetached` (not `run.ts`), so `scriptedSpawn` doesn't reach it. The terminal-test issue (#16) will add a `spawn?` param on `openTerminal` and pass a fake. |
 
 Don't reach for `mock.module(...)` to fake `git.ts`/`github.ts`/`run.ts`. Bun's
 `mock.module` is **process-global** for the whole `bun test` run, so any other

--- a/tests/README.md
+++ b/tests/README.md
@@ -106,9 +106,35 @@ The helper uses `git symbolic-ref HEAD refs/heads/<name>` (works on `git ≥
 
 ## Mixing fixtures
 
-`scriptedSpawn` and `tempRepo` should not be installed in the same test.
-`scriptedSpawn.install()` replaces the spawn `run()` uses, and `tempRepo`
-needs the real one to drive `git`. If a test needs both — for example,
-fake-`gh` plus real-`git` — that's a sign the module under test is doing
-two different I/O things; consider splitting it before reaching for a
-hybrid harness.
+For per-module unit tests, `scriptedSpawn` and `tempRepo` should not be
+installed together. `scriptedSpawn.install()` replaces the spawn `run()`
+uses, and `tempRepo` needs the real one to drive `git`. If a single
+module's test needs both, that's a sign the module is doing two different
+I/O things — split it before reaching for a hybrid harness.
+
+CLI-level integration tests (#15) are the documented exception: `cli.ts`
+fans out to both `fetchIssue` (gh) and `createWorktree` (git) in the same
+flow, so a happy-path test inherently needs fake-`gh` + real-`git`. The
+infra in this PR doesn't ship a hybrid harness yet; #15 will add one. The
+plan is a `passthrough?: (command, args) => boolean` option on
+`scriptedSpawn` so calls that match the predicate fall through to the
+real `spawn`. That keeps the "fake gh, real git" wiring expressible in
+one test without leaking back into per-module tests, which should keep
+using the strict matcher.
+
+## Concurrency assumption
+
+These fixtures lean on Bun running tests serially by default — within a
+file and across files. `process.chdir` (in the `tempRepo` pattern) and
+the module-level `spawnImpl` in `src/run.ts` are both process-global,
+and a sibling test running concurrently would observe the wrong cwd or
+the wrong spawn. None of that fires today because `bun test` is serial
+unless someone passes `--concurrent` / `--max-concurrency` or marks
+individual tests `test.concurrent()`.
+
+If we ever opt in to concurrency, the fix is structural: thread `cwd`
+through every `git.ts` function (it already accepts `cwd` at the `run()`
+boundary, so this is propagation, not new plumbing) and lift the spawn
+seam onto a per-fixture context instead of a module global. That's out
+of scope for this PR — flagged here so the future flip isn't a
+silent-flake landmine.

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -1,182 +1,170 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import * as realFsNs from 'node:fs';
+import { beforeEach, describe, expect, it } from 'bun:test';
 
-// Capture a plain-object snapshot of node:fs *before* mock.module runs.
-// Bun's mock.module is process-global and mutates the same namespace, so a
-// live `realFsNs.existsSync` reference inside the factory would recurse into
-// the mock itself.
-const realFs = { ...realFsNs };
+import { cleanup, type CleanupDeps } from '../src/cleanup.ts';
+import { GhError } from '../src/github.ts';
 
-let mergedReturn: boolean | Error = false;
-let branchExistsReturn = true;
-let removeWorktreeError: Error | null = null;
-let deleteBranchError: Error | null = null;
-let worktreeOnDisk = true;
+interface FakeState {
+  mergedReturn: boolean | Error;
+  branchExistsReturn: boolean;
+  removeWorktreeError: Error | null;
+  deleteBranchError: Error | null;
+  worktreeOnDisk: boolean;
+  calls: {
+    prMergedFor: string[];
+    removeWorktree: string[];
+    branchExists: string[];
+    deleteBranch: string[];
+  };
+}
 
-const calls = {
-  prMergedFor: [] as string[],
-  removeWorktree: [] as string[],
-  branchExists: [] as string[],
-  deleteBranch: [] as string[],
-};
+function newState(): FakeState {
+  return {
+    mergedReturn: false,
+    branchExistsReturn: true,
+    removeWorktreeError: null,
+    deleteBranchError: null,
+    worktreeOnDisk: true,
+    calls: {
+      prMergedFor: [],
+      removeWorktree: [],
+      branchExists: [],
+      deleteBranch: [],
+    },
+  };
+}
 
-// Bun's mock.module is process-global, so this overrides node:fs for every
-// other test file too. Pass non-fs exports through, and for existsSync only
-// stub paths under the synthetic "/work/" repoRoot the cleanup tests use —
-// real OS paths (workspace.test.ts uses tmpdir) fall through.
-mock.module('node:fs', () => ({
-  ...realFs,
-  existsSync: (p: string) => {
-    const norm = String(p).replace(/\\/g, '/');
-    if (norm.startsWith('/work/')) return worktreeOnDisk;
-    return realFs.existsSync(p);
-  },
-}));
+function fakeDeps(state: FakeState): CleanupDeps {
+  return {
+    prMergedFor: async (branch: string) => {
+      state.calls.prMergedFor.push(branch);
+      if (state.mergedReturn instanceof Error) throw state.mergedReturn;
+      return state.mergedReturn;
+    },
+    branchExists: async (branch: string) => {
+      state.calls.branchExists.push(branch);
+      return state.branchExistsReturn;
+    },
+    removeWorktree: async (path: string) => {
+      state.calls.removeWorktree.push(path);
+      if (state.removeWorktreeError) throw state.removeWorktreeError;
+    },
+    deleteBranch: async (branch: string) => {
+      state.calls.deleteBranch.push(branch);
+      if (state.deleteBranchError) throw state.deleteBranchError;
+    },
+    existsSync: (p: string) => {
+      const norm = String(p).replace(/\\/g, '/');
+      // The cleanup tests use '/work/...' synthetic paths; only stub those.
+      if (norm.startsWith('/work/')) return state.worktreeOnDisk;
+      throw new Error(`unexpected existsSync path in cleanup test: ${p}`);
+    },
+  };
+}
 
-mock.module('../src/github.ts', () => ({
-  GhError: class GhError extends Error {
-    constructor(message: string) {
-      super(message);
-      this.name = 'GhError';
-    }
-  },
-  prMergedFor: async (branch: string) => {
-    calls.prMergedFor.push(branch);
-    if (mergedReturn instanceof Error) throw mergedReturn;
-    return mergedReturn;
-  },
-}));
-
-mock.module('../src/git.ts', () => ({
-  branchExists: async (branch: string) => {
-    calls.branchExists.push(branch);
-    return branchExistsReturn;
-  },
-  removeWorktree: async (path: string) => {
-    calls.removeWorktree.push(path);
-    if (removeWorktreeError) throw removeWorktreeError;
-  },
-  deleteBranch: async (branch: string) => {
-    calls.deleteBranch.push(branch);
-    if (deleteBranchError) throw deleteBranchError;
-  },
-}));
-
-const { cleanup } = await import('../src/cleanup.ts');
-const { GhError } = await import('../src/github.ts');
+let state: FakeState;
+let deps: CleanupDeps;
 
 beforeEach(() => {
-  mergedReturn = false;
-  branchExistsReturn = true;
-  removeWorktreeError = null;
-  deleteBranchError = null;
-  worktreeOnDisk = true;
-  calls.prMergedFor.length = 0;
-  calls.removeWorktree.length = 0;
-  calls.branchExists.length = 0;
-  calls.deleteBranch.length = 0;
-});
-
-afterEach(() => {
-  // mock state reset by beforeEach; nothing to do here
+  state = newState();
+  deps = fakeDeps(state);
 });
 
 describe('cleanup', () => {
   it('removes worktree and branch when PR is merged', async () => {
-    mergedReturn = true;
-    worktreeOnDisk = true;
-    branchExistsReturn = true;
+    state.mergedReturn = true;
+    state.worktreeOnDisk = true;
+    state.branchExistsReturn = true;
 
-    const result = await cleanup('claude/issue-7', { repoRoot: '/work/handoff' });
+    const result = await cleanup('claude/issue-7', { repoRoot: '/work/handoff', deps });
 
     expect(result.status).toBe('removed');
     expect(result.message).toContain('Removed worktree');
     expect(result.message).toContain('deleted branch claude/issue-7');
-    expect(calls.prMergedFor).toEqual(['claude/issue-7']);
-    expect(calls.removeWorktree.length).toBe(1);
-    expect(calls.deleteBranch).toEqual(['claude/issue-7']);
+    expect(state.calls.prMergedFor).toEqual(['claude/issue-7']);
+    expect(state.calls.removeWorktree.length).toBe(1);
+    expect(state.calls.deleteBranch).toEqual(['claude/issue-7']);
   });
 
   it('reports cleanly when worktree and branch are already gone', async () => {
-    mergedReturn = true;
-    worktreeOnDisk = false;
-    branchExistsReturn = false;
+    state.mergedReturn = true;
+    state.worktreeOnDisk = false;
+    state.branchExistsReturn = false;
 
-    const result = await cleanup('codex/issue-9', { repoRoot: '/work/handoff' });
+    const result = await cleanup('codex/issue-9', { repoRoot: '/work/handoff', deps });
 
     expect(result.status).toBe('removed');
     expect(result.message).toContain('was not present');
     expect(result.message).toContain('branch codex/issue-9 was already gone');
-    expect(calls.removeWorktree.length).toBe(0);
-    expect(calls.deleteBranch.length).toBe(0);
+    expect(state.calls.removeWorktree.length).toBe(0);
+    expect(state.calls.deleteBranch.length).toBe(0);
   });
 
   it('retains the worktree when the PR is not merged', async () => {
-    mergedReturn = false;
+    state.mergedReturn = false;
 
-    const result = await cleanup('claude/issue-1', { repoRoot: '/work/handoff' });
+    const result = await cleanup('claude/issue-1', { repoRoot: '/work/handoff', deps });
 
     expect(result.status).toBe('retained');
     expect(result.message).toContain('not merged');
     expect(result.message).toContain('Worktree retained');
-    expect(calls.removeWorktree.length).toBe(0);
-    expect(calls.deleteBranch.length).toBe(0);
+    expect(state.calls.removeWorktree.length).toBe(0);
+    expect(state.calls.deleteBranch.length).toBe(0);
   });
 
   it('returns "unknown" when gh fails', async () => {
-    mergedReturn = new GhError('gh pr list failed: not authenticated');
+    state.mergedReturn = new GhError('gh pr list failed: not authenticated');
 
-    const result = await cleanup('claude/issue-3', { repoRoot: '/work/handoff' });
+    const result = await cleanup('claude/issue-3', { repoRoot: '/work/handoff', deps });
 
     expect(result.status).toBe('unknown');
     expect(result.message).toContain('Could not check PR status');
     expect(result.message).toContain('not authenticated');
     expect(result.message).toContain('Re-run');
-    expect(calls.removeWorktree.length).toBe(0);
-    expect(calls.deleteBranch.length).toBe(0);
+    expect(state.calls.removeWorktree.length).toBe(0);
+    expect(state.calls.deleteBranch.length).toBe(0);
   });
 
   it('returns "unknown" when worktree removal fails', async () => {
-    mergedReturn = true;
-    worktreeOnDisk = true;
-    removeWorktreeError = new Error('worktree is locked');
+    state.mergedReturn = true;
+    state.worktreeOnDisk = true;
+    state.removeWorktreeError = new Error('worktree is locked');
 
-    const result = await cleanup('claude/issue-4', { repoRoot: '/work/handoff' });
+    const result = await cleanup('claude/issue-4', { repoRoot: '/work/handoff', deps });
 
     expect(result.status).toBe('unknown');
     expect(result.message).toContain('Failed to remove worktree');
     expect(result.message).toContain('locked');
     expect(result.message).toContain('git worktree remove --force');
     expect(result.message).toContain('git branch -D claude/issue-4');
-    expect(calls.removeWorktree.length).toBe(1);
-    expect(calls.deleteBranch.length).toBe(0);
+    expect(state.calls.removeWorktree.length).toBe(1);
+    expect(state.calls.deleteBranch.length).toBe(0);
   });
 
   it('returns "unknown" when branch deletion fails after worktree removal', async () => {
-    mergedReturn = true;
-    worktreeOnDisk = true;
-    branchExistsReturn = true;
-    deleteBranchError = new Error('branch is checked out somewhere');
+    state.mergedReturn = true;
+    state.worktreeOnDisk = true;
+    state.branchExistsReturn = true;
+    state.deleteBranchError = new Error('branch is checked out somewhere');
 
-    const result = await cleanup('claude/issue-5', { repoRoot: '/work/handoff' });
+    const result = await cleanup('claude/issue-5', { repoRoot: '/work/handoff', deps });
 
     expect(result.status).toBe('unknown');
     expect(result.message).toContain('Removed worktree');
     expect(result.message).toContain('failed to delete branch');
     expect(result.message).toContain('git branch -D claude/issue-5');
-    expect(calls.removeWorktree.length).toBe(1);
+    expect(state.calls.removeWorktree.length).toBe(1);
   });
 
   it('skips branch deletion when the branch no longer exists', async () => {
-    mergedReturn = true;
-    worktreeOnDisk = true;
-    branchExistsReturn = false;
+    state.mergedReturn = true;
+    state.worktreeOnDisk = true;
+    state.branchExistsReturn = false;
 
-    const result = await cleanup('codex/issue-11', { repoRoot: '/work/handoff' });
+    const result = await cleanup('codex/issue-11', { repoRoot: '/work/handoff', deps });
 
     expect(result.status).toBe('removed');
     expect(result.message).toContain('Removed worktree');
     expect(result.message).toContain('branch codex/issue-11 was already gone');
-    expect(calls.deleteBranch.length).toBe(0);
+    expect(state.calls.deleteBranch.length).toBe(0);
   });
 });

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -219,7 +219,11 @@ describe('cleanup — production wiring (no opts.deps)', () => {
     //     expected `gh pr list ...` invocation
     //   - the message containing the stub's stderr text confirms
     //     cleanup's GhError handling consumed that exact failure
-    expect(spawn.calls).toEqual([{ command: 'gh', args: expectedArgv, cwd: undefined }]);
+    // cwd MUST be the passed repoRoot, not undefined: the runner scripts
+    // invoke `handoff cleanup` from inside the worktree being removed, and
+    // an inherited cwd would target the wrong (or doomed) directory once
+    // git starts mutating worktrees.
+    expect(spawn.calls).toEqual([{ command: 'gh', args: expectedArgv, cwd: '/work/handoff' }]);
     expect(result.status).toBe('unknown');
     expect(result.message).toContain('Could not check PR status');
     expect(result.message).toContain('gh test stub: not authenticated');
@@ -270,12 +274,20 @@ describe('cleanup — production wiring (no opts.deps)', () => {
       expect(result.message).toContain(`deleted branch ${branch}`);
       // All four subprocesses were issued in the order cleanup.ts walks
       // them: gh first, then worktree remove (gated by existsSync), then
-      // branchExists, then deleteBranch.
-      expect(spawn.calls.map((c) => `${c.command} ${c.args.join(' ')}`)).toEqual([
-        `gh pr list --head ${branch} --state merged --json number --limit 1`,
-        `git worktree remove --force ${worktreeDir}`,
-        `git show-ref --verify --quiet refs/heads/${branch}`,
-        `git branch -D ${branch}`,
+      // branchExists, then deleteBranch. Every call's cwd must be the
+      // passed repoRoot — production cleanup runs from inside the doomed
+      // worktree, so a regression that drops the cwd-binding here would
+      // re-break merged-PR cleanup the same way the original bug did.
+      expect(
+        spawn.calls.map((c) => ({ cmd: `${c.command} ${c.args.join(' ')}`, cwd: c.cwd })),
+      ).toEqual([
+        {
+          cmd: `gh pr list --head ${branch} --state merged --json number --limit 1`,
+          cwd: repoRoot,
+        },
+        { cmd: `git worktree remove --force ${worktreeDir}`, cwd: repoRoot },
+        { cmd: `git show-ref --verify --quiet refs/heads/${branch}`, cwd: repoRoot },
+        { cmd: `git branch -D ${branch}`, cwd: repoRoot },
       ]);
     } finally {
       rmSync(parent, { recursive: true, force: true });

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -187,26 +187,38 @@ describe('cleanup — production wiring (no opts.deps)', () => {
   afterEach(() => spawn.uninstall());
 
   it('falls through to defaultDeps and reaches the real gh wrapper', async () => {
+    const expectedArgv = [
+      'pr',
+      'list',
+      '--head',
+      'no-such-branch',
+      '--state',
+      'merged',
+      '--json',
+      'number',
+      '--limit',
+      '1',
+    ];
     spawn.expect({
       command: 'gh',
-      argv: [
-        'pr',
-        'list',
-        '--head',
-        'no-such-branch',
-        '--state',
-        'merged',
-        '--json',
-        'number',
-        '--limit',
-        '1',
-      ],
+      argv: expectedArgv,
       response: { stderr: 'gh test stub: not authenticated', exitCode: 1 },
     });
 
     const result = await cleanup('no-such-branch', { repoRoot: '/work/handoff' });
 
+    // Asserting only `status === 'unknown'` would also pass if the wiring
+    // missed the registered expectation entirely (scriptedSpawn's
+    // unmatched-call path emits an Error which cleanup also surfaces as
+    // 'unknown'). Pin both ends of the wire so a regression in either
+    // `defaultDeps.prMergedFor` *or* the gh argv contract trips this test:
+    //   - spawn.calls confirms cleanup actually shelled out to the
+    //     expected `gh pr list ...` invocation
+    //   - the message containing the stub's stderr text confirms
+    //     cleanup's GhError handling consumed that exact failure
+    expect(spawn.calls).toEqual([{ command: 'gh', args: expectedArgv, cwd: undefined }]);
     expect(result.status).toBe('unknown');
     expect(result.message).toContain('Could not check PR status');
+    expect(result.message).toContain('gh test stub: not authenticated');
   });
 });

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { cleanup, type CleanupDeps } from '../src/cleanup.ts';
 import { GhError } from '../src/github.ts';
@@ -220,5 +223,62 @@ describe('cleanup — production wiring (no opts.deps)', () => {
     expect(result.status).toBe('unknown');
     expect(result.message).toContain('Could not check PR status');
     expect(result.message).toContain('gh test stub: not authenticated');
+  });
+
+  it('drives the merged-PR happy path through every defaultDeps entry', async () => {
+    // The error-path test above only exercises `defaultDeps.prMergedFor`.
+    // A swap of `branchExists`/`removeWorktree`/`deleteBranch`/`existsSync`
+    // in the defaults table would still slip through. This case wires up
+    // a real on-disk worktree directory so the production `existsSync`
+    // returns true, then registers each gh/git argv the merged path is
+    // expected to produce — pinning all five wires by argv shape, not
+    // just the prMergedFor slot.
+    const parent = mkdtempSync(join(tmpdir(), 'handoff-cleanup-defaults-'));
+    const repoRoot = join(parent, 'myrepo');
+    const branch = 'claude/issue-9';
+    const worktreeDir = join(parent, 'myrepo-issue-9');
+    mkdirSync(worktreeDir);
+    try {
+      // gh pr list → returns a single merged PR → prMergedFor returns true.
+      spawn.expectGh(
+        ['pr', 'list', '--head', branch, '--state', 'merged', '--json', 'number', '--limit', '1'],
+        [{ number: 9 }],
+      );
+      // git worktree remove --force <path>
+      spawn.expect({
+        command: 'git',
+        argv: ['worktree', 'remove', '--force', worktreeDir],
+        response: { stdout: '' },
+      });
+      // git show-ref --verify --quiet refs/heads/<branch> → success → branchExists=true
+      spawn.expect({
+        command: 'git',
+        argv: ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
+        response: { stdout: '' },
+      });
+      // git branch -D <branch>
+      spawn.expect({
+        command: 'git',
+        argv: ['branch', '-D', branch],
+        response: { stdout: '' },
+      });
+
+      const result = await cleanup(branch, { repoRoot });
+
+      expect(result.status).toBe('removed');
+      expect(result.message).toContain(`Removed worktree ${worktreeDir}`);
+      expect(result.message).toContain(`deleted branch ${branch}`);
+      // All four subprocesses were issued in the order cleanup.ts walks
+      // them: gh first, then worktree remove (gated by existsSync), then
+      // branchExists, then deleteBranch.
+      expect(spawn.calls.map((c) => `${c.command} ${c.args.join(' ')}`)).toEqual([
+        `gh pr list --head ${branch} --state merged --json number --limit 1`,
+        `git worktree remove --force ${worktreeDir}`,
+        `git show-ref --verify --quiet refs/heads/${branch}`,
+        `git branch -D ${branch}`,
+      ]);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { cleanup, type CleanupDeps } from '../src/cleanup.ts';
 import { GhError } from '../src/github.ts';
+import { createScriptedSpawn } from './helpers/scriptedSpawn.ts';
 
 interface FakeState {
   mergedReturn: boolean | Error;
@@ -166,5 +167,46 @@ describe('cleanup', () => {
     expect(result.message).toContain('Removed worktree');
     expect(result.message).toContain('branch codex/issue-11 was already gone');
     expect(state.calls.deleteBranch.length).toBe(0);
+  });
+});
+
+describe('cleanup — production wiring (no opts.deps)', () => {
+  // The DI tests above all pass an explicit `deps` object, so the
+  // `opts.deps ?? defaultDeps` fallback that production (cli.ts) actually
+  // hits is otherwise uncovered. A regression in the defaultDeps mapping
+  // — `prMergedFor` swapped, `existsSync` undefined, etc. — would ship
+  // unnoticed.
+  //
+  // We use scriptedSpawn here even though tests/README.md says not to mix
+  // it with per-module tests. The carve-out: this is an integration check
+  // of the wiring through to the gh subprocess, exactly like the #15
+  // CLI-level pattern. We fake the gh call so it fails predictably and
+  // assert cleanup() reaches the failure path.
+  const spawn = createScriptedSpawn();
+  beforeEach(() => spawn.install());
+  afterEach(() => spawn.uninstall());
+
+  it('falls through to defaultDeps and reaches the real gh wrapper', async () => {
+    spawn.expect({
+      command: 'gh',
+      argv: [
+        'pr',
+        'list',
+        '--head',
+        'no-such-branch',
+        '--state',
+        'merged',
+        '--json',
+        'number',
+        '--limit',
+        '1',
+      ],
+      response: { stderr: 'gh test stub: not authenticated', exitCode: 1 },
+    });
+
+    const result = await cleanup('no-such-branch', { repoRoot: '/work/handoff' });
+
+    expect(result.status).toBe('unknown');
+    expect(result.message).toContain('Could not check PR status');
   });
 });

--- a/tests/helpers/scriptedSpawn.test.ts
+++ b/tests/helpers/scriptedSpawn.test.ts
@@ -91,6 +91,35 @@ describe('scriptedSpawn', () => {
     await expect(run('gh', ['repo', 'view'])).rejects.toBeInstanceOf(RunError);
   });
 
+  it('uninstall restores the previously-installed impl, not always real spawn', async () => {
+    // The seam in run.ts saves the *previous* spawn at install time and
+    // restores that — not unconditionally `nodeSpawn`. Without this test,
+    // a regression that always restored the real spawn would still pass
+    // every other case in this file (which only ever installs once) but
+    // would silently let scriptedSpawn's afterEach clobber a sibling
+    // fixture's install in any future stacked use.
+    const fixtureA = createScriptedSpawn();
+    fixtureA.install();
+    fixtureA.expect({ command: 'git', argv: ['a'], response: { stdout: 'A\n' } });
+
+    const fixtureB = createScriptedSpawn();
+    fixtureB.install();
+    fixtureB.expect({ command: 'git', argv: ['b'], response: { stdout: 'B\n' } });
+
+    // While B is on top, calls go to B.
+    await run('git', ['b']);
+    expect(fixtureB.calls.map((c) => c.args)).toEqual([['b']]);
+    expect(fixtureA.calls).toEqual([]);
+
+    // Uninstall B — A must be active again, not the real spawn (which would
+    // try to shell out to git for real and likely succeed, masking the bug).
+    fixtureB.uninstall();
+    await run('git', ['a']);
+    expect(fixtureA.calls.map((c) => c.args)).toEqual([['a']]);
+
+    fixtureA.uninstall();
+  });
+
   it('expectGh wires a JSON response into a github.ts call', async () => {
     spawn.expectGh(['issue', 'view', '7', '--json', 'number,title,body,labels,url'], {
       number: 7,

--- a/tests/helpers/scriptedSpawn.test.ts
+++ b/tests/helpers/scriptedSpawn.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { fetchIssue } from '../../src/github.ts';
+import { RunError, run } from '../../src/run.ts';
+import { createScriptedSpawn, type ScriptedSpawn } from './scriptedSpawn.ts';
+
+let spawn: ScriptedSpawn;
+
+beforeEach(() => {
+  spawn = createScriptedSpawn();
+  spawn.install();
+});
+
+afterEach(() => {
+  spawn.uninstall();
+});
+
+describe('scriptedSpawn', () => {
+  it('returns scripted stdout for a matching argv', async () => {
+    spawn.expect({
+      command: 'git',
+      argv: ['rev-parse', '--show-toplevel'],
+      response: { stdout: '/tmp/some/repo\n' },
+    });
+
+    const result = await run('git', ['rev-parse', '--show-toplevel']);
+
+    expect(result.stdout).toBe('/tmp/some/repo\n');
+    expect(result.exitCode).toBe(0);
+    expect(spawn.calls).toEqual([
+      { command: 'git', args: ['rev-parse', '--show-toplevel'], cwd: undefined },
+    ]);
+  });
+
+  it('rejects with RunError when the scripted exitCode is non-zero', async () => {
+    spawn.expect({
+      command: 'gh',
+      argv: ['repo', 'view'],
+      response: { stderr: 'gh: not authenticated', exitCode: 1 },
+    });
+
+    await expect(run('gh', ['repo', 'view'])).rejects.toBeInstanceOf(RunError);
+  });
+
+  it('fails loudly when no expectation matches the call', async () => {
+    await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
+  });
+
+  it('expectGh wires a JSON response into a github.ts call', async () => {
+    spawn.expectGh(['issue', 'view', '7', '--json', 'number,title,body,labels,url'], {
+      number: 7,
+      title: 'Loop mode',
+      body: 'body',
+      url: 'https://example.test/7',
+      labels: [{ name: 'feature' }],
+    });
+
+    const issue = await fetchIssue(7);
+
+    expect(issue).toEqual({
+      number: 7,
+      title: 'Loop mode',
+      body: 'body',
+      url: 'https://example.test/7',
+      labels: ['feature'],
+    });
+  });
+});

--- a/tests/helpers/scriptedSpawn.test.ts
+++ b/tests/helpers/scriptedSpawn.test.ts
@@ -46,6 +46,32 @@ describe('scriptedSpawn', () => {
     await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
   });
 
+  it('consumes each expectation on match — a second identical call needs its own', async () => {
+    // Pins the FIFO/consuming contract documented at the top of
+    // scriptedSpawn.ts: registering one ticket allows exactly one
+    // matching call, and a duplicate spawn fails the same way an
+    // un-registered call would. Without this test, a regression that
+    // reverted to non-consuming matching ("first registration satisfies
+    // all calls") would silently let test code re-spawn the same
+    // subprocess unnoticed.
+    spawn.expect({
+      command: 'git',
+      argv: ['status'],
+      response: { stdout: 'first\n' },
+    });
+
+    const first = await run('git', ['status']);
+    expect(first.stdout).toBe('first\n');
+
+    await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
+
+    // Two registrations → two matching calls allowed, in registration order.
+    spawn.expect({ command: 'git', argv: ['status'], response: { stdout: 'a\n' } });
+    spawn.expect({ command: 'git', argv: ['status'], response: { stdout: 'b\n' } });
+    expect((await run('git', ['status'])).stdout).toBe('a\n');
+    expect((await run('git', ['status'])).stdout).toBe('b\n');
+  });
+
   it('install() resets expectations and calls so reused fixtures start clean', async () => {
     spawn.expect({
       command: 'git',

--- a/tests/helpers/scriptedSpawn.test.ts
+++ b/tests/helpers/scriptedSpawn.test.ts
@@ -44,6 +44,26 @@ describe('scriptedSpawn', () => {
 
   it('fails loudly when no expectation matches the call', async () => {
     await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
+    // The teardown check would otherwise re-throw on this same record;
+    // we already asserted on the in-flight error, so drain it.
+    expect(spawn.clearUnmatchedCalls().map((c) => c.args)).toEqual([['status']]);
+  });
+
+  it('uninstall throws when an unmatched call was swallowed by the caller', async () => {
+    // The per-call 'error' event already fails an awaiting test — the case
+    // this guards is when the code under test catches the error (e.g. a
+    // cleanup() that maps subprocess failures to an 'unknown' result) and
+    // keeps going. Without the teardown check, the test would pass with no
+    // hint that an unsanctioned subprocess fired. Manage the fixture
+    // locally so the outer afterEach doesn't see the leftover.
+    const local = createScriptedSpawn();
+    local.install();
+    // Caller swallows the spawn-time error.
+    await run('git', ['status']).catch(() => undefined);
+
+    expect(() => local.uninstall()).toThrow(/unmatched call\(s\).*git status/);
+    // Drained on throw — a follow-up uninstall must be a clean no-op.
+    expect(() => local.uninstall()).not.toThrow();
   });
 
   it('uninstall throws when expectations were registered but never consumed', () => {
@@ -85,6 +105,7 @@ describe('scriptedSpawn', () => {
     expect(first.stdout).toBe('first\n');
 
     await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
+    spawn.clearUnmatchedCalls();
 
     // Two registrations → two matching calls allowed, in registration order.
     spawn.expect({ command: 'git', argv: ['status'], response: { stdout: 'a\n' } });
@@ -108,6 +129,7 @@ describe('scriptedSpawn', () => {
     spawn.install();
     expect(spawn.calls).toEqual([]);
     await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched/);
+    spawn.clearUnmatchedCalls();
   });
 
   it("drives run()'s spawn-error path when response.error is set", async () => {

--- a/tests/helpers/scriptedSpawn.test.ts
+++ b/tests/helpers/scriptedSpawn.test.ts
@@ -46,6 +46,16 @@ describe('scriptedSpawn', () => {
     await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
   });
 
+  it('rejects with RunError when only a signal is set (matches Node close-on-signal)', async () => {
+    spawn.expect({
+      command: 'gh',
+      argv: ['repo', 'view'],
+      response: { signal: 'SIGTERM' },
+    });
+
+    await expect(run('gh', ['repo', 'view'])).rejects.toBeInstanceOf(RunError);
+  });
+
   it('expectGh wires a JSON response into a github.ts call', async () => {
     spawn.expectGh(['issue', 'view', '7', '--json', 'number,title,body,labels,url'], {
       number: 7,

--- a/tests/helpers/scriptedSpawn.test.ts
+++ b/tests/helpers/scriptedSpawn.test.ts
@@ -46,6 +46,27 @@ describe('scriptedSpawn', () => {
     await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
   });
 
+  it('uninstall throws when expectations were registered but never consumed', () => {
+    // The test infra carve-out: this `it` manages its own fixture so the
+    // outer beforeEach/afterEach pair (which would re-throw on a clean
+    // teardown of the leftover) doesn't double-fire. A test that says
+    // "this subprocess must run" and then never triggers it is exactly
+    // the silent-pass bug strict uninstall is here to surface.
+    const local = createScriptedSpawn();
+    local.install();
+    local.expect({
+      command: 'gh',
+      argv: ['repo', 'view'],
+      response: { stdout: '{}' },
+    });
+
+    expect(() => local.uninstall()).toThrow(/unconsumed expectation\(s\).*gh repo view/);
+    // Drained on throw — a follow-up uninstall must be a clean no-op so
+    // the next `install()` (or a sibling fixture's teardown) doesn't
+    // re-trip on the same leftovers.
+    expect(() => local.uninstall()).not.toThrow();
+  });
+
   it('consumes each expectation on match — a second identical call needs its own', async () => {
     // Pins the FIFO/consuming contract documented at the top of
     // scriptedSpawn.ts: registering one ticket allows exactly one

--- a/tests/helpers/scriptedSpawn.test.ts
+++ b/tests/helpers/scriptedSpawn.test.ts
@@ -46,6 +46,24 @@ describe('scriptedSpawn', () => {
     await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
   });
 
+  it("drives run()'s spawn-error path when response.error is set", async () => {
+    // Synthetic ENOENT: the binary isn't on PATH. Node fires 'error' (never
+    // 'close') and `run()` rejects with the raw Error — *not* a RunError,
+    // since RunError is built from a close-event RunResult.
+    const enoent = Object.assign(new Error('spawn handoff-nonexistent ENOENT'), {
+      code: 'ENOENT',
+    });
+    spawn.expect({
+      command: 'handoff-nonexistent',
+      argv: ['--help'],
+      response: { error: enoent },
+    });
+
+    const promise = run('handoff-nonexistent', ['--help']);
+    await expect(promise).rejects.toBe(enoent);
+    await expect(promise).rejects.not.toBeInstanceOf(RunError);
+  });
+
   it('rejects with RunError when only a signal is set (matches Node close-on-signal)', async () => {
     spawn.expect({
       command: 'gh',

--- a/tests/helpers/scriptedSpawn.test.ts
+++ b/tests/helpers/scriptedSpawn.test.ts
@@ -46,6 +46,23 @@ describe('scriptedSpawn', () => {
     await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched git status/);
   });
 
+  it('install() resets expectations and calls so reused fixtures start clean', async () => {
+    spawn.expect({
+      command: 'git',
+      argv: ['status'],
+      response: { stdout: 'phase one\n' },
+    });
+    await run('git', ['status']);
+    expect(spawn.calls).toHaveLength(1);
+
+    // Phase two: uninstall, reinstall same fixture. The phase-one expectation
+    // and the phase-one recorded call should both be gone.
+    spawn.uninstall();
+    spawn.install();
+    expect(spawn.calls).toEqual([]);
+    await expect(run('git', ['status'])).rejects.toThrow(/no expectation matched/);
+  });
+
   it("drives run()'s spawn-error path when response.error is set", async () => {
     // Synthetic ENOENT: the binary isn't on PATH. Node fires 'error' (never
     // 'close') and `run()` rejects with the raw Error — *not* a RunError,

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -1,0 +1,157 @@
+/**
+ * Scripted-spawn fixture for I/O modules that shell out via `run.ts`.
+ *
+ * Each expectation matches one `(command, argv)` invocation exactly. The
+ * fixture records calls in order, in case the test wants to assert which
+ * subprocesses were spawned and with what arguments.
+ *
+ * Usage:
+ *
+ * ```ts
+ * const spawn = createScriptedSpawn();
+ * spawn.install();
+ * spawn.expect({ command: 'gh', argv: ['repo', 'view'], response: { stdout: '...' } });
+ * // ...exercise code that calls run('gh', ['repo', 'view'])...
+ * spawn.uninstall();
+ * ```
+ *
+ * For tests that exercise `git.ts` directly — where the contract under test
+ * is git's actual behaviour, not the wrapper — use `tempRepo.ts` instead.
+ */
+
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+
+import { __setSpawnForTesting } from '../../src/run.ts';
+
+export interface ScriptedResponse {
+  stdout?: string;
+  stderr?: string;
+  /** Defaults to 0 (success). Non-zero causes `run()` to reject with `RunError`. */
+  exitCode?: number;
+  /** Optional emitted signal (rare; use for SIGTERM-style tests). */
+  signal?: NodeJS.Signals;
+}
+
+export interface ScriptedExpectation {
+  command: string;
+  argv: readonly string[];
+  response: ScriptedResponse;
+}
+
+export interface ScriptedCall {
+  command: string;
+  args: readonly string[];
+  cwd: string | undefined;
+}
+
+export interface ScriptedSpawn {
+  /** Replace the spawn used by `run.ts`. Idempotent. */
+  install(): void;
+  /** Restore the real spawn. Always call from `afterEach`. */
+  uninstall(): void;
+  /** Register a `(command, argv) → response` mapping. Last write wins. */
+  expect(expectation: ScriptedExpectation): void;
+  /** Register a `gh` invocation that returns a JSON payload as stdout. */
+  expectGh(argv: readonly string[], jsonBody: unknown): void;
+  /** Calls observed since `install()`, in order. */
+  calls: ScriptedCall[];
+}
+
+function argvEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function findExpectation(
+  expectations: readonly ScriptedExpectation[],
+  command: string,
+  args: readonly string[],
+): ScriptedExpectation | undefined {
+  // Walk in reverse so a later-registered expectation overrides an earlier one
+  // for the same (command, argv) pair — matches "last write wins".
+  for (let i = expectations.length - 1; i >= 0; i -= 1) {
+    const e = expectations[i];
+    if (e && e.command === command && argvEqual(e.argv, args)) return e;
+  }
+  return undefined;
+}
+
+function fakeChild(response: ScriptedResponse): ChildProcess {
+  const child = new EventEmitter();
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+
+  // setImmediate ensures the test code has a chance to attach 'data' / 'close'
+  // listeners before we emit. (`run.ts` attaches synchronously after spawn,
+  // but that's an implementation detail we don't want this fixture to rely on.)
+  setImmediate(() => {
+    if (response.stdout) stdout.emit('data', Buffer.from(response.stdout, 'utf8'));
+    if (response.stderr) stderr.emit('data', Buffer.from(response.stderr, 'utf8'));
+    const code = response.exitCode ?? 0;
+    child.emit('close', code, response.signal ?? null);
+  });
+
+  return Object.assign(child, { stdout, stderr }) as unknown as ChildProcess;
+}
+
+function unmatchedChild(command: string, args: readonly string[]): ChildProcess {
+  const child = new EventEmitter();
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+
+  setImmediate(() => {
+    child.emit(
+      'error',
+      new Error(
+        `scriptedSpawn: no expectation matched ${command} ${args.join(' ')}\n` +
+          `  Register one with spawn.expect({ command, argv, response })`,
+      ),
+    );
+  });
+
+  return Object.assign(child, { stdout, stderr }) as unknown as ChildProcess;
+}
+
+export function createScriptedSpawn(): ScriptedSpawn {
+  const expectations: ScriptedExpectation[] = [];
+  const calls: ScriptedCall[] = [];
+  let installed = false;
+
+  const fixture: ScriptedSpawn = {
+    calls,
+    install() {
+      if (installed) return;
+      __setSpawnForTesting((command, args, options) => {
+        calls.push({ command, args: [...args], cwd: options.cwd as string | undefined });
+        const match = findExpectation(expectations, command, args);
+        return match ? fakeChild(match.response) : unmatchedChild(command, args);
+      });
+      installed = true;
+    },
+    uninstall() {
+      if (!installed) return;
+      __setSpawnForTesting(null);
+      installed = false;
+    },
+    expect(expectation) {
+      expectations.push({
+        command: expectation.command,
+        argv: [...expectation.argv],
+        response: { ...expectation.response },
+      });
+    },
+    expectGh(argv, jsonBody) {
+      fixture.expect({
+        command: 'gh',
+        argv,
+        response: { stdout: JSON.stringify(jsonBody) },
+      });
+    },
+  };
+
+  return fixture;
+}

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -7,7 +7,9 @@
  * If the same subprocess is expected twice, register two expectations.
  * If a call has no matching expectation — including a duplicate that
  * already consumed its match — the spawn emits an `error` event and the
- * test fails loudly.
+ * test fails loudly. `uninstall()` also throws if any expectations were
+ * never consumed, so a "this should have happened but didn't" bug
+ * doesn't slip through as a silently-passing test.
  *
  * Usage:
  *
@@ -68,6 +70,12 @@ export interface ScriptedSpawn {
    * when `install()` ran — which is the real `spawn` for a single-fixture
    * test, but a sibling scripted-spawn fixture under stacked use. Always
    * call from `afterEach` so the override doesn't leak past the test.
+   *
+   * Throws if any registered expectations were never consumed. An
+   * unconsumed expectation means the test claimed a subprocess would run
+   * and it didn't — surfacing that loudly catches "the code stopped
+   * spawning what we expected" regressions that a passive call-count
+   * assertion would miss.
    */
   uninstall(): void;
   /**
@@ -180,6 +188,19 @@ export function createScriptedSpawn(): ScriptedSpawn {
       if (!restore) return;
       restore();
       restore = null;
+      // Strict teardown: an `expect()` registration that never fires is a
+      // silent test bug — the test claimed "this subprocess will happen"
+      // and would still pass if the code stopped spawning it. Drain the
+      // queue *before* throwing so a subsequent `install()` starts clean
+      // even if afterEach fails here. Spawn is already restored above, so
+      // unrelated tests aren't polluted by this throw.
+      const leftovers = expectations.splice(0);
+      if (leftovers.length > 0) {
+        const detail = leftovers.map((e) => `${e.command} ${e.argv.join(' ')}`).join('; ');
+        throw new Error(
+          `scriptedSpawn: ${leftovers.length} unconsumed expectation(s) at uninstall: ${detail}`,
+        );
+      }
     },
     expect(expectation) {
       expectations.push({

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -26,6 +26,7 @@
  */
 
 import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 
 import { __setSpawnForTesting, type PipedChildProcess } from '../../src/run.ts';
 
@@ -118,8 +119,13 @@ function consumeExpectation(
 
 function fakeChild(response: ScriptedResponse): PipedChildProcess {
   const child = new EventEmitter();
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
+  // PassThrough is a real `stream.Readable` (and Writable), so the cast
+  // below isn't lying about the contract: any future `run()` change that
+  // uses standard stream APIs (`.pipe()`, `.read()`, `for await`) keeps
+  // working against the fake. `run()` only listens for `'data'` today,
+  // but the fixture is shared infra and shouldn't be the brittle hop.
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
 
   // setImmediate ensures the test code has a chance to attach 'data' / 'close'
   // listeners before we emit. (`run.ts` attaches synchronously after spawn,
@@ -127,13 +133,18 @@ function fakeChild(response: ScriptedResponse): PipedChildProcess {
   setImmediate(() => {
     if (response.error) {
       // Spawn-level failure (ENOENT etc.): Node only fires 'error', never
-      // 'close', so don't emit any stdout/stderr/close — `run()` rejects
-      // straight from its 'error' handler.
+      // 'close', so end the streams as part of the synthetic-failure
+      // exit and skip the close event — `run()` rejects straight from
+      // its 'error' handler.
+      stdout.end();
+      stderr.end();
       child.emit('error', response.error);
       return;
     }
-    if (response.stdout) stdout.emit('data', Buffer.from(response.stdout, 'utf8'));
-    if (response.stderr) stderr.emit('data', Buffer.from(response.stderr, 'utf8'));
+    if (response.stdout) stdout.write(Buffer.from(response.stdout, 'utf8'));
+    if (response.stderr) stderr.write(Buffer.from(response.stderr, 'utf8'));
+    stdout.end();
+    stderr.end();
     // Match Node's contract: when a child is terminated by a signal, `close`
     // fires with `code === null`. Otherwise it fires with the explicit exit
     // code (or 0). Without this branch a `response: { signal: 'SIGTERM' }`
@@ -147,10 +158,12 @@ function fakeChild(response: ScriptedResponse): PipedChildProcess {
 
 function unmatchedChild(command: string, args: readonly string[]): PipedChildProcess {
   const child = new EventEmitter();
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
 
   setImmediate(() => {
+    stdout.end();
+    stderr.end();
     child.emit(
       'error',
       new Error(

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -1,9 +1,12 @@
 /**
  * Scripted-spawn fixture for I/O modules that shell out via `run.ts`.
  *
- * Each expectation matches one `(command, argv)` invocation exactly. The
- * fixture records calls in order, in case the test wants to assert which
- * subprocesses were spawned and with what arguments.
+ * Each expectation registers a `(command, argv) → response` mapping.
+ * Matching is *non-consuming*: a single expectation will satisfy every
+ * subsequent call with that exact `(command, argv)` pair, so the fixture
+ * does not by itself catch "the code under test ran the same subprocess
+ * twice when it should have run it once." Use the recorded `calls` array
+ * to assert call counts when that matters.
  *
  * Usage:
  *
@@ -59,7 +62,12 @@ export interface ScriptedSpawn {
    * intervening `uninstall()` is a no-op (state is *not* re-cleared).
    */
   install(): void;
-  /** Restore the real spawn. Always call from `afterEach`. */
+  /**
+   * Pop this fixture's spawn override. Restores whatever impl was active
+   * when `install()` ran — which is the real `spawn` for a single-fixture
+   * test, but a sibling scripted-spawn fixture under stacked use. Always
+   * call from `afterEach` so the override doesn't leak past the test.
+   */
   uninstall(): void;
   /** Register a `(command, argv) → response` mapping. Last write wins. */
   expect(expectation: ScriptedExpectation): void;

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -123,23 +123,22 @@ function unmatchedChild(command: string, args: readonly string[]): ChildProcess 
 export function createScriptedSpawn(): ScriptedSpawn {
   const expectations: ScriptedExpectation[] = [];
   const calls: ScriptedCall[] = [];
-  let installed = false;
+  let restore: (() => void) | null = null;
 
   const fixture: ScriptedSpawn = {
     calls,
     install() {
-      if (installed) return;
-      __setSpawnForTesting((command, args, options) => {
+      if (restore) return;
+      restore = __setSpawnForTesting((command, args, options) => {
         calls.push({ command, args: [...args], cwd: options.cwd as string | undefined });
         const match = findExpectation(expectations, command, args);
         return match ? fakeChild(match.response) : unmatchedChild(command, args);
       });
-      installed = true;
     },
     uninstall() {
-      if (!installed) return;
-      __setSpawnForTesting(null);
-      installed = false;
+      if (!restore) return;
+      restore();
+      restore = null;
     },
     expect(expectation) {
       expectations.push({

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -1,12 +1,13 @@
 /**
  * Scripted-spawn fixture for I/O modules that shell out via `run.ts`.
  *
- * Each expectation registers a `(command, argv) → response` mapping.
- * Matching is *non-consuming*: a single expectation will satisfy every
- * subsequent call with that exact `(command, argv)` pair, so the fixture
- * does not by itself catch "the code under test ran the same subprocess
- * twice when it should have run it once." Use the recorded `calls` array
- * to assert call counts when that matters.
+ * Each `expect()` registers a `(command, argv) → response` mapping.
+ * Matching is *consuming* and FIFO: a call matches the first registered
+ * expectation that fits, and the expectation is removed once it fires.
+ * If the same subprocess is expected twice, register two expectations.
+ * If a call has no matching expectation — including a duplicate that
+ * already consumed its match — the spawn emits an `error` event and the
+ * test fails loudly.
  *
  * Usage:
  *
@@ -69,7 +70,11 @@ export interface ScriptedSpawn {
    * call from `afterEach` so the override doesn't leak past the test.
    */
   uninstall(): void;
-  /** Register a `(command, argv) → response` mapping. Last write wins. */
+  /**
+   * Register a `(command, argv) → response` mapping. Each `expect()` adds
+   * one ticket; calls consume tickets FIFO. Register N times to allow N
+   * matching invocations.
+   */
   expect(expectation: ScriptedExpectation): void;
   /** Register a `gh` invocation that returns a JSON payload as stdout. */
   expectGh(argv: readonly string[], jsonBody: unknown): void;
@@ -85,16 +90,20 @@ function argvEqual(a: readonly string[], b: readonly string[]): boolean {
   return true;
 }
 
-function findExpectation(
-  expectations: readonly ScriptedExpectation[],
+function consumeExpectation(
+  expectations: ScriptedExpectation[],
   command: string,
   args: readonly string[],
 ): ScriptedExpectation | undefined {
-  // Walk in reverse so a later-registered expectation overrides an earlier one
-  // for the same (command, argv) pair — matches "last write wins".
-  for (let i = expectations.length - 1; i >= 0; i -= 1) {
+  // FIFO: the first registered expectation that matches wins, and is
+  // removed so a second identical call has to find its own ticket. Tests
+  // that legitimately need N invocations register N expectations.
+  for (let i = 0; i < expectations.length; i += 1) {
     const e = expectations[i];
-    if (e && e.command === command && argvEqual(e.argv, args)) return e;
+    if (e && e.command === command && argvEqual(e.argv, args)) {
+      expectations.splice(i, 1);
+      return e;
+    }
   }
   return undefined;
 }
@@ -163,7 +172,7 @@ export function createScriptedSpawn(): ScriptedSpawn {
       calls.length = 0;
       restore = __setSpawnForTesting((command, args, options) => {
         calls.push({ command, args: [...args], cwd: options.cwd as string | undefined });
-        const match = findExpectation(expectations, command, args);
+        const match = consumeExpectation(expectations, command, args);
         return match ? fakeChild(match.response) : unmatchedChild(command, args);
       });
     },

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -91,7 +91,11 @@ function fakeChild(response: ScriptedResponse): ChildProcess {
   setImmediate(() => {
     if (response.stdout) stdout.emit('data', Buffer.from(response.stdout, 'utf8'));
     if (response.stderr) stderr.emit('data', Buffer.from(response.stderr, 'utf8'));
-    const code = response.exitCode ?? 0;
+    // Match Node's contract: when a child is terminated by a signal, `close`
+    // fires with `code === null`. Otherwise it fires with the explicit exit
+    // code (or 0). Without this branch a `response: { signal: 'SIGTERM' }`
+    // test would resolve in run.ts as if the process had exited cleanly.
+    const code = response.signal ? null : (response.exitCode ?? 0);
     child.emit('close', code, response.signal ?? null);
   });
 

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -54,7 +54,11 @@ export interface ScriptedCall {
 }
 
 export interface ScriptedSpawn {
-  /** Replace the spawn used by `run.ts`. Idempotent. */
+  /**
+   * Replace the spawn used by `run.ts` and reset recorded `calls` plus any
+   * registered `expectations`. Idempotent: a second `install()` with no
+   * intervening `uninstall()` is a no-op (state is *not* re-cleared).
+   */
   install(): void;
   /** Restore the real spawn. Always call from `afterEach`. */
   uninstall(): void;
@@ -62,7 +66,7 @@ export interface ScriptedSpawn {
   expect(expectation: ScriptedExpectation): void;
   /** Register a `gh` invocation that returns a JSON payload as stdout. */
   expectGh(argv: readonly string[], jsonBody: unknown): void;
-  /** Calls observed since `install()`, in order. */
+  /** Calls observed since the most recent `install()`, in order. */
   calls: ScriptedCall[];
 }
 
@@ -144,6 +148,12 @@ export function createScriptedSpawn(): ScriptedSpawn {
     calls,
     install() {
       if (restore) return;
+      // Reset on every fresh install so a fixture reused across phases
+      // (uninstall + reinstall) honours the documented "calls since the
+      // most recent install()" contract instead of accumulating state from
+      // earlier phases. Mutate in place — `fixture.calls` is a reference.
+      expectations.length = 0;
+      calls.length = 0;
       restore = __setSpawnForTesting((command, args, options) => {
         calls.push({ command, args: [...args], cwd: options.cwd as string | undefined });
         const match = findExpectation(expectations, command, args);

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -31,6 +31,14 @@ export interface ScriptedResponse {
   exitCode?: number;
   /** Optional emitted signal (rare; use for SIGTERM-style tests). */
   signal?: NodeJS.Signals;
+  /**
+   * Drive `run()`'s `child.on('error', ...)` path instead of `close` —
+   * the branch Node fires for spawn-level failures like ENOENT (binary not
+   * on PATH). Mutually exclusive with stdout/stderr/exitCode/signal; if set,
+   * those are ignored. Use this for tests that need to assert the wrapper's
+   * behaviour when the subprocess never starts.
+   */
+  error?: Error;
 }
 
 export interface ScriptedExpectation {
@@ -89,6 +97,13 @@ function fakeChild(response: ScriptedResponse): ChildProcess {
   // listeners before we emit. (`run.ts` attaches synchronously after spawn,
   // but that's an implementation detail we don't want this fixture to rely on.)
   setImmediate(() => {
+    if (response.error) {
+      // Spawn-level failure (ENOENT etc.): Node only fires 'error', never
+      // 'close', so don't emit any stdout/stderr/close — `run()` rejects
+      // straight from its 'error' handler.
+      child.emit('error', response.error);
+      return;
+    }
     if (response.stdout) stdout.emit('data', Buffer.from(response.stdout, 'utf8'));
     if (response.stderr) stderr.emit('data', Buffer.from(response.stderr, 'utf8'));
     // Match Node's contract: when a child is terminated by a signal, `close`

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -5,11 +5,19 @@
  * Matching is *consuming* and FIFO: a call matches the first registered
  * expectation that fits, and the expectation is removed once it fires.
  * If the same subprocess is expected twice, register two expectations.
- * If a call has no matching expectation — including a duplicate that
- * already consumed its match — the spawn emits an `error` event and the
- * test fails loudly. `uninstall()` also throws if any expectations were
- * never consumed, so a "this should have happened but didn't" bug
- * doesn't slip through as a silently-passing test.
+ *
+ * Teardown is strict in both directions. `uninstall()` throws if either
+ *
+ * - any expectation was registered but never matched (a "this should have
+ *   happened but didn't" bug), or
+ * - any call was made that no expectation matched (a "the code under test
+ *   spawned something we didn't sign off on" bug).
+ *
+ * The unmatched-call check matters because the spawn-time `'error'` event
+ * is only an in-band signal: if the code under test catches it (e.g.
+ * `cleanup()` mapping a failed subprocess to an `'unknown'` result), the
+ * test would otherwise pass with no indication that an unexpected
+ * subprocess fired. Surfacing it at teardown closes that hole.
  *
  * Usage:
  *
@@ -72,11 +80,12 @@ export interface ScriptedSpawn {
    * test, but a sibling scripted-spawn fixture under stacked use. Always
    * call from `afterEach` so the override doesn't leak past the test.
    *
-   * Throws if any registered expectations were never consumed. An
-   * unconsumed expectation means the test claimed a subprocess would run
-   * and it didn't — surfacing that loudly catches "the code stopped
-   * spawning what we expected" regressions that a passive call-count
-   * assertion would miss.
+   * Throws if either an `expect()` was never matched, or a call was made
+   * that no expectation matched. The first catches "the code stopped
+   * spawning what we expected"; the second catches "the code spawned
+   * something we didn't sign off on" (which the per-call `'error'` event
+   * misses if the SUT catches it). Both checks drain on throw so a
+   * subsequent `install()` starts clean.
    */
   uninstall(): void;
   /**
@@ -89,6 +98,14 @@ export interface ScriptedSpawn {
   expectGh(argv: readonly string[], jsonBody: unknown): void;
   /** Calls observed since the most recent `install()`, in order. */
   calls: ScriptedCall[];
+  /**
+   * Drain the unmatched-call queue and return the calls that were in it.
+   * Use this in a test that *deliberately* triggers an unmatched call
+   * (e.g. to assert the in-flight `'error'` rejection) so the outer
+   * `afterEach` teardown doesn't fail on a record the test already
+   * verified.
+   */
+  clearUnmatchedCalls(): readonly ScriptedCall[];
 }
 
 function argvEqual(a: readonly string[], b: readonly string[]): boolean {
@@ -179,6 +196,7 @@ function unmatchedChild(command: string, args: readonly string[]): PipedChildPro
 export function createScriptedSpawn(): ScriptedSpawn {
   const expectations: ScriptedExpectation[] = [];
   const calls: ScriptedCall[] = [];
+  const unmatchedCalls: ScriptedCall[] = [];
   let restore: (() => void) | null = null;
 
   const fixture: ScriptedSpawn = {
@@ -191,29 +209,55 @@ export function createScriptedSpawn(): ScriptedSpawn {
       // earlier phases. Mutate in place — `fixture.calls` is a reference.
       expectations.length = 0;
       calls.length = 0;
+      unmatchedCalls.length = 0;
       restore = __setSpawnForTesting((command, args, options) => {
-        calls.push({ command, args: [...args], cwd: options.cwd as string | undefined });
+        const call: ScriptedCall = {
+          command,
+          args: [...args],
+          cwd: options.cwd as string | undefined,
+        };
+        calls.push(call);
         const match = consumeExpectation(expectations, command, args);
-        return match ? fakeChild(match.response) : unmatchedChild(command, args);
+        if (match) {
+          return fakeChild(match.response);
+        }
+        // Track unmatched calls separately so teardown can fail even when
+        // the SUT swallows the per-call `'error'` event (e.g. `cleanup()`
+        // mapping a failed subprocess to an `'unknown'` result).
+        unmatchedCalls.push(call);
+        return unmatchedChild(command, args);
       });
     },
     uninstall() {
       if (!restore) return;
       restore();
       restore = null;
-      // Strict teardown: an `expect()` registration that never fires is a
-      // silent test bug — the test claimed "this subprocess will happen"
-      // and would still pass if the code stopped spawning it. Drain the
-      // queue *before* throwing so a subsequent `install()` starts clean
-      // even if afterEach fails here. Spawn is already restored above, so
-      // unrelated tests aren't polluted by this throw.
+      // Strict teardown in both directions:
+      //
+      // - leftover expectations: a registered call that never fired ("this
+      //   subprocess will happen" — and didn't).
+      // - unmatched calls: a spawn the test never signed off on. The
+      //   per-call `'error'` event already fires, but if the SUT catches
+      //   it the test would otherwise pass; surfacing it here closes that
+      //   hole.
+      //
+      // Drain both queues *before* throwing so a subsequent `install()`
+      // starts clean even if afterEach fails. Spawn is already restored
+      // above, so unrelated tests aren't polluted by this throw.
       const leftovers = expectations.splice(0);
+      const unexpected = unmatchedCalls.splice(0);
+      if (leftovers.length === 0 && unexpected.length === 0) return;
+
+      const parts: string[] = [];
       if (leftovers.length > 0) {
         const detail = leftovers.map((e) => `${e.command} ${e.argv.join(' ')}`).join('; ');
-        throw new Error(
-          `scriptedSpawn: ${leftovers.length} unconsumed expectation(s) at uninstall: ${detail}`,
-        );
+        parts.push(`${leftovers.length} unconsumed expectation(s): ${detail}`);
       }
+      if (unexpected.length > 0) {
+        const detail = unexpected.map((c) => `${c.command} ${c.args.join(' ')}`).join('; ');
+        parts.push(`${unexpected.length} unmatched call(s): ${detail}`);
+      }
+      throw new Error(`scriptedSpawn: ${parts.join(' / ')}`);
     },
     expect(expectation) {
       expectations.push({
@@ -228,6 +272,9 @@ export function createScriptedSpawn(): ScriptedSpawn {
         argv,
         response: { stdout: JSON.stringify(jsonBody) },
       });
+    },
+    clearUnmatchedCalls() {
+      return unmatchedCalls.splice(0);
     },
   };
 

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -20,9 +20,8 @@
  */
 
 import { EventEmitter } from 'node:events';
-import type { ChildProcess } from 'node:child_process';
 
-import { __setSpawnForTesting } from '../../src/run.ts';
+import { __setSpawnForTesting, type PipedChildProcess } from '../../src/run.ts';
 
 export interface ScriptedResponse {
   stdout?: string;
@@ -92,7 +91,7 @@ function findExpectation(
   return undefined;
 }
 
-function fakeChild(response: ScriptedResponse): ChildProcess {
+function fakeChild(response: ScriptedResponse): PipedChildProcess {
   const child = new EventEmitter();
   const stdout = new EventEmitter();
   const stderr = new EventEmitter();
@@ -118,10 +117,10 @@ function fakeChild(response: ScriptedResponse): ChildProcess {
     child.emit('close', code, response.signal ?? null);
   });
 
-  return Object.assign(child, { stdout, stderr }) as unknown as ChildProcess;
+  return Object.assign(child, { stdout, stderr }) as unknown as PipedChildProcess;
 }
 
-function unmatchedChild(command: string, args: readonly string[]): ChildProcess {
+function unmatchedChild(command: string, args: readonly string[]): PipedChildProcess {
   const child = new EventEmitter();
   const stdout = new EventEmitter();
   const stderr = new EventEmitter();
@@ -136,7 +135,7 @@ function unmatchedChild(command: string, args: readonly string[]): ChildProcess 
     );
   });
 
-  return Object.assign(child, { stdout, stderr }) as unknown as ChildProcess;
+  return Object.assign(child, { stdout, stderr }) as unknown as PipedChildProcess;
 }
 
 export function createScriptedSpawn(): ScriptedSpawn {

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+
+import { branchExists } from '../../src/git.ts';
+import { createTempRepo, type TempRepo } from './tempRepo.ts';
+
+let repo: TempRepo;
+let originalCwd: string;
+
+beforeEach(() => {
+  repo = createTempRepo({
+    branches: ['feature/x', 'fix/y'],
+    remotes: { origin: 'https://example.invalid/repo.git' },
+  });
+  originalCwd = process.cwd();
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  repo.cleanup();
+});
+
+describe('tempRepo', () => {
+  it('creates a real repo with the requested branches and remotes', () => {
+    expect(existsSync(repo.path)).toBe(true);
+
+    const branches = repo
+      .git(['branch', '--list', '--format=%(refname:short)'])
+      .stdout.split('\n')
+      .map((b) => b.trim())
+      .filter(Boolean);
+    expect(branches.sort()).toEqual(['dev', 'feature/x', 'fix/y']);
+
+    expect(repo.git(['symbolic-ref', '--short', 'HEAD']).stdout.trim()).toBe('dev');
+    expect(repo.git(['remote', 'get-url', 'origin']).stdout.trim()).toBe(
+      'https://example.invalid/repo.git',
+    );
+  });
+
+  it('drives src/git.ts through process.chdir into the temp repo', async () => {
+    // git.ts uses the process cwd when shelling out, so this is the wiring
+    // pattern the per-module tests in #14 will copy.
+    process.chdir(repo.path);
+
+    expect(await branchExists('feature/x')).toBe(true);
+    expect(await branchExists('does/not/exist')).toBe(false);
+  });
+
+  it('cleanup removes the repo from disk and is idempotent', () => {
+    const path = repo.path;
+    repo.cleanup();
+    expect(existsSync(path)).toBe(false);
+    expect(() => repo.cleanup()).not.toThrow();
+  });
+});

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -55,19 +55,17 @@ describe('tempRepo', () => {
   });
 
   it('does not leak a temp dir if setup fails', () => {
-    const before = new Set(readdirSync(tmpdir()).filter((n) => n.startsWith('handoff-temprepo-')));
+    // Use a dedicated prefix so the listing only sees dirs created by this
+    // test. Sibling tempRepo callers (default prefix) running in parallel
+    // under bun's cross-file scheduler can't leak into the snapshot.
+    const prefix = 'handoff-temprepo-leakcheck-';
 
     // `..bad` is rejected by `git branch` with "invalid branch name", which
     // throws partway through setup — after mkdtemp but before the handle is
     // returned. Guard ensures the directory doesn't survive the throw.
-    expect(() => createTempRepo({ branches: ['..bad'] })).toThrow();
+    expect(() => createTempRepo({ tmpPrefix: prefix, branches: ['..bad'] })).toThrow();
 
-    // Asserting "no *new* entries appeared" rather than "snapshot unchanged"
-    // is robust against bun's cross-file parallelism — sibling tests creating
-    // or removing their own `handoff-temprepo-*` dirs during this window
-    // shouldn't affect the verdict on whether *our* failed call leaked one.
-    const after = readdirSync(tmpdir()).filter((n) => n.startsWith('handoff-temprepo-'));
-    const newEntries = after.filter((n) => !before.has(n));
-    expect(newEntries).toEqual([]);
+    const survivors = readdirSync(tmpdir()).filter((n) => n.startsWith(prefix));
+    expect(survivors).toEqual([]);
   });
 });

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -104,16 +104,21 @@ describe('tempRepo', () => {
   });
 
   it('rejects a tmpPrefix that would escape os.tmpdir()', () => {
-    // Three escape modes the guard must catch:
+    // Four escape modes the guard must catch (each broke a previous
+    // iteration of this check):
     //   - separators: would land the fixture in a sub-tree of tmpdir
+    //   - trailing separator (`'nested/'`): a dirname-equals-tmpdir check
+    //     passes here because dirname strips the trailing separator, but
+    //     mkdtemp still creates the fixture under `<tmpdir>/nested/`
     //   - '.': collapses to tmpdir, so mkdtemp creates `<tmpdir>XXXXXX`
     //     (a sibling of tmpdir, not a child)
     //   - '..': escapes to tmpdir's parent
-    // All three would let cleanup() later rmSync something we don't own.
-    expect(() => createTempRepo({ tmpPrefix: '../foo-' })).toThrow(/outside os\.tmpdir/);
-    expect(() => createTempRepo({ tmpPrefix: 'a/b-' })).toThrow(/outside os\.tmpdir/);
-    expect(() => createTempRepo({ tmpPrefix: '.' })).toThrow(/outside os\.tmpdir/);
-    expect(() => createTempRepo({ tmpPrefix: '..' })).toThrow(/outside os\.tmpdir/);
+    // All four would let cleanup() later rmSync something we don't own.
+    expect(() => createTempRepo({ tmpPrefix: '../foo-' })).toThrow(/A-Za-z0-9/);
+    expect(() => createTempRepo({ tmpPrefix: 'a/b-' })).toThrow(/A-Za-z0-9/);
+    expect(() => createTempRepo({ tmpPrefix: 'nested/' })).toThrow(/A-Za-z0-9/);
+    expect(() => createTempRepo({ tmpPrefix: '.' })).toThrow(/A-Za-z0-9/);
+    expect(() => createTempRepo({ tmpPrefix: '..' })).toThrow(/A-Za-z0-9/);
   });
 
   it('does not leak a temp dir if setup fails', () => {

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -39,6 +39,21 @@ describe('tempRepo', () => {
     );
   });
 
+  it('honours an initialBranch override', () => {
+    // Documented contract — without this test, a regression in the
+    // `symbolic-ref HEAD refs/heads/<name>` setup would only surface when a
+    // future test happened to ask for a non-default branch.
+    const custom = createTempRepo({
+      tmpPrefix: 'handoff-temprepo-initbr-',
+      initialBranch: 'trunk',
+    });
+    try {
+      expect(custom.git(['symbolic-ref', '--short', 'HEAD']).stdout.trim()).toBe('trunk');
+    } finally {
+      custom.cleanup();
+    }
+  });
+
   it('drives src/git.ts through process.chdir into the temp repo', async () => {
     // git.ts uses the process cwd when shelling out, so this is the wiring
     // pattern the per-module tests in #14 will copy.

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -55,14 +55,19 @@ describe('tempRepo', () => {
   });
 
   it('does not leak a temp dir if setup fails', () => {
-    const before = readdirSync(tmpdir()).filter((n) => n.startsWith('handoff-temprepo-'));
+    const before = new Set(readdirSync(tmpdir()).filter((n) => n.startsWith('handoff-temprepo-')));
 
     // `..bad` is rejected by `git branch` with "invalid branch name", which
     // throws partway through setup — after mkdtemp but before the handle is
     // returned. Guard ensures the directory doesn't survive the throw.
     expect(() => createTempRepo({ branches: ['..bad'] })).toThrow();
 
+    // Asserting "no *new* entries appeared" rather than "snapshot unchanged"
+    // is robust against bun's cross-file parallelism — sibling tests creating
+    // or removing their own `handoff-temprepo-*` dirs during this window
+    // shouldn't affect the verdict on whether *our* failed call leaked one.
     const after = readdirSync(tmpdir()).filter((n) => n.startsWith('handoff-temprepo-'));
-    expect(after.sort()).toEqual(before.sort());
+    const newEntries = after.filter((n) => !before.has(n));
+    expect(newEntries).toEqual([]);
   });
 });

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -82,6 +82,25 @@ describe('tempRepo', () => {
 
     expect(existsSync(repo.path)).toBe(false);
     expect(existsSync(sibling)).toBe(false);
+  });
+
+  it('cleanup does not rm worktree paths outside the repo namespace', () => {
+    // A test that registered a worktree at an arbitrary path (rogue or
+    // typo'd absolute path) must not have its target deleted by cleanup.
+    // Stand up an unrelated temp dir, register it as a worktree on the
+    // fixture, and assert cleanup leaves it intact.
+    const outsider = mkdtempSync(join(tmpdir(), 'handoff-temprepo-outsider-'));
+    try {
+      repo.git(['worktree', 'add', outsider, 'feature/x']);
+      expect(existsSync(outsider)).toBe(true);
+
+      repo.cleanup();
+
+      expect(existsSync(repo.path)).toBe(false);
+      expect(existsSync(outsider)).toBe(true);
+    } finally {
+      rmSync(outsider, { recursive: true, force: true });
+    }
   });
 
   it('does not leak a temp dir if setup fails', () => {

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { existsSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 import { branchExists } from '../../src/git.ts';
 import { createTempRepo, type TempRepo } from './tempRepo.ts';
@@ -52,6 +53,20 @@ describe('tempRepo', () => {
     repo.cleanup();
     expect(existsSync(path)).toBe(false);
     expect(() => repo.cleanup()).not.toThrow();
+  });
+
+  it('cleanup also removes linked worktrees that landed as siblings', () => {
+    // Mimic what src/git.ts createWorktree does: register a sibling worktree
+    // off the temp repo. cleanup() should reach it via `git worktree list`,
+    // not just rm the main repo and leave the sibling on disk.
+    const sibling = join(dirname(repo.path), `${repo.path.split(/[\\/]/).pop()}-feature-x`);
+    repo.git(['worktree', 'add', sibling, 'feature/x']);
+    expect(existsSync(sibling)).toBe(true);
+
+    repo.cleanup();
+
+    expect(existsSync(repo.path)).toBe(false);
+    expect(existsSync(sibling)).toBe(false);
   });
 
   it('does not leak a temp dir if setup fails', () => {

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 import { branchExists } from '../../src/git.ts';
 import { createTempRepo, type TempRepo } from './tempRepo.ts';
@@ -51,5 +52,17 @@ describe('tempRepo', () => {
     repo.cleanup();
     expect(existsSync(path)).toBe(false);
     expect(() => repo.cleanup()).not.toThrow();
+  });
+
+  it('does not leak a temp dir if setup fails', () => {
+    const before = readdirSync(tmpdir()).filter((n) => n.startsWith('handoff-temprepo-'));
+
+    // `..bad` is rejected by `git branch` with "invalid branch name", which
+    // throws partway through setup — after mkdtemp but before the handle is
+    // returned. Guard ensures the directory doesn't survive the throw.
+    expect(() => createTempRepo({ branches: ['..bad'] })).toThrow();
+
+    const after = readdirSync(tmpdir()).filter((n) => n.startsWith('handoff-temprepo-'));
+    expect(after.sort()).toEqual(before.sort());
   });
 });

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -103,6 +103,16 @@ describe('tempRepo', () => {
     }
   });
 
+  it('rejects a tmpPrefix that would escape os.tmpdir()', () => {
+    // path.join('/tmp', '../foo-') collapses to '/foo-' — a fixture
+    // created under that prefix would land outside tmpdir entirely and
+    // cleanup would later rmSync it. The guard rejects the prefix before
+    // mkdtempSync even runs.
+    expect(() => createTempRepo({ tmpPrefix: '../foo-' })).toThrow(/path separators/);
+    expect(() => createTempRepo({ tmpPrefix: 'a/b-' })).toThrow(/path separators/);
+    expect(() => createTempRepo({ tmpPrefix: 'a\\b-' })).toThrow(/path separators/);
+  });
+
   it('does not leak a temp dir if setup fails', () => {
     // Dedicated prefix isolates from sibling tempRepo callers in this run;
     // the before-snapshot then isolates from stale `*-leakcheck-*` dirs

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -70,17 +70,20 @@ describe('tempRepo', () => {
   });
 
   it('does not leak a temp dir if setup fails', () => {
-    // Use a dedicated prefix so the listing only sees dirs created by this
-    // test. Sibling tempRepo callers (default prefix) running in parallel
-    // under bun's cross-file scheduler can't leak into the snapshot.
+    // Dedicated prefix isolates from sibling tempRepo callers in this run;
+    // the before-snapshot then isolates from stale `*-leakcheck-*` dirs
+    // left behind by a previous aborted run on the same machine. Either
+    // alone would let unrelated state poison the assertion.
     const prefix = 'handoff-temprepo-leakcheck-';
+    const before = new Set(readdirSync(tmpdir()).filter((n) => n.startsWith(prefix)));
 
     // `..bad` is rejected by `git branch` with "invalid branch name", which
     // throws partway through setup — after mkdtemp but before the handle is
     // returned. Guard ensures the directory doesn't survive the throw.
     expect(() => createTempRepo({ tmpPrefix: prefix, branches: ['..bad'] })).toThrow();
 
-    const survivors = readdirSync(tmpdir()).filter((n) => n.startsWith(prefix));
-    expect(survivors).toEqual([]);
+    const after = readdirSync(tmpdir()).filter((n) => n.startsWith(prefix));
+    const newEntries = after.filter((n) => !before.has(n));
+    expect(newEntries).toEqual([]);
   });
 });

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import { branchExists } from '../../src/git.ts';
-import { createTempRepo, type TempRepo } from './tempRepo.ts';
+import { __getSuiteRootForTesting, createTempRepo, type TempRepo } from './tempRepo.ts';
 
 let repo: TempRepo;
 let originalCwd: string;
@@ -103,17 +103,19 @@ describe('tempRepo', () => {
     }
   });
 
-  it('rejects a tmpPrefix that would escape os.tmpdir()', () => {
+  it('rejects a tmpPrefix that would escape the suite root', () => {
     // Four escape modes the guard must catch (each broke a previous
     // iteration of this check):
-    //   - separators: would land the fixture in a sub-tree of tmpdir
-    //   - trailing separator (`'nested/'`): a dirname-equals-tmpdir check
+    //   - separators: would land the fixture in a sub-tree of the root
+    //   - trailing separator (`'nested/'`): a dirname-equals-root check
     //     passes here because dirname strips the trailing separator, but
-    //     mkdtemp still creates the fixture under `<tmpdir>/nested/`
-    //   - '.': collapses to tmpdir, so mkdtemp creates `<tmpdir>XXXXXX`
-    //     (a sibling of tmpdir, not a child)
-    //   - '..': escapes to tmpdir's parent
-    // All four would let cleanup() later rmSync something we don't own.
+    //     mkdtemp still creates the fixture under `<root>/nested/`
+    //   - '.': collapses to the root, so mkdtemp creates `<root>XXXXXX`
+    //     (a sibling of the root, not a child)
+    //   - '..': escapes to the root's parent
+    // The suite-root realpath gate would already refuse to rmSync any of
+    // these, but failing fast at creation gives a clearer error than
+    // letting a confusingly-named directory get created and orphaned.
     expect(() => createTempRepo({ tmpPrefix: '../foo-' })).toThrow(/A-Za-z0-9/);
     expect(() => createTempRepo({ tmpPrefix: 'a/b-' })).toThrow(/A-Za-z0-9/);
     expect(() => createTempRepo({ tmpPrefix: 'nested/' })).toThrow(/A-Za-z0-9/);
@@ -122,19 +124,20 @@ describe('tempRepo', () => {
   });
 
   it('does not leak a temp dir if setup fails', () => {
-    // Dedicated prefix isolates from sibling tempRepo callers in this run;
-    // the before-snapshot then isolates from stale `*-leakcheck-*` dirs
-    // left behind by a previous aborted run on the same machine. Either
-    // alone would let unrelated state poison the assertion.
+    // Scope the leak check to the suite root, not os.tmpdir(): every
+    // `createTempRepo` mkdtemps under the root, so a setup that throws
+    // can only orphan a directory there. A dedicated prefix then isolates
+    // this assertion from sibling tempRepo callers in the same run.
     const prefix = 'handoff-temprepo-leakcheck-';
-    const before = new Set(readdirSync(tmpdir()).filter((n) => n.startsWith(prefix)));
+    const root = __getSuiteRootForTesting();
+    const before = new Set(readdirSync(root).filter((n) => n.startsWith(prefix)));
 
     // `..bad` is rejected by `git branch` with "invalid branch name", which
     // throws partway through setup — after mkdtemp but before the handle is
     // returned. Guard ensures the directory doesn't survive the throw.
     expect(() => createTempRepo({ tmpPrefix: prefix, branches: ['..bad'] })).toThrow();
 
-    const after = readdirSync(tmpdir()).filter((n) => n.startsWith(prefix));
+    const after = readdirSync(root).filter((n) => n.startsWith(prefix));
     const newEntries = after.filter((n) => !before.has(n));
     expect(newEntries).toEqual([]);
   });

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -104,13 +104,16 @@ describe('tempRepo', () => {
   });
 
   it('rejects a tmpPrefix that would escape os.tmpdir()', () => {
-    // path.join('/tmp', '../foo-') collapses to '/foo-' — a fixture
-    // created under that prefix would land outside tmpdir entirely and
-    // cleanup would later rmSync it. The guard rejects the prefix before
-    // mkdtempSync even runs.
-    expect(() => createTempRepo({ tmpPrefix: '../foo-' })).toThrow(/path separators/);
-    expect(() => createTempRepo({ tmpPrefix: 'a/b-' })).toThrow(/path separators/);
-    expect(() => createTempRepo({ tmpPrefix: 'a\\b-' })).toThrow(/path separators/);
+    // Three escape modes the guard must catch:
+    //   - separators: would land the fixture in a sub-tree of tmpdir
+    //   - '.': collapses to tmpdir, so mkdtemp creates `<tmpdir>XXXXXX`
+    //     (a sibling of tmpdir, not a child)
+    //   - '..': escapes to tmpdir's parent
+    // All three would let cleanup() later rmSync something we don't own.
+    expect(() => createTempRepo({ tmpPrefix: '../foo-' })).toThrow(/outside os\.tmpdir/);
+    expect(() => createTempRepo({ tmpPrefix: 'a/b-' })).toThrow(/outside os\.tmpdir/);
+    expect(() => createTempRepo({ tmpPrefix: '.' })).toThrow(/outside os\.tmpdir/);
+    expect(() => createTempRepo({ tmpPrefix: '..' })).toThrow(/outside os\.tmpdir/);
   });
 
   it('does not leak a temp dir if setup fails', () => {

--- a/tests/helpers/tempRepo.test.ts
+++ b/tests/helpers/tempRepo.test.ts
@@ -103,6 +103,28 @@ describe('tempRepo', () => {
     }
   });
 
+  it('cleanup leaves in-suite paths that do not match the createWorktree pattern', () => {
+    // The realpath-under-SUITE_ROOT check alone is too broad: another
+    // fixture's repo (or any unrelated dir) under the same per-process
+    // root would be a delete candidate just by being in the same run.
+    // The namespace also requires the createWorktree `<repo.path>-<tail>`
+    // shape — paths that happen to live under SUITE_ROOT but don't match
+    // that pattern must be left alone.
+    const root = __getSuiteRootForTesting();
+    const stranger = mkdtempSync(join(root, 'handoff-temprepo-stranger-'));
+    try {
+      repo.git(['worktree', 'add', stranger, 'fix/y']);
+      expect(existsSync(stranger)).toBe(true);
+
+      repo.cleanup();
+
+      expect(existsSync(repo.path)).toBe(false);
+      expect(existsSync(stranger)).toBe(true);
+    } finally {
+      rmSync(stranger, { recursive: true, force: true });
+    }
+  });
+
   it('rejects a tmpPrefix that would escape the suite root', () => {
     // Four escape modes the guard must catch (each broke a previous
     // iteration of this check):

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -228,7 +228,15 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
     }
   } catch (err) {
     cleanedUp = true;
-    rmSync(path, { recursive: true, force: true });
+    // Best-effort scrub: don't let an rmSync failure (Windows EBUSY/EPERM,
+    // antivirus holding a handle) overwrite the underlying setup error
+    // the caller actually needs to diagnose. SUITE_ROOT's exit-time sweep
+    // is the backstop for any orphan that survives this attempt.
+    try {
+      rmSync(path, { recursive: true, force: true });
+    } catch {
+      /* swallow — surface the original setup failure below */
+    }
     throw err;
   }
 

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -4,8 +4,14 @@
  * The contract under test in `git.ts` is git's actual behaviour — `git
  * worktree add`, `branch -D`, etc. — so a scripted-spawn fake would just
  * encode our wrapper's expectations and miss every real divergence. This
- * fixture instead spins up a throwaway repo in `os.tmpdir()` and runs the
- * real `git`. Cleanup removes the directory.
+ * fixture instead spins up a throwaway repo under a suite-owned root in
+ * `os.tmpdir()` and runs the real `git`. Cleanup removes the directory.
+ *
+ * Path safety: every repo lives under a single per-process root (`SUITE_ROOT`
+ * below). `cleanup()` will only `rmSync` paths whose realpath resolves
+ * under that root, so a test that registers a stray worktree path —
+ * accidentally or otherwise — cannot turn this helper into a recursive
+ * deleter for a directory outside its own namespace.
  *
  * Usage:
  *
@@ -21,9 +27,9 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { join, sep } from 'node:path';
 
 export interface TempRepoOptions {
   /** Initial branch name. Defaults to `'dev'` to match this repo's convention. */
@@ -33,14 +39,65 @@ export interface TempRepoOptions {
   /** Remotes to register. Map of remote name → URL. URL can be any string git accepts. */
   remotes?: Readonly<Record<string, string>>;
   /**
-   * `mkdtemp` prefix under `os.tmpdir()`. Defaults to `'handoff-temprepo-'`.
-   * Override when a test needs to scan `tmpdir()` for its own dirs without
-   * picking up sibling tempRepo callers running in parallel.
+   * `mkdtemp` prefix under the suite root. Defaults to `'handoff-temprepo-'`.
+   * Override when a test needs to scan the suite root for its own dirs
+   * without picking up sibling tempRepo callers in the same run.
    */
   tmpPrefix?: string;
 }
 
 export const DEFAULT_TMP_PREFIX = 'handoff-temprepo-';
+
+// Suite-owned root: every tempRepo lives under this single mkdtemp'd
+// directory, and `cleanup()` refuses to rmSync any path that doesn't
+// resolve under it. The realpath anchor — not a basename predicate — is
+// the safety boundary against "a test typo'd a worktree path and cleanup
+// deleted an unrelated directory." Everything destructive in this file
+// gates on `isUnderSuiteRoot()`.
+//
+// realpath both ends so macOS `/var` ↔ `/private/var` and Windows 8.3
+// short names normalize. realpathSync.native goes through the OS's own
+// realpath, which is the variant that resolves Windows short names
+// reliably.
+const SUITE_ROOT = realpathSync.native(mkdtempSync(join(tmpdir(), 'handoff-test-suite-')));
+
+// Sweep at process exit. Under normal flow each test's `cleanup()` already
+// removed its own repo, but if a `beforeEach` throws after `mkdtemp` and
+// the local try/catch ever regresses, the orphan still lives under
+// SUITE_ROOT — which the exit handler will tear down.
+process.on('exit', () => {
+  try {
+    rmSync(SUITE_ROOT, { recursive: true, force: true });
+  } catch {
+    /* exit-time cleanup is best-effort */
+  }
+});
+
+function isUnderSuiteRoot(candidate: string): boolean {
+  let resolved: string;
+  try {
+    resolved = realpathSync.native(candidate);
+  } catch {
+    // Path doesn't exist (already removed) or unreadable. Don't fall back
+    // to a raw `startsWith` — without realpath we can't tell `/var/...`
+    // apart from `/private/var/...` on macOS, and a permissive fallback
+    // would defeat the boundary. Caller treats `false` as "leave it
+    // alone," which is the safe choice.
+    return false;
+  }
+  // Strict descendant — never SUITE_ROOT itself. The `process.on('exit')`
+  // handler owns the root; cleanup() only deletes *under* it.
+  return resolved.startsWith(SUITE_ROOT + sep);
+}
+
+/**
+ * @internal Test-only accessor for the suite root. Tests that need to
+ * scan the root directly (e.g. leak-check) read it through this.
+ * Production code has no business knowing the path.
+ */
+export function __getSuiteRootForTesting(): string {
+  return SUITE_ROOT;
+}
 
 export interface GitResult {
   stdout: string;
@@ -102,22 +159,19 @@ function runGit(cwd: string, args: readonly string[]): GitResult {
 export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
   const initialBranch = opts.initialBranch ?? 'dev';
   const tmpPrefix = opts.tmpPrefix ?? DEFAULT_TMP_PREFIX;
-  // mkdtempSync joins the prefix with tmpdir() and creates a dir at
-  // `<joined><6-random-chars>`. We've now hit three distinct escape
-  // modes — separators (`'a/b-'`), trailing separators (`'nested/'`,
-  // which collapses past dirname-equals-tmpdir checks), and dot
-  // segments (`'.'` resolves to tmpdir itself, `'..'` to its parent).
-  // Each fix-by-pattern attempt missed at least one. Replace with a
-  // strict allowlist: alphanumerics, underscore, hyphen. Test fixtures
-  // don't need anything richer, and any character class outside this
-  // set is either a separator, a dot segment, or trivially weird —
-  // safer to reject all of them than to keep enumerating escape modes.
+  // Strict allowlist: alphanumerics, underscore, hyphen. The suite-root
+  // anchor (`isUnderSuiteRoot`) is the load-bearing guarantee against
+  // out-of-namespace deletions, but rejecting weird prefixes here also
+  // fails fast — separators (`'a/b-'`), trailing separators
+  // (`'nested/'`), and dot segments (`'.'`, `'..'`) are all rejected
+  // before mkdtemp gets a chance to land somewhere surprising under
+  // SUITE_ROOT.
   if (!/^[A-Za-z0-9_-]+$/.test(tmpPrefix)) {
     throw new Error(
-      `tmpPrefix must match /^[A-Za-z0-9_-]+$/ to stay safely inside os.tmpdir(); got: ${JSON.stringify(tmpPrefix)}`,
+      `tmpPrefix must match /^[A-Za-z0-9_-]+$/ to stay safely inside the suite root; got: ${JSON.stringify(tmpPrefix)}`,
     );
   }
-  const path = mkdtempSync(join(tmpdir(), tmpPrefix));
+  const path = mkdtempSync(join(SUITE_ROOT, tmpPrefix));
   let cleanedUp = false;
 
   // If any setup step throws (missing git, bad ref name, etc.) the caller
@@ -167,21 +221,21 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
       // git.ts's createWorktree puts linked worktrees at
       // `<repo.path>-<branch-tail>` (see worktreePath in src/branch.ts),
       // so rm'ing repo.path alone would leak any worktree the test added.
-      // Constrain removal to that namespace via a name predicate: a test
-      // that called `repo.git(['worktree', 'add', '/some/unrelated/dir',
-      // ...])` could otherwise turn this helper into a recursive deleter
-      // for an arbitrary path. Out-of-namespace registrations are left
-      // for the test to own.
+      // We sweep them via `git worktree list --porcelain`, but every
+      // candidate is gated through `isUnderSuiteRoot` — `git worktree
+      // list` is untrusted input (a test can register an arbitrary
+      // absolute path), and the suite-root anchor is what stops a typo
+      // from turning this helper into a recursive deleter for some
+      // unrelated directory.
       //
       // Earlier iterations routed this through `git worktree remove
-      // --force` for the same safety reason, but git's removal can fail
-      // (locked file, dir already gone) — which then orphaned the
-      // worktree the moment we proceeded to rm the main repo, with no
-      // way for a retry to discover it. Direct rmSync is more reliable
-      // (`force: true` no-ops on missing) and the predicate gives us the
-      // same path-safety guarantee.
+      // --force`, but git's removal can fail (locked file, dir already
+      // gone) and orphaned the worktree once we proceeded to rm the main
+      // repo. Direct rmSync is more reliable (`force: true` no-ops on
+      // missing) and the suite-root gate gives us the path-safety
+      // guarantee a basename predicate could not.
       for (const linkedPath of listLinkedWorktrees(path)) {
-        if (isWithinRepoNamespace(linkedPath, path)) {
+        if (isUnderSuiteRoot(linkedPath)) {
           rmSync(linkedPath, { recursive: true, force: true });
         }
       }
@@ -193,35 +247,6 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
       cleanedUp = true;
     },
   };
-}
-
-function isWithinRepoNamespace(linkedPath: string, repoPath: string): boolean {
-  // Compare basenames, not full paths. The directory parts are a
-  // platform-canonicalisation minefield (macOS /var ↔ /private/var;
-  // Windows RUNNER~1 ↔ runneradmin short/long names; backslashes vs git's
-  // forward slashes), and realpath resolution differs across runtimes —
-  // Bun on Windows CI didn't resolve the short name even when called
-  // explicitly, which broke the previous full-path predicate.
-  //
-  // The basename predicate trades off:
-  //   - Covers the realistic threat — a typo or accidentally absolute
-  //     path the test never meant to register will have an unrelated
-  //     basename and be left alone.
-  //   - Does *not* cover a test that deliberately constructs a path of
-  //     the form `<some-other-dir>/<repo-basename>-<anything>` and
-  //     registers it with `repo.git(['worktree', 'add', ...])`. The
-  //     basename matches, so cleanup *will* rm it even though the
-  //     directory part is outside the temp repo's parent.
-  //
-  // We accept that second gap because (a) constructing such a path
-  // requires the test to read `repo.path` and splice its random-suffix
-  // basename into a foreign directory — that's deliberate, not
-  // accidental, and (b) any path that does match the pattern is
-  // mimicking the createWorktree contract closely enough that removing
-  // it is the right answer for the common case. A future test that
-  // legitimately needs an out-of-namespace worktree should manage that
-  // path's lifecycle itself.
-  return basename(linkedPath).startsWith(`${basename(repoPath)}-`);
 }
 
 function listLinkedWorktrees(repoPath: string): readonly string[] {

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -20,7 +20,7 @@
  * `git init -b <name>` which arrived in 2.28.
  */
 
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -56,22 +56,22 @@ function runGit(cwd: string, args: readonly string[]): GitResult {
     GIT_TERMINAL_PROMPT: '0',
     GIT_OPTIONAL_LOCKS: '0',
   };
-  try {
-    const stdout = execFileSync('git', args as string[], {
-      cwd,
-      env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      encoding: 'utf8',
-    });
-    return { stdout, stderr: '' };
-  } catch (err) {
-    const error = err as { stdout?: Buffer | string; stderr?: Buffer | string; message: string };
-    const stderr =
-      typeof error.stderr === 'string'
-        ? error.stderr
-        : (error.stderr?.toString('utf8') ?? error.message);
-    throw new Error(`git ${args.join(' ')} failed in ${cwd}: ${stderr.trim()}`);
+  const result = spawnSync('git', args as string[], {
+    cwd,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+  if (result.error) {
+    throw new Error(`git ${args.join(' ')} failed in ${cwd}: ${result.error.message}`);
   }
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || '').trim();
+    throw new Error(
+      `git ${args.join(' ')} failed in ${cwd} (exit ${result.status ?? 'null'}): ${detail}`,
+    );
+  }
+  return { stdout: result.stdout, stderr: result.stderr };
 }
 
 export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -134,15 +134,29 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
     },
     cleanup() {
       if (cleanedUp) return;
-      cleanedUp = true;
       // git.ts's createWorktree puts linked worktrees as *siblings* of the
       // repo root (see worktreePath in src/branch.ts), so rm'ing repo.path
-      // alone would leak any worktree the test added. Enumerate them via
-      // `git worktree list` and scrub each before the main dir.
+      // alone would leak any worktree the test added. Route removal through
+      // `git worktree remove --force` rather than raw rmSync of whatever
+      // path git happens to report — a test that called `repo.git(['worktree',
+      // 'add', '/some/important/dir', ...])` could otherwise turn this
+      // helper into a recursive deleter for unrelated directories. Letting
+      // git handle it constrains deletion to paths git itself registered
+      // (and unregisters them from the repo's worktree list as a bonus).
       for (const linkedPath of listLinkedWorktrees(path)) {
-        rmSync(linkedPath, { recursive: true, force: true });
+        try {
+          runGit(path, ['worktree', 'remove', '--force', linkedPath]);
+        } catch {
+          // Best-effort: worktree dir may already be gone, locked, or in
+          // some partially-broken state. Don't throw out of cleanup.
+        }
       }
       rmSync(path, { recursive: true, force: true });
+      // Mark cleaned-up only after rmSync succeeds — if it throws (Windows
+      // EBUSY/EPERM, antivirus holding a handle), a subsequent retry from
+      // the same `repo.cleanup()` reference can still attempt the work
+      // instead of becoming a silent no-op.
+      cleanedUp = true;
     },
   };
 }

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -135,7 +135,41 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
     cleanup() {
       if (cleanedUp) return;
       cleanedUp = true;
+      // git.ts's createWorktree puts linked worktrees as *siblings* of the
+      // repo root (see worktreePath in src/branch.ts), so rm'ing repo.path
+      // alone would leak any worktree the test added. Enumerate them via
+      // `git worktree list` and scrub each before the main dir.
+      for (const linkedPath of listLinkedWorktrees(path)) {
+        rmSync(linkedPath, { recursive: true, force: true });
+      }
       rmSync(path, { recursive: true, force: true });
     },
   };
+}
+
+function listLinkedWorktrees(repoPath: string): readonly string[] {
+  // Best-effort — cleanup must never throw, so if the repo is in some half-
+  // wedged state we just skip the sibling sweep and let rm of repo.path
+  // handle whatever's left under the main worktree.
+  let stdout: string;
+  try {
+    stdout = runGit(repoPath, ['worktree', 'list', '--porcelain']).stdout;
+  } catch {
+    return [];
+  }
+  const linked: string[] = [];
+  let seenMain = false;
+  for (const line of stdout.split('\n')) {
+    if (!line.startsWith('worktree ')) continue;
+    // `git worktree list` always emits the main worktree first; skip it
+    // rather than comparing paths (Windows backslashes vs git's forward
+    // slashes, macOS /var vs /private/var would all need normalising).
+    if (!seenMain) {
+      seenMain = true;
+      continue;
+    }
+    const wt = line.slice('worktree '.length).trim();
+    if (wt) linked.push(wt);
+  }
+  return linked;
 }

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -1,0 +1,116 @@
+/**
+ * Real-git temp repo fixture for tests that exercise `src/git.ts`.
+ *
+ * The contract under test in `git.ts` is git's actual behaviour — `git
+ * worktree add`, `branch -D`, etc. — so a scripted-spawn fake would just
+ * encode our wrapper's expectations and miss every real divergence. This
+ * fixture instead spins up a throwaway repo in `os.tmpdir()` and runs the
+ * real `git`. Cleanup removes the directory.
+ *
+ * Usage:
+ *
+ * ```ts
+ * let repo: TempRepo;
+ * beforeEach(() => { repo = createTempRepo({ branches: ['feature/x'] }); });
+ * afterEach(() => repo.cleanup());
+ * ```
+ *
+ * Compatibility: uses `git symbolic-ref HEAD` to set the initial branch so the
+ * helper works on `git ≥ 2.20` (the documented minimum), pre-dating
+ * `git init -b <name>` which arrived in 2.28.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface TempRepoOptions {
+  /** Initial branch name. Defaults to `'dev'` to match this repo's convention. */
+  initialBranch?: string;
+  /** Additional branches to create off the initial commit. */
+  branches?: readonly string[];
+  /** Remotes to register. Map of remote name → URL. URL can be any string git accepts. */
+  remotes?: Readonly<Record<string, string>>;
+}
+
+export interface GitResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface TempRepo {
+  /** Absolute path to the repo's working directory. */
+  path: string;
+  /** Run a git command inside the repo and return its stdout/stderr. Throws on non-zero exit. */
+  git(args: readonly string[]): GitResult;
+  /** Remove the repo from disk. Safe to call more than once. */
+  cleanup(): void;
+}
+
+function runGit(cwd: string, args: readonly string[]): GitResult {
+  // Pin a couple of envs so the repo behaves the same across developer
+  // machines: don't pick up the user's commit-signing config, don't prompt.
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_OPTIONAL_LOCKS: '0',
+  };
+  try {
+    const stdout = execFileSync('git', args as string[], {
+      cwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+    return { stdout, stderr: '' };
+  } catch (err) {
+    const error = err as { stdout?: Buffer | string; stderr?: Buffer | string; message: string };
+    const stderr =
+      typeof error.stderr === 'string'
+        ? error.stderr
+        : (error.stderr?.toString('utf8') ?? error.message);
+    throw new Error(`git ${args.join(' ')} failed in ${cwd}: ${stderr.trim()}`);
+  }
+}
+
+export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
+  const initialBranch = opts.initialBranch ?? 'dev';
+  const path = mkdtempSync(join(tmpdir(), 'handoff-temprepo-'));
+  let cleanedUp = false;
+
+  // git init, then point HEAD at the configured initial branch *before* any
+  // commit. `git init -b <name>` is the modern shortcut but only landed in
+  // 2.28; symbolic-ref works on every supported version.
+  runGit(path, ['init', '--quiet']);
+  runGit(path, ['symbolic-ref', 'HEAD', `refs/heads/${initialBranch}`]);
+
+  // Local config so `git commit` works on machines without global identity
+  // and never tries to sign — signing prompts would hang the test.
+  runGit(path, ['config', 'user.email', 'handoff-test@example.invalid']);
+  runGit(path, ['config', 'user.name', 'Handoff Test']);
+  runGit(path, ['config', 'commit.gpgsign', 'false']);
+  runGit(path, ['config', 'tag.gpgsign', 'false']);
+
+  // Empty initial commit so HEAD resolves and `git worktree add` has a base.
+  runGit(path, ['commit', '--allow-empty', '-m', 'init', '--no-gpg-sign']);
+
+  for (const branch of opts.branches ?? []) {
+    runGit(path, ['branch', branch]);
+  }
+  for (const [name, url] of Object.entries(opts.remotes ?? {})) {
+    runGit(path, ['remote', 'add', name, url]);
+  }
+
+  return {
+    path,
+    git(args) {
+      return runGit(path, args);
+    },
+    cleanup() {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      rmSync(path, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -73,7 +73,7 @@ process.on('exit', () => {
   }
 });
 
-function isUnderSuiteRoot(candidate: string): boolean {
+function isInRepoNamespace(candidate: string, repoPath: string): boolean {
   let resolved: string;
   try {
     resolved = realpathSync.native(candidate);
@@ -85,9 +85,18 @@ function isUnderSuiteRoot(candidate: string): boolean {
     // alone," which is the safe choice.
     return false;
   }
-  // Strict descendant — never SUITE_ROOT itself. The `process.on('exit')`
-  // handler owns the root; cleanup() only deletes *under* it.
-  return resolved.startsWith(SUITE_ROOT + sep);
+  // Two boundaries, both required:
+  //   1. Outer: must be under SUITE_ROOT. Defense in depth — if (2)
+  //      regresses, the realpath gate still blocks deletes outside the
+  //      per-process root.
+  //   2. Inner: must match `createWorktree`'s contract — a sibling at
+  //      `<repoPath>-<tail>` (see `src/branch.ts:worktreePath`). Without
+  //      this, a sibling test's repo or any unrelated dir under
+  //      SUITE_ROOT would be a delete candidate just by being in the
+  //      same process. The fixture only owns paths that match the
+  //      production worktreePath contract.
+  if (!resolved.startsWith(SUITE_ROOT + sep)) return false;
+  return resolved.startsWith(`${repoPath}-`);
 }
 
 /**
@@ -171,7 +180,12 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
       `tmpPrefix must match /^[A-Za-z0-9_-]+$/ to stay safely inside the suite root; got: ${JSON.stringify(tmpPrefix)}`,
     );
   }
-  const path = mkdtempSync(join(SUITE_ROOT, tmpPrefix));
+  // Canonicalise: mkdtemp returns the platform-native form (case, short
+  // names on Windows, /var↔/private/var on macOS). `git worktree list`
+  // emits its own canonicalisation, and the namespace check below
+  // realpaths each candidate before comparison — so the *base* it
+  // compares against (this `path`) has to be canonical too.
+  const path = realpathSync.native(mkdtempSync(join(SUITE_ROOT, tmpPrefix)));
   let cleanedUp = false;
 
   // If any setup step throws (missing git, bad ref name, etc.) the caller
@@ -222,20 +236,21 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
       // `<repo.path>-<branch-tail>` (see worktreePath in src/branch.ts),
       // so rm'ing repo.path alone would leak any worktree the test added.
       // We sweep them via `git worktree list --porcelain`, but every
-      // candidate is gated through `isUnderSuiteRoot` — `git worktree
-      // list` is untrusted input (a test can register an arbitrary
-      // absolute path), and the suite-root anchor is what stops a typo
-      // from turning this helper into a recursive deleter for some
-      // unrelated directory.
+      // candidate is gated through `isInRepoNamespace`: realpath under
+      // SUITE_ROOT *and* matching the `<repo.path>-<tail>` createWorktree
+      // pattern. `git worktree list` is untrusted input — a test can
+      // register an arbitrary absolute path, or even another fixture's
+      // path running in the same process — and only paths that match
+      // the production contract are this fixture's to delete.
       //
       // Earlier iterations routed this through `git worktree remove
       // --force`, but git's removal can fail (locked file, dir already
       // gone) and orphaned the worktree once we proceeded to rm the main
       // repo. Direct rmSync is more reliable (`force: true` no-ops on
-      // missing) and the suite-root gate gives us the path-safety
+      // missing) and the namespace gate gives us the path-safety
       // guarantee a basename predicate could not.
       for (const linkedPath of listLinkedWorktrees(path)) {
-        if (isUnderSuiteRoot(linkedPath)) {
+        if (isInRepoNamespace(linkedPath, path)) {
           rmSync(linkedPath, { recursive: true, force: true });
         }
       }

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -21,6 +21,12 @@
  * afterEach(() => repo.cleanup());
  * ```
  *
+ * If a test calls `process.chdir(repo.path)` to drive `git.ts` (which
+ * shells out in `process.cwd()`), restore the original cwd in the same
+ * `afterEach` *before* `repo.cleanup()`. On Windows, `rmSync` of a
+ * directory the process is sitting inside will fail. See
+ * `tests/README.md` for the full chdir + restore pattern.
+ *
  * Compatibility: uses `git symbolic-ref HEAD` to set the initial branch so the
  * helper works on `git ≥ 2.20` (the documented minimum), pre-dating
  * `git init -b <name>` which arrived in 2.28.
@@ -53,7 +59,8 @@ export const DEFAULT_TMP_PREFIX = 'handoff-temprepo-';
 // resolve under it. The realpath anchor — not a basename predicate — is
 // the safety boundary against "a test typo'd a worktree path and cleanup
 // deleted an unrelated directory." Everything destructive in this file
-// gates on `isUnderSuiteRoot()`.
+// gates on `isInRepoNamespace()` below, which combines the SUITE_ROOT
+// anchor with the per-repo `<repoPath>-<tail>` createWorktree contract.
 //
 // realpath both ends so macOS `/var` ↔ `/private/var` and Windows 8.3
 // short names normalize. realpathSync.native goes through the OS's own
@@ -168,8 +175,8 @@ function runGit(cwd: string, args: readonly string[]): GitResult {
 export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
   const initialBranch = opts.initialBranch ?? 'dev';
   const tmpPrefix = opts.tmpPrefix ?? DEFAULT_TMP_PREFIX;
-  // Strict allowlist: alphanumerics, underscore, hyphen. The suite-root
-  // anchor (`isUnderSuiteRoot`) is the load-bearing guarantee against
+  // Strict allowlist: alphanumerics, underscore, hyphen. The namespace
+  // gate (`isInRepoNamespace`) is the load-bearing guarantee against
   // out-of-namespace deletions, but rejecting weird prefixes here also
   // fails fast — separators (`'a/b-'`), trailing separators
   // (`'nested/'`), and dot segments (`'.'`, `'..'`) are all rejected

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -79,27 +79,36 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
   const path = mkdtempSync(join(tmpdir(), 'handoff-temprepo-'));
   let cleanedUp = false;
 
-  // git init, then point HEAD at the configured initial branch *before* any
-  // commit. `git init -b <name>` is the modern shortcut but only landed in
-  // 2.28; symbolic-ref works on every supported version.
-  runGit(path, ['init', '--quiet']);
-  runGit(path, ['symbolic-ref', 'HEAD', `refs/heads/${initialBranch}`]);
+  // If any setup step throws (missing git, bad ref name, etc.) the caller
+  // never gets a TempRepo handle, so afterEach's cleanup() won't fire and
+  // the mkdtemp directory would leak. Catch, scrub, and rethrow.
+  try {
+    // git init, then point HEAD at the configured initial branch *before* any
+    // commit. `git init -b <name>` is the modern shortcut but only landed in
+    // 2.28; symbolic-ref works on every supported version.
+    runGit(path, ['init', '--quiet']);
+    runGit(path, ['symbolic-ref', 'HEAD', `refs/heads/${initialBranch}`]);
 
-  // Local config so `git commit` works on machines without global identity
-  // and never tries to sign — signing prompts would hang the test.
-  runGit(path, ['config', 'user.email', 'handoff-test@example.invalid']);
-  runGit(path, ['config', 'user.name', 'Handoff Test']);
-  runGit(path, ['config', 'commit.gpgsign', 'false']);
-  runGit(path, ['config', 'tag.gpgsign', 'false']);
+    // Local config so `git commit` works on machines without global identity
+    // and never tries to sign — signing prompts would hang the test.
+    runGit(path, ['config', 'user.email', 'handoff-test@example.invalid']);
+    runGit(path, ['config', 'user.name', 'Handoff Test']);
+    runGit(path, ['config', 'commit.gpgsign', 'false']);
+    runGit(path, ['config', 'tag.gpgsign', 'false']);
 
-  // Empty initial commit so HEAD resolves and `git worktree add` has a base.
-  runGit(path, ['commit', '--allow-empty', '-m', 'init', '--no-gpg-sign']);
+    // Empty initial commit so HEAD resolves and `git worktree add` has a base.
+    runGit(path, ['commit', '--allow-empty', '-m', 'init', '--no-gpg-sign']);
 
-  for (const branch of opts.branches ?? []) {
-    runGit(path, ['branch', branch]);
-  }
-  for (const [name, url] of Object.entries(opts.remotes ?? {})) {
-    runGit(path, ['remote', 'add', name, url]);
+    for (const branch of opts.branches ?? []) {
+      runGit(path, ['branch', branch]);
+    }
+    for (const [name, url] of Object.entries(opts.remotes ?? {})) {
+      runGit(path, ['remote', 'add', name, url]);
+    }
+  } catch (err) {
+    cleanedUp = true;
+    rmSync(path, { recursive: true, force: true });
+    throw err;
   }
 
   return {

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -87,7 +87,19 @@ function runGit(cwd: string, args: readonly string[]): GitResult {
 
 export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
   const initialBranch = opts.initialBranch ?? 'dev';
-  const path = mkdtempSync(join(tmpdir(), opts.tmpPrefix ?? DEFAULT_TMP_PREFIX));
+  const tmpPrefix = opts.tmpPrefix ?? DEFAULT_TMP_PREFIX;
+  // mkdtempSync joins the prefix with tmpdir() and creates the result. A
+  // prefix containing path separators (e.g. `'../foo-'`) would escape
+  // tmpdir entirely, and cleanup would later rmSync the external path —
+  // path.join collapses the `..` segments. Test code is the only caller,
+  // so this is guarding against typos (and only typos), but a 3-line
+  // check beats reasoning about path-traversal blast radius.
+  if (/[\\/]/.test(tmpPrefix)) {
+    throw new Error(
+      `tmpPrefix must be a single basename segment with no path separators; got: ${tmpPrefix}`,
+    );
+  }
+  const path = mkdtempSync(join(tmpdir(), tmpPrefix));
   let cleanedUp = false;
 
   // If any setup step throws (missing git, bad ref name, etc.) the caller

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -32,7 +32,15 @@ export interface TempRepoOptions {
   branches?: readonly string[];
   /** Remotes to register. Map of remote name → URL. URL can be any string git accepts. */
   remotes?: Readonly<Record<string, string>>;
+  /**
+   * `mkdtemp` prefix under `os.tmpdir()`. Defaults to `'handoff-temprepo-'`.
+   * Override when a test needs to scan `tmpdir()` for its own dirs without
+   * picking up sibling tempRepo callers running in parallel.
+   */
+  tmpPrefix?: string;
 }
+
+export const DEFAULT_TMP_PREFIX = 'handoff-temprepo-';
 
 export interface GitResult {
   stdout: string;
@@ -79,7 +87,7 @@ function runGit(cwd: string, args: readonly string[]): GitResult {
 
 export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
   const initialBranch = opts.initialBranch ?? 'dev';
-  const path = mkdtempSync(join(tmpdir(), 'handoff-temprepo-'));
+  const path = mkdtempSync(join(tmpdir(), opts.tmpPrefix ?? DEFAULT_TMP_PREFIX));
   let cleanedUp = false;
 
   // If any setup step throws (missing git, bad ref name, etc.) the caller

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -21,7 +21,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -166,11 +166,29 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
 }
 
 function isWithinRepoNamespace(linkedPath: string, repoPath: string): boolean {
-  // git on Windows reports paths with forward slashes while `repoPath`
-  // came from `node:path.join` and uses backslashes; normalise so the
-  // startsWith check doesn't false-negative on a legitimate sibling.
+  // Two canonicalisation hazards force a realpath on both sides:
+  //   - macOS: `os.tmpdir()` returns `/var/folders/...` but git stores the
+  //     resolved `/private/var/folders/...` (the /var → /private/var
+  //     symlink), so a literal startsWith false-negatives on legitimate
+  //     siblings.
+  //   - Windows: GitHub's runner home is `C:\Users\RUNNER~1\...` (8.3
+  //     short name) under `os.tmpdir()`, while git reports the long-name
+  //     form. Same false-negative.
+  // Then normalise separators so Windows backslashes vs git's forward
+  // slashes don't sneak a false-negative past realpath.
   const norm = (p: string) => p.replace(/\\/g, '/');
-  return norm(linkedPath).startsWith(`${norm(repoPath)}-`);
+  let canonicalLinked: string;
+  let canonicalRepo: string;
+  try {
+    canonicalLinked = norm(realpathSync(linkedPath));
+    canonicalRepo = norm(realpathSync(repoPath));
+  } catch {
+    // If either path can't be resolved (already deleted, broken symlink),
+    // the conservative answer is "skip removal" — better to leak than to
+    // rm something we couldn't verify.
+    return false;
+  }
+  return canonicalLinked.startsWith(`${canonicalRepo}-`);
 }
 
 function listLinkedWorktrees(repoPath: string): readonly string[] {

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -134,21 +134,25 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
     },
     cleanup() {
       if (cleanedUp) return;
-      // git.ts's createWorktree puts linked worktrees as *siblings* of the
-      // repo root (see worktreePath in src/branch.ts), so rm'ing repo.path
-      // alone would leak any worktree the test added. Route removal through
-      // `git worktree remove --force` rather than raw rmSync of whatever
-      // path git happens to report — a test that called `repo.git(['worktree',
-      // 'add', '/some/important/dir', ...])` could otherwise turn this
-      // helper into a recursive deleter for unrelated directories. Letting
-      // git handle it constrains deletion to paths git itself registered
-      // (and unregisters them from the repo's worktree list as a bonus).
+      // git.ts's createWorktree puts linked worktrees at
+      // `<repo.path>-<branch-tail>` (see worktreePath in src/branch.ts),
+      // so rm'ing repo.path alone would leak any worktree the test added.
+      // Constrain removal to that namespace via a name predicate: a test
+      // that called `repo.git(['worktree', 'add', '/some/unrelated/dir',
+      // ...])` could otherwise turn this helper into a recursive deleter
+      // for an arbitrary path. Out-of-namespace registrations are left
+      // for the test to own.
+      //
+      // Earlier iterations routed this through `git worktree remove
+      // --force` for the same safety reason, but git's removal can fail
+      // (locked file, dir already gone) — which then orphaned the
+      // worktree the moment we proceeded to rm the main repo, with no
+      // way for a retry to discover it. Direct rmSync is more reliable
+      // (`force: true` no-ops on missing) and the predicate gives us the
+      // same path-safety guarantee.
       for (const linkedPath of listLinkedWorktrees(path)) {
-        try {
-          runGit(path, ['worktree', 'remove', '--force', linkedPath]);
-        } catch {
-          // Best-effort: worktree dir may already be gone, locked, or in
-          // some partially-broken state. Don't throw out of cleanup.
+        if (isWithinRepoNamespace(linkedPath, path)) {
+          rmSync(linkedPath, { recursive: true, force: true });
         }
       }
       rmSync(path, { recursive: true, force: true });
@@ -159,6 +163,14 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
       cleanedUp = true;
     },
   };
+}
+
+function isWithinRepoNamespace(linkedPath: string, repoPath: string): boolean {
+  // git on Windows reports paths with forward slashes while `repoPath`
+  // came from `node:path.join` and uses backslashes; normalise so the
+  // startsWith check doesn't false-negative on a legitimate sibling.
+  const norm = (p: string) => p.replace(/\\/g, '/');
+  return norm(linkedPath).startsWith(`${norm(repoPath)}-`);
 }
 
 function listLinkedWorktrees(repoPath: string): readonly string[] {

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -21,9 +21,9 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 export interface TempRepoOptions {
   /** Initial branch name. Defaults to `'dev'` to match this repo's convention. */
@@ -166,29 +166,22 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
 }
 
 function isWithinRepoNamespace(linkedPath: string, repoPath: string): boolean {
-  // Two canonicalisation hazards force a realpath on both sides:
-  //   - macOS: `os.tmpdir()` returns `/var/folders/...` but git stores the
-  //     resolved `/private/var/folders/...` (the /var → /private/var
-  //     symlink), so a literal startsWith false-negatives on legitimate
-  //     siblings.
-  //   - Windows: GitHub's runner home is `C:\Users\RUNNER~1\...` (8.3
-  //     short name) under `os.tmpdir()`, while git reports the long-name
-  //     form. Same false-negative.
-  // Then normalise separators so Windows backslashes vs git's forward
-  // slashes don't sneak a false-negative past realpath.
-  const norm = (p: string) => p.replace(/\\/g, '/');
-  let canonicalLinked: string;
-  let canonicalRepo: string;
-  try {
-    canonicalLinked = norm(realpathSync(linkedPath));
-    canonicalRepo = norm(realpathSync(repoPath));
-  } catch {
-    // If either path can't be resolved (already deleted, broken symlink),
-    // the conservative answer is "skip removal" — better to leak than to
-    // rm something we couldn't verify.
-    return false;
-  }
-  return canonicalLinked.startsWith(`${canonicalRepo}-`);
+  // Compare basenames rather than full paths. The directory parts are a
+  // platform-canonicalisation minefield (macOS /var ↔ /private/var; Windows
+  // RUNNER~1 ↔ runneradmin short/long names; backslashes vs git's forward
+  // slashes), and realpath resolution differs across runtimes — Bun on
+  // Windows CI didn't resolve the short name even when called explicitly,
+  // which broke the previous full-path predicate.
+  //
+  // Basenames sidestep all of that. createWorktree puts worktrees at
+  // `<repoRoot>-<branch-tail>` (see worktreePath in src/branch.ts), so the
+  // legitimate sibling's basename starts with `<repo-basename>-`. The
+  // repo's basename is `<prefix><6-random-chars>` (`mkdtempSync`), so the
+  // collision risk against an unrelated path that happens to share that
+  // exact basename is vanishingly small — and any path that *does* match
+  // that basename pattern was almost certainly created by createWorktree
+  // off this fixture, so removing it is the right answer anyway.
+  return basename(linkedPath).startsWith(`${basename(repoPath)}-`);
 }
 
 function listLinkedWorktrees(repoPath: string): readonly string[] {

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -203,22 +203,24 @@ function isWithinRepoNamespace(linkedPath: string, repoPath: string): boolean {
   // Bun on Windows CI didn't resolve the short name even when called
   // explicitly, which broke the previous full-path predicate.
   //
-  // The basename predicate trades off: it covers the realistic threat
-  // (a typo or accidentally absolute path the test never meant to
-  // register — those will have an unrelated basename and be left alone)
-  // but it does *not* cover a test that deliberately registers a
-  // worktree at `<some-other-dir>/<repo-basename>-<anything>`. Such a
-  // path shares the random-suffix basename and would be removed by
-  // cleanup. We accept that gap because (a) constructing such a path
-  // requires the test to read `repo.path`, splice its basename into a
-  // foreign directory, and pass the result to `repo.git(['worktree',
-  // 'add', ...])` — i.e. it's deliberate, not accidental — and (b) any
-  // path that does match the pattern is almost certainly mimicking the
-  // createWorktree contract, where removing it is the right answer.
+  // The basename predicate trades off:
+  //   - Covers the realistic threat — a typo or accidentally absolute
+  //     path the test never meant to register will have an unrelated
+  //     basename and be left alone.
+  //   - Does *not* cover a test that deliberately constructs a path of
+  //     the form `<some-other-dir>/<repo-basename>-<anything>` and
+  //     registers it with `repo.git(['worktree', 'add', ...])`. The
+  //     basename matches, so cleanup *will* rm it even though the
+  //     directory part is outside the temp repo's parent.
   //
-  // If a future test legitimately needs to register a worktree outside
-  // the namespace, the test owns the cleanup of that path itself; this
-  // helper only sweeps what looks like its own.
+  // We accept that second gap because (a) constructing such a path
+  // requires the test to read `repo.path` and splice its random-suffix
+  // basename into a foreign directory — that's deliberate, not
+  // accidental, and (b) any path that does match the pattern is
+  // mimicking the createWorktree contract closely enough that removing
+  // it is the right answer for the common case. A future test that
+  // legitimately needs an out-of-namespace worktree should manage that
+  // path's lifecycle itself.
   return basename(linkedPath).startsWith(`${basename(repoPath)}-`);
 }
 

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -23,7 +23,7 @@
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 
 export interface TempRepoOptions {
   /** Initial branch name. Defaults to `'dev'` to match this repo's convention. */
@@ -88,18 +88,24 @@ function runGit(cwd: string, args: readonly string[]): GitResult {
 export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
   const initialBranch = opts.initialBranch ?? 'dev';
   const tmpPrefix = opts.tmpPrefix ?? DEFAULT_TMP_PREFIX;
-  // mkdtempSync joins the prefix with tmpdir() and creates the result. A
-  // prefix containing path separators (e.g. `'../foo-'`) would escape
-  // tmpdir entirely, and cleanup would later rmSync the external path —
-  // path.join collapses the `..` segments. Test code is the only caller,
-  // so this is guarding against typos (and only typos), but a 3-line
-  // check beats reasoning about path-traversal blast radius.
-  if (/[\\/]/.test(tmpPrefix)) {
+  // mkdtempSync joins the prefix with tmpdir() and creates a dir at
+  // `<joined><6-random-chars>`. The escape modes are:
+  //   - separators: `'a/b-'` lands in `tmpdir/a`, not tmpdir
+  //   - `'.'`: collapses to tmpdir itself, so mkdtemp creates
+  //     `<tmpdir>XXXXXX` — a *sibling* of tmpdir, not a child
+  //   - `'..'`: escapes to tmpdir's parent
+  // and cleanup would later rmSync that out-of-namespace path.
+  //
+  // A separator-only check missed the `.`/`..` cases. Use the same
+  // invariant for all of them: `dirname(joined)` must equal tmpdir,
+  // i.e. mkdtemp's output lands directly under it.
+  const candidate = join(tmpdir(), tmpPrefix);
+  if (resolve(dirname(candidate)) !== resolve(tmpdir())) {
     throw new Error(
-      `tmpPrefix must be a single basename segment with no path separators; got: ${tmpPrefix}`,
+      `tmpPrefix would create a fixture outside os.tmpdir(): ${tmpPrefix} → ${candidate}`,
     );
   }
-  const path = mkdtempSync(join(tmpdir(), tmpPrefix));
+  const path = mkdtempSync(candidate);
   let cleanedUp = false;
 
   // If any setup step throws (missing git, bad ref name, etc.) the caller

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -49,8 +49,11 @@ export interface TempRepo {
 }
 
 function runGit(cwd: string, args: readonly string[]): GitResult {
-  // Pin a couple of envs so the repo behaves the same across developer
-  // machines: don't pick up the user's commit-signing config, don't prompt.
+  // Pin a couple of envs so git can't block the test: GIT_TERMINAL_PROMPT=0
+  // turns off credential/auth prompts (so a misconfigured remote can't hang),
+  // and GIT_OPTIONAL_LOCKS=0 skips advisory locks that occasionally trip on
+  // shared CI runners. Signing is disabled separately via `git config
+  // commit.gpgsign false` after init.
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     GIT_TERMINAL_PROMPT: '0',

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -100,6 +100,11 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
     runGit(path, ['init', '--quiet']);
     runGit(path, ['symbolic-ref', 'HEAD', `refs/heads/${initialBranch}`]);
 
+    // Point hooksPath at a directory we never create so a developer's global
+    // `core.hooksPath` (or template-installed hooks) can't fire on the
+    // bootstrap commit, hang the test, or leak side effects into the fixture.
+    runGit(path, ['config', 'core.hooksPath', join(path, '.git', 'handoff-no-hooks')]);
+
     // Local config so `git commit` works on machines without global identity
     // and never tries to sign — signing prompts would hang the test.
     runGit(path, ['config', 'user.email', 'handoff-test@example.invalid']);

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -67,6 +67,20 @@ function runGit(cwd: string, args: readonly string[]): GitResult {
     GIT_TERMINAL_PROMPT: '0',
     GIT_OPTIONAL_LOCKS: '0',
   };
+  // Scrub repo-selection env vars so a developer who has e.g. `GIT_DIR`
+  // exported in their shell doesn't have this fixture silently start
+  // operating on (and potentially deleting branches/worktrees in) their
+  // real repo. cwd plus an empty repo-selection environment leaves git no
+  // ambiguity about which repo it's working with.
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  delete env.GIT_ALTERNATE_OBJECT_DIRECTORIES;
+  delete env.GIT_CEILING_DIRECTORIES;
+  delete env.GIT_DISCOVERY_ACROSS_FILESYSTEM;
+  delete env.GIT_NAMESPACE;
   const result = spawnSync('git', args as string[], {
     cwd,
     env,

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -23,7 +23,7 @@
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, dirname, join, resolve } from 'node:path';
+import { basename, join } from 'node:path';
 
 export interface TempRepoOptions {
   /** Initial branch name. Defaults to `'dev'` to match this repo's convention. */
@@ -103,23 +103,21 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
   const initialBranch = opts.initialBranch ?? 'dev';
   const tmpPrefix = opts.tmpPrefix ?? DEFAULT_TMP_PREFIX;
   // mkdtempSync joins the prefix with tmpdir() and creates a dir at
-  // `<joined><6-random-chars>`. The escape modes are:
-  //   - separators: `'a/b-'` lands in `tmpdir/a`, not tmpdir
-  //   - `'.'`: collapses to tmpdir itself, so mkdtemp creates
-  //     `<tmpdir>XXXXXX` — a *sibling* of tmpdir, not a child
-  //   - `'..'`: escapes to tmpdir's parent
-  // and cleanup would later rmSync that out-of-namespace path.
-  //
-  // A separator-only check missed the `.`/`..` cases. Use the same
-  // invariant for all of them: `dirname(joined)` must equal tmpdir,
-  // i.e. mkdtemp's output lands directly under it.
-  const candidate = join(tmpdir(), tmpPrefix);
-  if (resolve(dirname(candidate)) !== resolve(tmpdir())) {
+  // `<joined><6-random-chars>`. We've now hit three distinct escape
+  // modes — separators (`'a/b-'`), trailing separators (`'nested/'`,
+  // which collapses past dirname-equals-tmpdir checks), and dot
+  // segments (`'.'` resolves to tmpdir itself, `'..'` to its parent).
+  // Each fix-by-pattern attempt missed at least one. Replace with a
+  // strict allowlist: alphanumerics, underscore, hyphen. Test fixtures
+  // don't need anything richer, and any character class outside this
+  // set is either a separator, a dot segment, or trivially weird —
+  // safer to reject all of them than to keep enumerating escape modes.
+  if (!/^[A-Za-z0-9_-]+$/.test(tmpPrefix)) {
     throw new Error(
-      `tmpPrefix would create a fixture outside os.tmpdir(): ${tmpPrefix} → ${candidate}`,
+      `tmpPrefix must match /^[A-Za-z0-9_-]+$/ to stay safely inside os.tmpdir(); got: ${JSON.stringify(tmpPrefix)}`,
     );
   }
-  const path = mkdtempSync(candidate);
+  const path = mkdtempSync(join(tmpdir(), tmpPrefix));
   let cleanedUp = false;
 
   // If any setup step throws (missing git, bad ref name, etc.) the caller

--- a/tests/helpers/tempRepo.ts
+++ b/tests/helpers/tempRepo.ts
@@ -178,21 +178,29 @@ export function createTempRepo(opts: TempRepoOptions = {}): TempRepo {
 }
 
 function isWithinRepoNamespace(linkedPath: string, repoPath: string): boolean {
-  // Compare basenames rather than full paths. The directory parts are a
-  // platform-canonicalisation minefield (macOS /var ↔ /private/var; Windows
-  // RUNNER~1 ↔ runneradmin short/long names; backslashes vs git's forward
-  // slashes), and realpath resolution differs across runtimes — Bun on
-  // Windows CI didn't resolve the short name even when called explicitly,
-  // which broke the previous full-path predicate.
+  // Compare basenames, not full paths. The directory parts are a
+  // platform-canonicalisation minefield (macOS /var ↔ /private/var;
+  // Windows RUNNER~1 ↔ runneradmin short/long names; backslashes vs git's
+  // forward slashes), and realpath resolution differs across runtimes —
+  // Bun on Windows CI didn't resolve the short name even when called
+  // explicitly, which broke the previous full-path predicate.
   //
-  // Basenames sidestep all of that. createWorktree puts worktrees at
-  // `<repoRoot>-<branch-tail>` (see worktreePath in src/branch.ts), so the
-  // legitimate sibling's basename starts with `<repo-basename>-`. The
-  // repo's basename is `<prefix><6-random-chars>` (`mkdtempSync`), so the
-  // collision risk against an unrelated path that happens to share that
-  // exact basename is vanishingly small — and any path that *does* match
-  // that basename pattern was almost certainly created by createWorktree
-  // off this fixture, so removing it is the right answer anyway.
+  // The basename predicate trades off: it covers the realistic threat
+  // (a typo or accidentally absolute path the test never meant to
+  // register — those will have an unrelated basename and be left alone)
+  // but it does *not* cover a test that deliberately registers a
+  // worktree at `<some-other-dir>/<repo-basename>-<anything>`. Such a
+  // path shares the random-suffix basename and would be removed by
+  // cleanup. We accept that gap because (a) constructing such a path
+  // requires the test to read `repo.path`, splice its basename into a
+  // foreign directory, and pass the result to `repo.git(['worktree',
+  // 'add', ...])` — i.e. it's deliberate, not accidental — and (b) any
+  // path that does match the pattern is almost certainly mimicking the
+  // createWorktree contract, where removing it is the right answer.
+  //
+  // If a future test legitimately needs to register a worktree outside
+  // the namespace, the test owns the cleanup of that path itself; this
+  // helper only sweeps what looks like its own.
   return basename(linkedPath).startsWith(`${basename(repoPath)}-`);
 }
 

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+
+import { run } from '../src/run.ts';
+
+describe('run() default spawn (production path)', () => {
+  it('shells out via the real node:child_process.spawn wrapper', async () => {
+    // All the scriptedSpawn tests install a fake spawn in beforeEach, which
+    // bypasses `spawnImpl = pipedNodeSpawn`. That's the wiring every CLI
+    // caller actually uses, so a regression in the default — the wrapper
+    // around node:child_process.spawn that narrows the nullable streams —
+    // would ship unnoticed.
+    //
+    // `git --version` is the most portable real subprocess we have: git is
+    // required by tempRepo (so it's already present everywhere this suite
+    // runs), the output format is stable, and the call has no side effects
+    // on the working tree.
+    const result = await run('git', ['--version']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/^git version /);
+    expect(result.stderr).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #13.

## Summary

- Adds the test infra v0.2.0 needs to unit-test the I/O modules: a spawn-injection seam in `run.ts`, a `scriptedSpawn` fixture for argv-keyed fakes, and a real-git `tempRepo` fixture.
- Refactors `cleanup.ts` to take its I/O deps via an optional `opts.deps` struct so `cleanup.test.ts` no longer needs `mock.module('../src/git.ts')`. Bun's `mock.module` is process-global with no test-scoped restore, and the old approach was poisoning `git.ts`/`github.ts` for every test file that imported the real modules — i.e. it would have blocked #14 the moment it landed.
- Documents which fixture to pick when (and why `mock.module(src/*.ts)` is off-limits) in `tests/README.md`.

Sample tests for both fixtures live alongside them in `tests/helpers/` so the per-module test issues (#14, #15, #16) can copy-paste the wiring.

## Test plan

- [x] `bun test` — 112 pass / 0 fail
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] Smoke-tested on Windows 11 (the tempRepo fixture uses `git symbolic-ref` instead of `git init -b` for portability to git ≥ 2.20, and disables gpg signing locally so the initial empty commit doesn't prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)