### PR TITLE
test(cli): integration tests for happy-path handoff (#15)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -335,8 +335,23 @@ function emitFireAndForget(...args: Parameters<typeof emit>): void {
   void emit(...args).catch(() => {});
 }
 
+/**
+ * Run the CLI with the given argv and return the exit code. Exported so
+ * integration tests can drive the full pipeline in-process — see
+ * `tests/cli.integration.test.ts` and `tests/README.md`. Production callers
+ * should rely on the entry-point gate below.
+ */
+export async function cliMain(argv: readonly string[]): Promise<number> {
+  return main(argv);
+}
+
 // Use process.exitCode (not process.exit) so any in-flight `emit` fetches get
 // a chance to drain — they're already bounded by AbortController(EMIT_TIMEOUT_MS),
 // so the worst-case extra wall time is one timeout window. process.exit would
 // abort them immediately, which silently lost telemetry for users who'd opted in.
-process.exitCode = await main(process.argv.slice(2));
+//
+// Gate on `import.meta.main` so importing this file from a test doesn't
+// auto-execute against the test's argv.
+if (import.meta.main) {
+  process.exitCode = await main(process.argv.slice(2));
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -37,16 +37,18 @@ const pipedNodeSpawn: SpawnFn = (command, args, options) => {
 let spawnImpl: SpawnFn = pipedNodeSpawn;
 
 /**
- * @internal Test-only injection seam. Replaces the spawn used by `run()` and
- * returns a restore function that puts back whatever impl was active before
- * this call — *not* unconditionally `nodeSpawn`. That lets nested fixtures
+ * @internal Test-only injection seam. The factory receives the previous
+ * spawn impl active at install time so a fixture can fall through to it
+ * (the hybrid harness `tests/helpers/scriptedSpawn.ts` uses this for its
+ * `passthrough` option). Returns a restore function that puts back that
+ * previous impl — *not* unconditionally `nodeSpawn`, so nested fixtures
  * (or sibling tests in the same process) stack installs without clobbering
  * each other when uninstalled in LIFO order. Production code must not call
  * this — see `tests/README.md`.
  */
-export function __setSpawnForTesting(impl: SpawnFn): () => void {
+export function __setSpawnForTesting(factory: (previous: SpawnFn) => SpawnFn): () => void {
   const previous = spawnImpl;
-  spawnImpl = impl;
+  spawnImpl = factory(previous);
   let restored = false;
   return () => {
     if (restored) return;

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -14,6 +14,31 @@ export type TerminalSpawnFn = (
   options: SpawnOptions,
 ) => ChildProcess;
 
+let terminalSpawnImpl: TerminalSpawnFn = nodeSpawn;
+
+/**
+ * @internal Test-only injection seam. Mirrors `__setSpawnForTesting` in
+ * `run.ts`: replaces the spawn used by `openTerminal` and returns a restore
+ * function that puts back whatever impl was active before this call. The
+ * CLI integration harness uses this to fake the terminal launch in-process
+ * without needing to thread a `spawn?` arg through `cli.ts`. Per-call
+ * injection via `OpenTerminalInput.spawn` still wins when set, so the
+ * existing per-platform unit tests in `tests/terminal.test.ts` are
+ * unaffected.
+ */
+export function __setTerminalSpawnForTesting(
+  factory: (previous: TerminalSpawnFn) => TerminalSpawnFn,
+): () => void {
+  const previous = terminalSpawnImpl;
+  terminalSpawnImpl = factory(previous);
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    terminalSpawnImpl = previous;
+  };
+}
+
 export interface OpenTerminalInput {
   /** Directory the new terminal should start in. */
   cwd: string;
@@ -137,7 +162,10 @@ export async function openTerminalOn(
     throw new TerminalError(`Unsupported platform: ${plat}`);
   }
 
-  const spawnImpl: TerminalSpawnFn = input.spawn ?? nodeSpawn;
+  // Per-call `input.spawn` wins (existing per-platform unit tests rely on
+  // this); the module-level test seam is for integration tests that drive
+  // `openTerminal` indirectly through the CLI.
+  const spawnImpl: TerminalSpawnFn = input.spawn ?? terminalSpawnImpl;
   const candidates: string[] =
     plat === 'win32'
       ? ['wt', 'cmd']

--- a/tests/README.md
+++ b/tests/README.md
@@ -117,15 +117,32 @@ uses, and `tempRepo` needs the real one to drive `git`. If a single
 module's test needs both, that's a sign the module is doing two different
 I/O things — split it before reaching for a hybrid harness.
 
-CLI-level integration tests (#15) are the documented exception: `cli.ts`
-fans out to both `fetchIssue` (gh) and `createWorktree` (git) in the same
-flow, so a happy-path test inherently needs fake-`gh` + real-`git`. The
-infra in this PR doesn't ship a hybrid harness yet; #15 will add one. The
-plan is a `passthrough?: (command, args) => boolean` option on
-`scriptedSpawn` so calls that match the predicate fall through to the
-real `spawn`. That keeps the "fake gh, real git" wiring expressible in
-one test without leaking back into per-module tests, which should keep
-using the strict matcher.
+### Hybrid harness for CLI integration tests
+
+CLI-level integration tests are the documented exception: `cli.ts` fans
+out to `fetchIssue` (gh), `createWorktree` (git), and `openTerminal`
+(internal spawn) in the same flow, so a happy-path test inherently needs
+fake-`gh` + real-`git` + fake-terminal. `tests/cli.integration.test.ts`
+wires this together using three opt-ins:
+
+1. **`createScriptedSpawn({ passthrough })`** — predicate that decides
+   which calls fall through to the _previous_ spawn impl active at
+   `install()` time (typically the production `pipedNodeSpawn`). The CLI
+   integration test passes `(cmd) => cmd === 'git'` so git operates on
+   the tempRepo while gh stays faked. Pass-through calls are still
+   recorded but don't count toward the unmatched-call teardown check.
+2. **`__setTerminalSpawnForTesting`** in `src/terminal.ts` — the
+   module-level seam paralleling `__setSpawnForTesting` in `run.ts`.
+   `openTerminal` reads it instead of `node:child_process.spawn`, so the
+   integration test can capture launches without the CLI threading a
+   `spawn?` arg through.
+3. **`HOME` / `USERPROFILE` redirection** — `showFirstRunBanner` and the
+   telemetry config read `os.homedir()`, so the test points it at a
+   mkdtemp dir to keep the developer's real `~/.handoff/` untouched.
+
+Per-module tests should keep using the strict matcher — `passthrough` is
+for integration tests where multiple I/O surfaces fan out from a single
+entry point.
 
 ## Concurrency assumption
 

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -16,19 +16,40 @@ interface TerminalCall {
   options: SpawnOptions;
 }
 
-let repo: TempRepo;
-let originalCwd: string;
-let homeDir: string;
+// Every cleanup-relevant handle is nullable so a partial `beforeEach`
+// failure (e.g. `mkdtemp` permission error before `createTempRepo` runs)
+// still leaves `afterEach` with a coherent picture of what to undo.
+let repo: TempRepo | undefined;
+let originalCwd: string | undefined;
+let homeDir: string | undefined;
 let savedHome: string | undefined;
 let savedUserProfile: string | undefined;
-let spawn: ScriptedSpawn;
+let envSaved = false;
+let spawn: ScriptedSpawn | undefined;
 let terminalCalls: TerminalCall[];
-let restoreTerminal: () => void;
+let restoreTerminal: (() => void) | undefined;
 
 const REPO_VIEW_ARGV = ['repo', 'view', '--json', 'defaultBranchRef'];
 const ISSUE_VIEW_FIELDS = 'number,title,body,labels,url';
 
 beforeEach(() => {
+  // Reset everything up front so a partial `beforeEach` failure leaves
+  // `afterEach` with the same baseline a fresh test would see (the watch
+  // runner reuses module state across reruns).
+  repo = undefined;
+  originalCwd = undefined;
+  homeDir = undefined;
+  savedHome = undefined;
+  savedUserProfile = undefined;
+  envSaved = false;
+  spawn = undefined;
+  terminalCalls = [];
+  restoreTerminal = undefined;
+
+  // Capture cwd first so even an early `createTempRepo` throw still has
+  // a value to chdir back to in afterEach.
+  originalCwd = process.cwd();
+
   // Real git, real worktree — but anchored under tempRepo's SUITE_ROOT so
   // teardown is hermetic. The CLI's `gh repo view --json defaultBranchRef`
   // is faked, so the bogus origin URL never gets dialed; remotes still
@@ -37,15 +58,17 @@ beforeEach(() => {
   repo = createTempRepo({
     remotes: { origin: 'https://example.invalid/test/repo.git' },
   });
-  originalCwd = process.cwd();
 
   // Redirect HOME / USERPROFILE so showFirstRunBanner and the telemetry
   // emit don't read or write the developer's real ~/.handoff/. Without
   // this, the suite would (a) create or mutate the user's config, and (b)
-  // pick up state from prior runs, making test order matter.
+  // pick up state from prior runs, making test order matter. Save *both*
+  // env vars before flipping either, then mark `envSaved` so afterEach
+  // knows whether the saved values are meaningful.
   homeDir = mkdtempSync(join(tmpdir(), 'handoff-cli-int-home-'));
   savedHome = process.env.HOME;
   savedUserProfile = process.env.USERPROFILE;
+  envSaved = true;
   process.env.HOME = homeDir;
   process.env.USERPROFILE = homeDir;
 
@@ -58,7 +81,6 @@ beforeEach(() => {
   // Capture terminal launches in-process. The CLI calls `openTerminal`
   // which would otherwise spawn a real wt/cmd/gnome-terminal/Terminal.app
   // window — disastrous in a test runner.
-  terminalCalls = [];
   restoreTerminal = __setTerminalSpawnForTesting(() => (command, args, options) => {
     terminalCalls.push({ command, args: [...args], options });
     const child = new EventEmitter() as EventEmitter & { unref: () => void };
@@ -70,27 +92,65 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Restore cwd *before* teardown so the temp dirs aren't pinned by the
-  // process — Windows rmSync fails on a directory the process is in.
-  process.chdir(originalCwd);
-  restoreTerminal();
-  spawn.uninstall();
+  // Run every teardown step independently and capture errors. Without
+  // this, a throwing `spawn.uninstall()` (unmatched calls / leftover
+  // expectations) would leak env vars and temp dirs into the next test
+  // — devastating under `bun test --watch`. Re-throw the first captured
+  // error at the end so the failure still surfaces.
+  const errors: unknown[] = [];
+  const safe = (label: string, fn: () => void) => {
+    try {
+      fn();
+    } catch (e) {
+      errors.push(new Error(`afterEach: ${label} failed: ${(e as Error).message ?? e}`));
+    }
+  };
 
-  if (savedHome === undefined) delete process.env.HOME;
-  else process.env.HOME = savedHome;
-  if (savedUserProfile === undefined) delete process.env.USERPROFILE;
-  else process.env.USERPROFILE = savedUserProfile;
+  // cwd restore first — Windows rmSync fails on a directory the process
+  // is sitting inside, so this needs to land before any temp-dir cleanup.
+  if (originalCwd !== undefined) safe('chdir(originalCwd)', () => process.chdir(originalCwd!));
 
-  rmSync(homeDir, { recursive: true, force: true });
-  repo.cleanup();
+  if (restoreTerminal) safe('restoreTerminal()', () => restoreTerminal!());
+  if (spawn) safe('spawn.uninstall()', () => spawn!.uninstall());
+
+  // Env restoration runs unconditionally when the save was completed —
+  // these are simple property writes that can't really fail, but being
+  // strict about ordering (don't restore if we didn't save) keeps the
+  // partial-setup case correct.
+  if (envSaved) {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
+  }
+
+  if (homeDir) safe('rmSync(homeDir)', () => rmSync(homeDir!, { recursive: true, force: true }));
+  if (repo) safe('repo.cleanup()', () => repo!.cleanup());
+
+  if (errors.length > 0) throw errors[0];
 });
 
+/**
+ * Unwrap the nullable fixture handles after `beforeEach`. If either is
+ * still undefined, the setup didn't complete — fail the test fast rather
+ * than letting a `repo!` blow up halfway through with a less-readable
+ * error.
+ */
+function fixtures(): { repo: TempRepo; spawn: ScriptedSpawn } {
+  if (!repo || !spawn) {
+    throw new Error('cli.integration: beforeEach did not complete; fixtures are unset');
+  }
+  return { repo, spawn };
+}
+
 function expectedWorktreePath(branchTail: string): string {
+  const { repo } = fixtures();
   return join(dirname(repo.path), `${basename(repo.path)}-${branchTail}`);
 }
 
 describe('cli integration — happy path', () => {
   it('handoff claude #7: creates worktree + branch, writes PROMPT.md, launches terminal', async () => {
+    const { repo, spawn } = fixtures();
     spawn.expectGh(REPO_VIEW_ARGV, { defaultBranchRef: { name: 'dev' } });
     spawn.expectGh(['issue', 'view', '7', '--json', ISSUE_VIEW_FIELDS], {
       number: 7,
@@ -148,6 +208,7 @@ describe('cli integration — happy path', () => {
 
 describe('cli integration — fleet mode', () => {
   it('handoff claude #7 #8: creates two worktrees and two terminal launches', async () => {
+    const { spawn } = fixtures();
     // defaultBranch is fetched once per invocation, then per-issue fetches
     // happen in order. Each gh expectation consumes FIFO — register all
     // three before running.
@@ -186,6 +247,7 @@ describe('cli integration — fleet mode', () => {
 
 describe('cli integration — cleanup', () => {
   it('handoff cleanup <branch> removes the worktree and branch when the PR is merged', async () => {
+    const { repo, spawn } = fixtures();
     // Pre-create the worktree as if a previous handoff had run. We can't
     // ride the same flow as the happy-path test because cliMain returns
     // before the worktree is "released" (the runner script normally calls

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+
+import { cliMain } from '../src/cli.ts';
+import { __setTerminalSpawnForTesting } from '../src/terminal.ts';
+import { createScriptedSpawn, type ScriptedSpawn } from './helpers/scriptedSpawn.ts';
+import { createTempRepo, type TempRepo } from './helpers/tempRepo.ts';
+
+interface TerminalCall {
+  command: string;
+  args: readonly string[];
+  options: SpawnOptions;
+}
+
+let repo: TempRepo;
+let originalCwd: string;
+let homeDir: string;
+let savedHome: string | undefined;
+let savedUserProfile: string | undefined;
+let spawn: ScriptedSpawn;
+let terminalCalls: TerminalCall[];
+let restoreTerminal: () => void;
+
+const REPO_VIEW_ARGV = ['repo', 'view', '--json', 'defaultBranchRef'];
+const ISSUE_VIEW_FIELDS = 'number,title,body,labels,url';
+
+beforeEach(() => {
+  // Real git, real worktree — but anchored under tempRepo's SUITE_ROOT so
+  // teardown is hermetic. The CLI's `gh repo view --json defaultBranchRef`
+  // is faked, so the bogus origin URL never gets dialed; remotes still
+  // need to be set so the repo *looks* configured (some git versions warn
+  // otherwise on `worktree add`).
+  repo = createTempRepo({
+    remotes: { origin: 'https://example.invalid/test/repo.git' },
+  });
+  originalCwd = process.cwd();
+
+  // Redirect HOME / USERPROFILE so showFirstRunBanner and the telemetry
+  // emit don't read or write the developer's real ~/.handoff/. Without
+  // this, the suite would (a) create or mutate the user's config, and (b)
+  // pick up state from prior runs, making test order matter.
+  homeDir = mkdtempSync(join(tmpdir(), 'handoff-cli-int-home-'));
+  savedHome = process.env.HOME;
+  savedUserProfile = process.env.USERPROFILE;
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+
+  // Hybrid harness: gh is faked, git is passed through to the real spawn
+  // so it operates on the tempRepo. The recorded `calls` include both,
+  // which keeps assertions grounded in what actually happened.
+  spawn = createScriptedSpawn({ passthrough: (cmd) => cmd === 'git' });
+  spawn.install();
+
+  // Capture terminal launches in-process. The CLI calls `openTerminal`
+  // which would otherwise spawn a real wt/cmd/gnome-terminal/Terminal.app
+  // window — disastrous in a test runner.
+  terminalCalls = [];
+  restoreTerminal = __setTerminalSpawnForTesting(() => (command, args, options) => {
+    terminalCalls.push({ command, args: [...args], options });
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = () => {};
+    return child as unknown as ChildProcess;
+  });
+
+  process.chdir(repo.path);
+});
+
+afterEach(() => {
+  // Restore cwd *before* teardown so the temp dirs aren't pinned by the
+  // process — Windows rmSync fails on a directory the process is in.
+  process.chdir(originalCwd);
+  restoreTerminal();
+  spawn.uninstall();
+
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
+  if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = savedUserProfile;
+
+  rmSync(homeDir, { recursive: true, force: true });
+  repo.cleanup();
+});
+
+function expectedWorktreePath(branchTail: string): string {
+  return join(dirname(repo.path), `${basename(repo.path)}-${branchTail}`);
+}
+
+describe('cli integration — happy path', () => {
+  it('handoff claude #7: creates worktree + branch, writes PROMPT.md, launches terminal', async () => {
+    spawn.expectGh(REPO_VIEW_ARGV, { defaultBranchRef: { name: 'dev' } });
+    spawn.expectGh(['issue', 'view', '7', '--json', ISSUE_VIEW_FIELDS], {
+      number: 7,
+      title: 'Loop mode',
+      body: 'Issue body content.',
+      url: 'https://example.test/issues/7',
+      labels: [{ name: 'feature' }],
+    });
+
+    const exitCode = await cliMain(['claude', '#7']);
+    expect(exitCode).toBe(0);
+
+    const wt = expectedWorktreePath('issue-7');
+    expect(existsSync(wt)).toBe(true);
+
+    // Branch exists in the main repo and points at the same commit as dev
+    // (worktree add -b creates it off the base ref). show-ref --quiet
+    // exits non-zero when the ref is missing — runGit throws on that, so
+    // a missing branch would error here rather than producing a misleading
+    // "ok" result.
+    repo.git(['show-ref', '--verify', '--quiet', 'refs/heads/claude/issue-7']);
+
+    // PROMPT.md interpolations: branch, issue header, body, label.
+    const prompt = readFileSync(join(wt, 'PROMPT.md'), 'utf8');
+    expect(prompt).toContain('**Branch:** `claude/issue-7`');
+    expect(prompt).toContain('**Parent branch:** `dev`');
+    expect(prompt).toContain('## Issue #7: Loop mode');
+    expect(prompt).toContain('Issue body content.');
+    expect(prompt).toContain('`feature`');
+
+    // .handoff/state.json was written so cleanup can later report the
+    // tool/ref it was launched with.
+    expect(existsSync(join(wt, '.handoff', 'state.json'))).toBe(true);
+    const state = JSON.parse(readFileSync(join(wt, '.handoff', 'state.json'), 'utf8'));
+    expect(state.tool).toBe('claude');
+    expect(state.branch).toBe('claude/issue-7');
+    expect(state.ref).toEqual({ type: 'issue', number: 7 });
+
+    // Exactly one terminal launch. The argv shape is OS-dependent (wt on
+    // win32, gnome-terminal/etc. on linux, osascript on darwin), but in
+    // every case the runner script + tool + branch are part of it — so
+    // pin those rather than the platform-specific launcher.
+    expect(terminalCalls).toHaveLength(1);
+    const launchArgv = terminalCalls[0]?.args.join(' ') ?? '';
+    expect(launchArgv).toMatch(/handoff-runner\.(sh|ps1)/);
+    expect(launchArgv).toContain('claude');
+    expect(launchArgv).toContain('claude/issue-7');
+    // The cwd appears in the launch argv (e.g. `wt -d <cwd>`,
+    // `gnome-terminal --working-directory <cwd>`, AppleScript `cd <cwd>`),
+    // not in spawn options. Pin that the worktree path is in there
+    // somewhere.
+    expect(launchArgv).toContain(wt);
+  });
+});
+
+describe('cli integration — fleet mode', () => {
+  it('handoff claude #7 #8: creates two worktrees and two terminal launches', async () => {
+    // defaultBranch is fetched once per invocation, then per-issue fetches
+    // happen in order. Each gh expectation consumes FIFO — register all
+    // three before running.
+    spawn.expectGh(REPO_VIEW_ARGV, { defaultBranchRef: { name: 'dev' } });
+    spawn.expectGh(['issue', 'view', '7', '--json', ISSUE_VIEW_FIELDS], {
+      number: 7,
+      title: 'A',
+      body: 'a',
+      url: 'https://example.test/7',
+      labels: [],
+    });
+    spawn.expectGh(['issue', 'view', '8', '--json', ISSUE_VIEW_FIELDS], {
+      number: 8,
+      title: 'B',
+      body: 'b',
+      url: 'https://example.test/8',
+      labels: [],
+    });
+
+    const exitCode = await cliMain(['claude', '#7', '#8']);
+    expect(exitCode).toBe(0);
+
+    const wt7 = expectedWorktreePath('issue-7');
+    const wt8 = expectedWorktreePath('issue-8');
+    expect(existsSync(wt7)).toBe(true);
+    expect(existsSync(wt8)).toBe(true);
+
+    // One terminal launch per ref — fleet mode is "parallel but
+    // independent" (CLAUDE.md), not a single multiplexed session.
+    expect(terminalCalls).toHaveLength(2);
+    const allArgs = terminalCalls.map((c) => c.args.join(' ')).join('\n');
+    expect(allArgs).toContain('claude/issue-7');
+    expect(allArgs).toContain('claude/issue-8');
+  });
+});
+
+describe('cli integration — cleanup', () => {
+  it('handoff cleanup <branch> removes the worktree and branch when the PR is merged', async () => {
+    // Pre-create the worktree as if a previous handoff had run. We can't
+    // ride the same flow as the happy-path test because cliMain returns
+    // before the worktree is "released" (the runner script normally calls
+    // cleanup after the user-driven tool exits).
+    const branch = 'claude/issue-9';
+    const wt = expectedWorktreePath('issue-9');
+    repo.git(['worktree', 'add', '-b', branch, wt, 'dev']);
+    expect(existsSync(wt)).toBe(true);
+
+    spawn.expectGh(
+      ['pr', 'list', '--head', branch, '--state', 'merged', '--json', 'number', '--limit', '1'],
+      [{ number: 9 }],
+    );
+
+    const exitCode = await cliMain(['cleanup', branch]);
+    expect(exitCode).toBe(0);
+
+    expect(existsSync(wt)).toBe(false);
+    // Branch is gone — show-ref --verify exits non-zero, runGit throws.
+    expect(() => repo.git(['show-ref', '--verify', `refs/heads/${branch}`])).toThrow();
+  });
+});

--- a/tests/helpers/scriptedSpawn.ts
+++ b/tests/helpers/scriptedSpawn.ts
@@ -38,6 +38,21 @@ import { PassThrough } from 'node:stream';
 
 import { __setSpawnForTesting, type PipedChildProcess } from '../../src/run.ts';
 
+export interface ScriptedSpawnOptions {
+  /**
+   * Predicate that decides which calls are not the fixture's responsibility
+   * and should fall through to the *previous* spawn impl that was active at
+   * `install()` time (typically the production `pipedNodeSpawn`). Used for
+   * the CLI integration harness in `tests/cli.integration.test.ts`, where
+   * `gh` is faked but `git` runs against a real `tempRepo`.
+   *
+   * Pass-through calls are still recorded in `calls` so the test can assert
+   * what was spawned, but they are *not* tracked as unmatched calls — the
+   * fixture isn't claiming ownership of them.
+   */
+  passthrough?: (command: string, args: readonly string[]) => boolean;
+}
+
 export interface ScriptedResponse {
   stdout?: string;
   stderr?: string;
@@ -193,10 +208,11 @@ function unmatchedChild(command: string, args: readonly string[]): PipedChildPro
   return Object.assign(child, { stdout, stderr }) as unknown as PipedChildProcess;
 }
 
-export function createScriptedSpawn(): ScriptedSpawn {
+export function createScriptedSpawn(opts: ScriptedSpawnOptions = {}): ScriptedSpawn {
   const expectations: ScriptedExpectation[] = [];
   const calls: ScriptedCall[] = [];
   const unmatchedCalls: ScriptedCall[] = [];
+  const passthrough = opts.passthrough;
   let restore: (() => void) | null = null;
 
   const fixture: ScriptedSpawn = {
@@ -210,13 +226,21 @@ export function createScriptedSpawn(): ScriptedSpawn {
       expectations.length = 0;
       calls.length = 0;
       unmatchedCalls.length = 0;
-      restore = __setSpawnForTesting((command, args, options) => {
+      restore = __setSpawnForTesting((previous) => (command, args, options) => {
         const call: ScriptedCall = {
           command,
           args: [...args],
           cwd: options.cwd as string | undefined,
         };
         calls.push(call);
+        if (passthrough?.(command, args)) {
+          // Hybrid harness: this call isn't ours to fake (e.g. CLI
+          // integration test fakes `gh` but lets `git` hit tempRepo). The
+          // call is still recorded so the test can assert what ran, but
+          // it doesn't count toward the unmatched-call teardown check
+          // because the fixture isn't claiming ownership.
+          return previous(command, args, options);
+        }
         const match = consumeExpectation(expectations, command, args);
         if (match) {
           return fakeChild(match.response);

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -120,7 +120,7 @@ describe('run() — spawn options', () => {
 
   beforeEach(() => {
     recorded = [];
-    restore = __setSpawnForTesting((_command, _args, options) => {
+    restore = __setSpawnForTesting(() => (_command, _args, options) => {
       recorded.push(options);
       const child = new EventEmitter();
       const stdout = new PassThrough();
@@ -183,8 +183,8 @@ describe('run() — output handling', () => {
     stdoutChunks: string[];
     stderrChunks: string[];
     exitCode: number;
-  }) {
-    return ((_command: string, _args: readonly string[], _options: SpawnOptions) => {
+  }): Parameters<typeof __setSpawnForTesting>[0] {
+    return () => (_command: string, _args: readonly string[], _options: SpawnOptions) => {
       const child = new EventEmitter();
       const stdout = new PassThrough();
       const stderr = new PassThrough();
@@ -196,7 +196,7 @@ describe('run() — output handling', () => {
         child.emit('close', opts.exitCode, null);
       });
       return Object.assign(child, { stdout, stderr }) as unknown as PipedChildProcess;
-    }) satisfies Parameters<typeof __setSpawnForTesting>[0];
+    };
   }
 
   afterEach(() => {


### PR DESCRIPTION
Closes #15.

## Summary

Three end-to-end CLI integration tests, one per scenario the issue called for. Built on a hybrid harness layered onto the existing fixtures from #46:

- **\`refactor(cli)\`** (\`22ad7a5\`): exports \`cliMain\` and gates the top-level auto-run on \`import.meta.main\` so a test can drive the CLI in-process. Production behaviour unchanged.
- **\`test(infra)\` — passthrough** (\`d5df2e8\`): \`__setSpawnForTesting\` becomes a factory \`(previous) => SpawnFn\`, and \`createScriptedSpawn({ passthrough })\` lets the CLI test fake \`gh\` while \`git\` operates on a real \`tempRepo\`. Pass-through calls are recorded but don't count toward the strict unmatched-call teardown check, so per-module tests are unaffected.
- **\`test(infra)\` — terminal seam** (\`bb7dce8\`): module-level \`__setTerminalSpawnForTesting\` parallels \`run.ts\`'s seam. Per-call \`input.spawn\` still wins; the module global is consulted only when the CLI calls \`openTerminal\` indirectly.
- **\`test(cli)\` — integration tests** (\`a8bf8a1\`): three tests in \`tests/cli.integration.test.ts\` — happy path (\`handoff claude #7\`), fleet mode (\`#7 #8\` → two worktrees), cleanup (\`handoff cleanup\` against a merged-PR fake). HOME/USERPROFILE redirected per-test so showFirstRunBanner can't touch the developer's real \`~/.handoff/\`.

## Test plan

- [x] \`bun run test\` — 172 pass / 0 fail (was 169 on \`dev\`)
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run format:check\` clean
- [x] Integration test runtime: ~2.6s, well under the 5s acceptance criterion
- [x] Smoke-tested on Windows 11 — terminal launch argv assertions are platform-agnostic (match the runner script + tool + branch + worktree path that every \`buildLaunchSpec\` produces, not the per-platform launcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)