### PR TITLE
feat(ux): error UX pass — HandoffError, exit codes, --verbose/--debug (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ handoff cleanup claude/issue-42
 
 This re-checks the PR state and removes the worktree + branch if merged.
 
+## Exit codes
+
+| Code | Meaning                                                                  |
+| ---- | ------------------------------------------------------------------------ |
+| `0`  | success                                                                  |
+| `1`  | user error — bad args, unknown tool, unauthenticated `gh`                |
+| `2`  | operational failure — worktree already exists, `git`/`gh` command failed |
+| `3`  | internal / unexpected error                                              |
+
 ## Architecture
 
 ```

--- a/src/args.ts
+++ b/src/args.ts
@@ -35,9 +35,11 @@ export type TelemetryArgs =
 
 export type CliInvocation = ParsedArgs | CleanupArgs | TelemetryArgs;
 
-export class ArgsError extends Error {
+import { HandoffError } from './errors.ts';
+
+export class ArgsError extends HandoffError {
   constructor(message: string) {
-    super(message);
+    super(message, 1);
     this.name = 'ArgsError';
   }
 }

--- a/src/args.ts
+++ b/src/args.ts
@@ -79,10 +79,71 @@ function isGlobalFlag(tok: string): boolean {
   return tok === '--verbose' || tok === '--debug';
 }
 
+/**
+ * Walk argv with the same scanning-mode logic as parseInvocation and return
+ * which global flags were seen **before** free-form mode started. This is the
+ * authoritative detection path — rawArgv.includes() would fire even for a
+ * literal `--verbose` inside a free-form task description.
+ *
+ * Mirrors the scanning loop in parseInvocation: leading flags, then
+ * `--loop`/`--verbose`/`--debug`/issue-refs in any order, stopping at the
+ * first token that triggers free-form mode.
+ */
+export function extractGlobalFlags(argv: readonly string[]): { verbose: boolean; debug: boolean } {
+  let verbose = false;
+  let debug = false;
+  let i = 0;
+
+  // Consume leading global flags before the tool/command name.
+  while (i < argv.length && isGlobalFlag(argv[i]!)) {
+    if (argv[i] === '--verbose') verbose = true;
+    else debug = true;
+    i++;
+  }
+
+  // Skip the tool/command name token.
+  if (i >= argv.length) return { verbose, debug };
+  i++;
+
+  // Scan the refs region — stop at the first free-form token.
+  while (i < argv.length) {
+    const tok = argv[i]!;
+    if (tok === '--verbose') {
+      verbose = true;
+      i++;
+      continue;
+    }
+    if (tok === '--debug') {
+      debug = true;
+      i++;
+      continue;
+    }
+    if (tok === '--loop') {
+      i++;
+      continue;
+    }
+    // Issue ref: #N
+    if (/^#\d+$/.test(tok)) {
+      i++;
+      continue;
+    }
+    // Issue ref: "Issue #N" (two tokens)
+    if (/^issue$/i.test(tok)) {
+      const next = argv[i + 1];
+      if (next !== undefined && /^#?\d+$/.test(next)) {
+        i += 2;
+        continue;
+      }
+    }
+    // Anything else is the start of free-form mode — stop.
+    break;
+  }
+
+  return { verbose, debug };
+}
+
 export function parseInvocation(argv: readonly string[]): CliInvocation {
-  // Skip any leading --verbose/--debug before the tool/command name so
-  // `handoff --verbose claude …` works. main() detects these flags via
-  // rawArgv.includes() before this call — we just need to not choke on them.
+  // Skip any leading --verbose/--debug before the tool/command name.
   let start = 0;
   while (start < argv.length && isGlobalFlag(argv[start]!)) {
     start += 1;

--- a/src/args.ts
+++ b/src/args.ts
@@ -79,6 +79,10 @@ function isGlobalFlag(tok: string): boolean {
   return tok === '--verbose' || tok === '--debug';
 }
 
+function stripGlobalFlags(tokens: readonly string[]): string[] {
+  return tokens.filter((t) => !isGlobalFlag(t));
+}
+
 /**
  * Walk argv with the same scanning-mode logic as parseInvocation and return
  * which global flags were seen **before** free-form mode started. This is the
@@ -162,7 +166,11 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
   }
 
   if (head === 'cleanup') {
-    const branch = trimmed[1];
+    // No free-form mode under `cleanup` — global flags can appear anywhere
+    // between the subcommand and the branch arg, e.g.
+    // `handoff cleanup --verbose <branch>`.
+    const rest = stripGlobalFlags(trimmed.slice(1));
+    const branch = rest[0];
     if (branch === undefined || branch.trim() === '') {
       throw new ArgsError('Usage: handoff cleanup <branch>');
     }
@@ -170,7 +178,9 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
   }
 
   if (head === 'telemetry') {
-    return parseTelemetry(trimmed.slice(1));
+    // Same reasoning as cleanup: telemetry has no free-form mode, so global
+    // flags can be filtered out anywhere in the subcommand args.
+    return parseTelemetry(stripGlobalFlags(trimmed.slice(1)));
   }
 
   if (!isTool(head)) {
@@ -202,8 +212,8 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
       i += 1;
       continue;
     }
-    // Global flags consumed silently in scanning mode; main() reads them from
-    // rawArgv.includes() before this function is called.
+    // Global flags consumed silently in scanning mode; main() reads them via
+    // extractGlobalFlags() before this function is called.
     if (isGlobalFlag(tok!)) {
       i += 1;
       continue;

--- a/src/args.ts
+++ b/src/args.ts
@@ -75,20 +75,33 @@ function parseIssueToken(
   return null;
 }
 
+function isGlobalFlag(tok: string): boolean {
+  return tok === '--verbose' || tok === '--debug';
+}
+
 export function parseInvocation(argv: readonly string[]): CliInvocation {
-  if (argv.length === 0) {
+  // Skip any leading --verbose/--debug before the tool/command name so
+  // `handoff --verbose claude …` works. main() detects these flags via
+  // rawArgv.includes() before this call — we just need to not choke on them.
+  let start = 0;
+  while (start < argv.length && isGlobalFlag(argv[start]!)) {
+    start += 1;
+  }
+  const trimmed = start === 0 ? argv : argv.slice(start);
+
+  if (trimmed.length === 0) {
     throw new ArgsError(
       'No arguments provided. Usage: handoff <tool> <ref...> | handoff cleanup <branch>',
     );
   }
 
-  const head = argv[0];
+  const head = trimmed[0];
   if (head === undefined) {
     throw new ArgsError('Empty arguments.');
   }
 
   if (head === 'cleanup') {
-    const branch = argv[1];
+    const branch = trimmed[1];
     if (branch === undefined || branch.trim() === '') {
       throw new ArgsError('Usage: handoff cleanup <branch>');
     }
@@ -96,7 +109,7 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
   }
 
   if (head === 'telemetry') {
-    return parseTelemetry(argv.slice(1));
+    return parseTelemetry(trimmed.slice(1));
   }
 
   if (!isTool(head)) {
@@ -105,7 +118,7 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     );
   }
 
-  const rest = argv.slice(1);
+  const rest = trimmed.slice(1);
   if (rest.length === 0) {
     throw new ArgsError(
       `Missing reference. Usage: handoff ${head} <ref...> ` +
@@ -113,11 +126,11 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     );
   }
 
-  // Walk tokens once. While we're still in "flag-or-ref" mode, `--loop` is the
-  // flag and may appear anywhere among the issue refs (before, between, after).
+  // Walk tokens once. While we're still in "flag-or-ref" mode, `--loop`,
+  // `--verbose`, and `--debug` may appear anywhere among the issue refs.
   // The first token that is neither a flag nor an issue-ref pattern flips us
   // into free-form mode, and from there everything (including a literal
-  // `--loop`) becomes part of the description.
+  // `--loop` or `--verbose`) becomes part of the description verbatim.
   let loop = false;
   const refs: Ref[] = [];
   let i = 0;
@@ -125,6 +138,12 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     const tok = rest[i];
     if (tok === '--loop') {
       loop = true;
+      i += 1;
+      continue;
+    }
+    // Global flags consumed silently in scanning mode; main() reads them from
+    // rawArgv.includes() before this function is called.
+    if (isGlobalFlag(tok!)) {
       i += 1;
       continue;
     }

--- a/src/args.ts
+++ b/src/args.ts
@@ -92,6 +92,10 @@ function stripGlobalFlags(tokens: readonly string[]): string[] {
  * Mirrors the scanning loop in parseInvocation: leading flags, then
  * `--loop`/`--verbose`/`--debug`/issue-refs in any order, stopping at the
  * first token that triggers free-form mode.
+ *
+ * For `cleanup` and `telemetry` heads there is no free-form mode, so global
+ * flags can appear anywhere in the remaining argv — scan to the end. (This
+ * mirrors `parseInvocation`'s wholesale-strip behavior on those branches.)
  */
 export function extractGlobalFlags(argv: readonly string[]): { verbose: boolean; debug: boolean } {
   let verbose = false;
@@ -107,9 +111,21 @@ export function extractGlobalFlags(argv: readonly string[]): { verbose: boolean;
 
   // Skip the tool/command name token.
   if (i >= argv.length) return { verbose, debug };
+  const head = argv[i];
   i++;
 
-  // Scan the refs region — stop at the first free-form token.
+  // No free-form mode under cleanup / telemetry — scan the whole tail.
+  if (head === 'cleanup' || head === 'telemetry') {
+    while (i < argv.length) {
+      const tok = argv[i]!;
+      if (tok === '--verbose') verbose = true;
+      else if (tok === '--debug') debug = true;
+      i++;
+    }
+    return { verbose, debug };
+  }
+
+  // Tool invocations: scan the refs region — stop at the first free-form token.
   while (i < argv.length) {
     const tok = argv[i]!;
     if (tok === '--verbose') {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -134,7 +134,10 @@ async function runCleanup(branch: string): Promise<number> {
     }),
   );
 
-  return result.status === 'unknown' ? 1 : 0;
+  // 'unknown' from cleanup.ts means an operational step (gh pr-merged check,
+  // worktree remove, branch delete) failed — that's exit code 2 per the
+  // documented categories, not 1 (which is reserved for user errors).
+  return result.status === 'unknown' ? 2 : 0;
 }
 
 function cleanupOutcome(result: CleanupResult): CleanupOutcome {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,23 +36,26 @@ import {
 } from './telemetry.ts';
 
 async function main(rawArgv: readonly string[]): Promise<number> {
-  // Strip global flags before routing so parseInvocation never sees them.
-  const argv = rawArgv.filter((a) => a !== '--verbose' && a !== '--debug');
+  // Detect global flags before routing. Do NOT filter rawArgv before passing
+  // to parseInvocation — that would mangle free-form descriptions that
+  // happen to contain a literal `--verbose` or `--debug` token. Instead,
+  // parseInvocation's scanning loop consumes them when they appear in flag
+  // position (same as --loop), preserving free-form text verbatim.
   setVerbose(rawArgv.includes('--verbose'));
   setDebug(rawArgv.includes('--debug'));
 
-  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
+  if (rawArgv.length === 0 || rawArgv[0] === '--help' || rawArgv[0] === '-h') {
     console.log(HELP);
     return 0;
   }
-  if (argv[0] === '--version' || argv[0] === '-v') {
+  if (rawArgv[0] === '--version' || rawArgv[0] === '-v') {
     console.log(VERSION);
     return 0;
   }
 
   let invocation;
   try {
-    invocation = parseInvocation(argv);
+    invocation = parseInvocation(rawArgv);
   } catch (err) {
     if (err instanceof ArgsError) {
       console.error(`error: ${err.message}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -442,5 +442,5 @@ export async function cliMain(argv: readonly string[]): Promise<number> {
 // Gate on `import.meta.main` so importing this file from a test doesn't
 // auto-execute against the test's argv.
 if (import.meta.main) {
-  process.exitCode = await main(process.argv.slice(2));
+  process.exitCode = await cliMain(process.argv.slice(2));
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,14 @@ import { dirname, join, resolve } from 'node:path';
 import { platform } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-import { ArgsError, parseInvocation, type Ref, type Tool, type TelemetryArgs } from './args.ts';
+import {
+  ArgsError,
+  extractGlobalFlags,
+  parseInvocation,
+  type Ref,
+  type Tool,
+  type TelemetryArgs,
+} from './args.ts';
 import { HandoffError } from './errors.ts';
 import { setDebug, setVerbose, verbose } from './logger.ts';
 import { branchName, worktreePath } from './branch.ts';
@@ -36,19 +43,31 @@ import {
 } from './telemetry.ts';
 
 async function main(rawArgv: readonly string[]): Promise<number> {
-  // Detect global flags before routing. Do NOT filter rawArgv before passing
-  // to parseInvocation — that would mangle free-form descriptions that
-  // happen to contain a literal `--verbose` or `--debug` token. Instead,
-  // parseInvocation's scanning loop consumes them when they appear in flag
-  // position (same as --loop), preserving free-form text verbatim.
-  setVerbose(rawArgv.includes('--verbose'));
-  setDebug(rawArgv.includes('--debug'));
+  // Use extractGlobalFlags rather than rawArgv.includes() so that a literal
+  // `--verbose`/`--debug` token inside a free-form description (e.g.
+  // `handoff claude fix the --verbose flag`) doesn't accidentally enable
+  // verbose mode. extractGlobalFlags walks the same scanning-mode boundary
+  // as parseInvocation and only counts flags seen before free-form starts.
+  const { verbose, debug } = extractGlobalFlags(rawArgv);
+  setVerbose(verbose);
+  setDebug(debug);
 
-  if (rawArgv.length === 0 || rawArgv[0] === '--help' || rawArgv[0] === '-h') {
+  // Find the first non-global-flag token so that `--verbose --help` (and
+  // similar) routes correctly instead of falling through to parseInvocation.
+  let firstIdx = 0;
+  while (
+    firstIdx < rawArgv.length &&
+    (rawArgv[firstIdx] === '--verbose' || rawArgv[firstIdx] === '--debug')
+  ) {
+    firstIdx++;
+  }
+  const firstToken = rawArgv[firstIdx];
+
+  if (firstToken === undefined || firstToken === '--help' || firstToken === '-h') {
     console.log(HELP);
     return 0;
   }
-  if (rawArgv[0] === '--version' || rawArgv[0] === '-v') {
+  if (firstToken === '--version' || firstToken === '-v') {
     console.log(VERSION);
     return 0;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,11 +5,14 @@ import { platform } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { ArgsError, parseInvocation, type Ref, type Tool, type TelemetryArgs } from './args.ts';
+import { HandoffError } from './errors.ts';
+import { setDebug, setVerbose, verbose } from './logger.ts';
 import { branchName, worktreePath } from './branch.ts';
 import { cleanup, type CleanupResult } from './cleanup.ts';
 import { createWorktree, mainRepoRoot, repoName } from './git.ts';
 import { defaultBranch, fetchIssue, type IssueDetails } from './github.ts';
 import { renderPrompt } from './prompt.ts';
+import { RunError } from './run.ts';
 import { slugify } from './slug.ts';
 import { openTerminal } from './terminal.ts';
 import { HELP, VERSION } from './config.ts';
@@ -32,7 +35,12 @@ import {
   type CleanupOutcome,
 } from './telemetry.ts';
 
-async function main(argv: readonly string[]): Promise<number> {
+async function main(rawArgv: readonly string[]): Promise<number> {
+  // Strip global flags before routing so parseInvocation never sees them.
+  const argv = rawArgv.filter((a) => a !== '--verbose' && a !== '--debug');
+  setVerbose(rawArgv.includes('--verbose'));
+  setDebug(rawArgv.includes('--debug'));
+
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
     console.log(HELP);
     return 0;
@@ -49,7 +57,7 @@ async function main(argv: readonly string[]): Promise<number> {
     if (err instanceof ArgsError) {
       console.error(`error: ${err.message}\n`);
       console.error(HELP);
-      return 64;
+      return 1;
     }
     throw err;
   }
@@ -89,8 +97,10 @@ async function runCleanup(branch: string): Promise<number> {
     }
   }
 
+  verbose(`cleanup: branch = ${branch}, worktree = ${path}`);
   const t0 = Date.now();
   const result = await cleanup(branch, { repoRoot });
+  verbose(`cleanup: result = ${result.status}`);
   console.log(result.message);
 
   const durationMs = Number.isFinite(startedAt) ? Date.now() - startedAt : Date.now() - t0;
@@ -222,6 +232,9 @@ async function runHandoffs(tool: Tool, refs: Ref[], loop: boolean) {
       failures += 1;
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[handoff] FAILED for ${describeRef(ref)}: ${msg}`);
+      if (err instanceof HandoffError && err.hint) {
+        console.error(`           hint: ${err.hint}`);
+      }
       emitFireAndForget(
         eventError({ code: errorCode(err), module: 'cli.spawnHandoff', exitCode: 1 }),
       );
@@ -252,18 +265,21 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
   let issue: IssueDetails | undefined;
   let branch: string;
   if (input.ref.kind === 'issue') {
+    verbose(`fetching issue #${input.ref.number}`);
     issue = await fetchIssue(input.ref.number);
     branch = branchName({ tool: input.tool, issueNumber: issue.number });
   } else {
     const slug = slugify(input.ref.text, { maxLen: 20 });
     branch = branchName({ tool: input.tool, slug });
   }
+  verbose(`branch: ${branch}`);
 
   const path = worktreePath({ repoRoot: input.repoRoot, branch });
 
   console.log(`[handoff] ${input.tool} → ${branch}`);
   console.log(`           worktree: ${path}`);
 
+  verbose(`creating worktree at ${path}`);
   await createWorktree({ branch, path, base: input.parentBranch });
 
   const promptCtx = {
@@ -290,6 +306,7 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
     updatedAt: now,
   });
 
+  verbose(`launching terminal for ${branch}`);
   await openTerminal({
     cwd: path,
     scriptPath: input.runnerScript,
@@ -317,9 +334,10 @@ function resolveRunnerScript(handoffRoot: string): string {
   const isWin = platform() === 'win32';
   const script = join(handoffRoot, 'scripts', isWin ? 'handoff-runner.ps1' : 'handoff-runner.sh');
   if (!existsSync(script)) {
-    throw new Error(
-      `handoff: runner script not found at ${script}. ` +
-        `The handoff CLI must be run from a checkout of the handoff repo (or an install that ships scripts/handoff-runner.{sh,ps1}).`,
+    throw new HandoffError(
+      `runner script not found at ${script}`,
+      2,
+      `Run handoff from its repo checkout, or re-run the installer (scripts/install.py).`,
     );
   }
   return script;
@@ -359,7 +377,22 @@ function emitFireAndForget(...args: Parameters<typeof emit>): void {
  * should rely on the entry-point gate below.
  */
 export async function cliMain(argv: readonly string[]): Promise<number> {
-  return main(argv);
+  try {
+    return await main(argv);
+  } catch (err) {
+    if (err instanceof HandoffError) {
+      console.error(`error: ${err.message}`);
+      if (err.hint) console.error(`hint:  ${err.hint}`);
+      return err.exitCode;
+    }
+    if (err instanceof RunError) {
+      console.error(`error: ${err.message}`);
+      return 2;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`error: unexpected error: ${msg}`);
+    return 3;
+  }
 }
 
 // Use process.exitCode (not process.exit) so any in-flight `emit` fetches get

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,9 +48,11 @@ async function main(rawArgv: readonly string[]): Promise<number> {
   // `handoff claude fix the --verbose flag`) doesn't accidentally enable
   // verbose mode. extractGlobalFlags walks the same scanning-mode boundary
   // as parseInvocation and only counts flags seen before free-form starts.
-  const { verbose, debug } = extractGlobalFlags(rawArgv);
-  setVerbose(verbose);
-  setDebug(debug);
+  // Aliased as *Flag so the booleans don't shadow the imported `verbose()`
+  // logger when this scope grows.
+  const { verbose: verboseFlag, debug: debugFlag } = extractGlobalFlags(rawArgv);
+  setVerbose(verboseFlag);
+  setDebug(debugFlag);
 
   // Find the first non-global-flag token so that `--verbose --help` (and
   // similar) routes correctly instead of falling through to parseInvocation.
@@ -63,7 +65,11 @@ async function main(rawArgv: readonly string[]): Promise<number> {
   }
   const firstToken = rawArgv[firstIdx];
 
-  if (firstToken === undefined || firstToken === '--help' || firstToken === '-h') {
+  // Empty argv → show help (the friendly default). But `handoff --verbose`
+  // (only global flags) is a usage error: route those through
+  // parseInvocation so it raises ArgsError → exit 1, matching the
+  // documented exit-code categories.
+  if (rawArgv.length === 0 || firstToken === '--help' || firstToken === '-h') {
     console.log(HELP);
     return 0;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -236,6 +236,11 @@ async function runHandoffs(tool: Tool, refs: Ref[], loop: boolean) {
   const runnerScript = resolveRunnerScript(handoffRoot);
 
   let failures = 0;
+  // Track the most-severe (highest) exit code seen across per-ref failures so
+  // the documented exit-code categories (1=user, 2=operational, 3=internal)
+  // surface even when refs fail independently. cliMain only sees this single
+  // return value because the per-ref try/catch swallows the throw.
+  let worstExitCode = 0;
   for (const ref of refs) {
     try {
       await spawnHandoff({
@@ -252,14 +257,14 @@ async function runHandoffs(tool: Tool, refs: Ref[], loop: boolean) {
       console.log(`[handoff] OK ${describeRef(ref)}`);
     } catch (err) {
       failures += 1;
+      const exitCode = exitCodeFor(err);
+      if (exitCode > worstExitCode) worstExitCode = exitCode;
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[handoff] FAILED for ${describeRef(ref)}: ${msg}`);
       if (err instanceof HandoffError && err.hint) {
         console.error(`           hint: ${err.hint}`);
       }
-      emitFireAndForget(
-        eventError({ code: errorCode(err), module: 'cli.spawnHandoff', exitCode: 1 }),
-      );
+      emitFireAndForget(eventError({ code: errorCode(err), module: 'cli.spawnHandoff', exitCode }));
     }
   }
   if (refs.length > 1) {
@@ -268,7 +273,7 @@ async function runHandoffs(tool: Tool, refs: Ref[], loop: boolean) {
       `[handoff] ${ok}/${refs.length} succeeded${failures ? `, ${failures} failed` : ''}`,
     );
   }
-  return failures === 0 ? 0 : 1;
+  return failures === 0 ? 0 : worstExitCode;
 }
 
 interface SpawnInput {
@@ -381,6 +386,18 @@ function errorCode(err: unknown): string {
     return err.name;
   }
   return 'Error';
+}
+
+/**
+ * Map an error to the exit-code category cliMain would use if the error
+ * propagated out unchanged. Mirrors the cliMain catch ladder so per-ref
+ * failures inside runHandoffs can report the same code on stderr/telemetry
+ * that a single-ref run would.
+ */
+function exitCodeFor(err: unknown): number {
+  if (err instanceof HandoffError) return err.exitCode;
+  if (err instanceof RunError) return 2;
+  return 3;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,10 @@ FLAGS
   --loop         (claude only) keep the agent resident after \`gh pr create\`
                  to triage review feedback and CI, push fixes, and iterate
                  until the PR is merged (or a bail condition trips).
+  --verbose      print info-level traces to stderr (branch, worktree path,
+                 terminal launch)
+  --debug        print raw subprocess invocations and exit codes to stderr
+                 (implies --verbose)
 
 TELEMETRY
   Off by default. Nothing is sent until both telemetry is enabled and an
@@ -47,6 +51,12 @@ EXAMPLES
   handoff claude #1 #2 #3                    # fleet: 3 parallel worktrees
   handoff claude --loop #7                   # implement and self-drive review
   handoff claude "tidy up the README"
+
+EXIT CODES
+  0  success
+  1  user error (bad args, unknown tool, unauthenticated gh)
+  2  operational failure (worktree exists, git/gh command failed)
+  3  internal / unexpected error
 
 REQUIREMENTS
   bun, git, gh, and the chosen tool must all be on PATH.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,21 @@
+/** Process exit code semantics for handoff CLI errors. */
+export type ProcessExitCode = 1 | 2 | 3;
+
+/**
+ * Base class for all user-visible handoff errors. Carries a numeric exit
+ * code and an optional recovery hint that cli.ts prints after the message.
+ *
+ *  1 — user error (bad args, unknown tool, unauthenticated gh)
+ *  2 — operational failure (worktree exists, git/gh command failed)
+ *  3 — internal / unexpected error
+ */
+export class HandoffError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: ProcessExitCode,
+    readonly hint?: string,
+  ) {
+    super(message);
+    this.name = 'HandoffError';
+  }
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,9 +1,10 @@
 import { dirname, resolve } from 'node:path';
-import { run, type RunOpts } from './run.ts';
+import { HandoffError } from './errors.ts';
+import { run, RunError, type RunOpts } from './run.ts';
 
-export class GitError extends Error {
-  constructor(message: string) {
-    super(message);
+export class GitError extends HandoffError {
+  constructor(message: string, hint?: string) {
+    super(message, 2, hint);
     this.name = 'GitError';
   }
 }
@@ -34,7 +35,18 @@ export async function currentRepoRoot(): Promise<string> {
  * handoff is invoked from inside a previous handoff's worktree.
  */
 export async function mainRepoRoot(): Promise<string> {
-  const { stdout } = await run('git', ['rev-parse', '--git-common-dir']);
+  let stdout: string;
+  try {
+    ({ stdout } = await run('git', ['rev-parse', '--git-common-dir']));
+  } catch (err) {
+    if (err instanceof RunError) {
+      throw new GitError(
+        'not inside a git repository',
+        'Run handoff from inside a git repo (cd into one, or `git init`).',
+      );
+    }
+    throw err;
+  }
   const gitDir = stdout.trim();
   if (!gitDir) throw new GitError('git rev-parse --git-common-dir returned empty output');
   // Pre-2.31, git returns this relative to cwd; resolve in TS to stay

--- a/src/git.ts
+++ b/src/git.ts
@@ -39,7 +39,7 @@ export async function mainRepoRoot(): Promise<string> {
   try {
     ({ stdout } = await run('git', ['rev-parse', '--git-common-dir']));
   } catch (err) {
-    if (err instanceof RunError) {
+    if (err instanceof RunError && (err.exitCode === 128 || /not a git repo/i.test(err.stderr))) {
       throw new GitError(
         'not inside a git repository',
         'Run handoff from inside a git repo (cd into one, or `git init`).',

--- a/src/github.ts
+++ b/src/github.ts
@@ -2,8 +2,8 @@ import { HandoffError } from './errors.ts';
 import { RunError, run } from './run.ts';
 
 export class GhError extends HandoffError {
-  constructor(message: string) {
-    super(message, 2);
+  constructor(message: string, exitCode: 1 | 2 = 2) {
+    super(message, exitCode);
     this.name = 'GhError';
   }
 }
@@ -26,9 +26,11 @@ async function gh(args: readonly string[], opts: GhOpts = {}): Promise<string> {
     return stdout;
   } catch (err) {
     if (err instanceof RunError) {
-      const hint = /authentication/i.test(err.stderr) ? ' (run `gh auth login`)' : '';
+      const isAuthFailure = /authentication/i.test(err.stderr);
+      const hint = isAuthFailure ? ' (run `gh auth login`)' : '';
       throw new GhError(
         `gh ${args.join(' ')} failed${hint}: ${err.stderr.trim() || err.stdout.trim()}`,
+        isAuthFailure ? 1 : 2,
       );
     }
     throw err;

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,8 +1,9 @@
+import { HandoffError } from './errors.ts';
 import { RunError, run } from './run.ts';
 
-export class GhError extends Error {
+export class GhError extends HandoffError {
   constructor(message: string) {
-    super(message);
+    super(message, 2);
     this.name = 'GhError';
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,19 @@
+let _verbose = false;
+let _debug = false;
+
+export function setVerbose(on: boolean): void {
+  _verbose = on;
+}
+export function setDebug(on: boolean): void {
+  _debug = on;
+}
+
+/** Info-level trace — printed when --verbose or --debug is active. */
+export function verbose(msg: string): void {
+  if (_verbose || _debug) console.error(`[handoff:verbose] ${msg}`);
+}
+
+/** Debug-level trace — printed only when --debug is active. */
+export function debug(msg: string): void {
+  if (_debug) console.error(`[handoff:debug] ${msg}`);
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,6 +13,10 @@ export function verbose(msg: string): void {
   if (_verbose || _debug) console.error(`[handoff:verbose] ${msg}`);
 }
 
+export function isDebug(): boolean {
+  return _debug;
+}
+
 /** Debug-level trace — printed only when --debug is active. */
 export function debug(msg: string): void {
   if (_debug) console.error(`[handoff:debug] ${msg}`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,7 +1,7 @@
 import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
 import type { Readable } from 'node:stream';
 
-import { debug } from './logger.ts';
+import { debug, isDebug } from './logger.ts';
 
 export interface RunResult {
   stdout: string;
@@ -88,7 +88,7 @@ export function run(
   args: readonly string[],
   opts: RunOpts = {},
 ): Promise<RunResult> {
-  debug(`spawn: ${command} ${args.join(' ')}`);
+  if (isDebug()) debug(`spawn: ${command} ${args.join(' ')}`);
   return new Promise((resolve, reject) => {
     const child = spawnImpl(command, args, {
       cwd: opts.cwd,
@@ -108,7 +108,7 @@ export function run(
     child.on('error', reject);
     child.on('close', (code, signal) => {
       const exitCode = code ?? (signal ? 128 : 0);
-      debug(`exit ${exitCode}: ${command} ${args.join(' ')}`);
+      if (isDebug()) debug(`exit ${exitCode}: ${command} ${args.join(' ')}`);
       const result: RunResult = { stdout, stderr, exitCode };
       if (code !== 0) {
         reject(new RunError(command, args, result));

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,8 @@
 import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
 import type { Readable } from 'node:stream';
 
+import { debug } from './logger.ts';
+
 export interface RunResult {
   stdout: string;
   stderr: string;
@@ -86,6 +88,7 @@ export function run(
   args: readonly string[],
   opts: RunOpts = {},
 ): Promise<RunResult> {
+  debug(`spawn: ${command} ${args.join(' ')}`);
   return new Promise((resolve, reject) => {
     const child = spawnImpl(command, args, {
       cwd: opts.cwd,
@@ -105,6 +108,7 @@ export function run(
     child.on('error', reject);
     child.on('close', (code, signal) => {
       const exitCode = code ?? (signal ? 128 : 0);
+      debug(`exit ${exitCode}: ${command} ${args.join(' ')}`);
       const result: RunResult = { stdout, stderr, exitCode };
       if (code !== 0) {
         reject(new RunError(command, args, result));

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 import type { Tool } from './args.ts';
+import { HandoffError } from './errors.ts';
 
 export const HOME_DIRNAME = '.handoff';
 export const CONFIG_FILENAME = 'config.json';
@@ -22,9 +23,9 @@ export interface TelemetryConfig {
   firstRunBannerSeen: boolean;
 }
 
-export class TelemetryConfigError extends Error {
+export class TelemetryConfigError extends HandoffError {
   constructor(message: string) {
-    super(message);
+    super(message, 1);
     this.name = 'TelemetryConfigError';
   }
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,9 +1,10 @@
 import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
 import { platform } from 'node:os';
+import { HandoffError } from './errors.ts';
 
-export class TerminalError extends Error {
-  constructor(message: string) {
-    super(message);
+export class TerminalError extends HandoffError {
+  constructor(message: string, hint?: string) {
+    super(message, 2, hint);
     this.name = 'TerminalError';
   }
 }
@@ -183,7 +184,10 @@ export async function openTerminalOn(
       lastErr = err instanceof Error ? err : new Error(String(err));
     }
   }
-  throw new TerminalError(`Failed to open a terminal window. Last error: ${lastErr?.message}`);
+  throw new TerminalError(
+    `Failed to open a terminal window. Last error: ${lastErr?.message}`,
+    'Ensure a supported terminal emulator is installed and on PATH.',
+  );
 }
 
 function spawnDetached(spawnImpl: TerminalSpawnFn, spec: LaunchSpec): Promise<void> {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node
 import { join } from 'node:path';
 
 import type { Tool } from './args.ts';
+import { HandoffError } from './errors.ts';
 
 export const WORKSPACE_DIRNAME = '.handoff';
 export const STATE_FILENAME = 'state.json';
@@ -24,9 +25,9 @@ export interface WorkspaceState {
   updatedAt: string;
 }
 
-export class WorkspaceStateError extends Error {
+export class WorkspaceStateError extends HandoffError {
   constructor(message: string) {
-    super(message);
+    super(message, 2);
     this.name = 'WorkspaceStateError';
   }
 }

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -225,6 +225,39 @@ describe('parseInvocation', () => {
       const out = parseInvocation(['--verbose', 'claude', '--debug', '--loop', '#3']);
       expect(out).toEqual({ tool: 'claude', refs: [{ kind: 'issue', number: 3 }], loop: true });
     });
+
+    it('accepts --verbose between cleanup and the branch arg', () => {
+      // Regression: cleanup has no free-form mode, so a global flag wedged
+      // between `cleanup` and the branch must be filtered, not adopted as
+      // the branch name.
+      const out = parseInvocation(['cleanup', '--verbose', 'claude/issue-1']);
+      expect(out).toEqual({ command: 'cleanup', branch: 'claude/issue-1' });
+    });
+
+    it('accepts --debug after cleanup branch arg', () => {
+      const out = parseInvocation(['cleanup', 'claude/issue-1', '--debug']);
+      expect(out).toEqual({ command: 'cleanup', branch: 'claude/issue-1' });
+    });
+
+    it('accepts --verbose between telemetry and its subcommand', () => {
+      const out = parseInvocation(['telemetry', '--verbose', 'status']);
+      expect(out).toEqual({ command: 'telemetry', sub: 'status' });
+    });
+
+    it('accepts --debug interleaved with telemetry enable --endpoint', () => {
+      const out = parseInvocation([
+        'telemetry',
+        '--debug',
+        'enable',
+        '--endpoint',
+        'https://x.test/t',
+      ]);
+      expect(out).toEqual({
+        command: 'telemetry',
+        sub: 'enable',
+        endpoint: 'https://x.test/t',
+      });
+    });
   });
 });
 

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -296,4 +296,20 @@ describe('extractGlobalFlags', () => {
   it('returns false/false for empty argv', () => {
     expect(extractGlobalFlags([])).toEqual({ verbose: false, debug: false });
   });
+
+  it('detects --debug after the cleanup branch arg', () => {
+    // No free-form mode under cleanup, so flags placed after the branch
+    // must still toggle logging — otherwise parseInvocation accepts them
+    // (and the stripped invocation runs) but verbosity is silently off.
+    expect(extractGlobalFlags(['cleanup', 'claude/issue-1', '--debug'])).toEqual({
+      verbose: false,
+      debug: true,
+    });
+  });
+
+  it('detects --verbose interleaved through telemetry args', () => {
+    expect(
+      extractGlobalFlags(['telemetry', 'enable', '--verbose', '--endpoint', 'https://x.test/t']),
+    ).toEqual({ verbose: true, debug: false });
+  });
 });

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -198,4 +198,32 @@ describe('parseInvocation', () => {
       );
     });
   });
+
+  describe('global flags (--verbose / --debug)', () => {
+    it('accepts --verbose before the tool name', () => {
+      const out = parseInvocation(['--verbose', 'claude', '#1']);
+      expect(out).toEqual({ tool: 'claude', refs: [{ kind: 'issue', number: 1 }], loop: false });
+    });
+
+    it('accepts --debug after the tool name and before refs', () => {
+      const out = parseInvocation(['claude', '--debug', '#2']);
+      expect(out).toEqual({ tool: 'claude', refs: [{ kind: 'issue', number: 2 }], loop: false });
+    });
+
+    it('preserves --verbose in a free-form description verbatim', () => {
+      // The whole point of this fix: --verbose must NOT be stripped when it
+      // appears after the free-form boundary.
+      const out = parseInvocation(['claude', 'fix', 'the', '--verbose', 'flag']);
+      expect(out).toEqual({
+        tool: 'claude',
+        refs: [{ kind: 'freeform', text: 'fix the --verbose flag' }],
+        loop: false,
+      });
+    });
+
+    it('accepts multiple global flags mixed with --loop and refs', () => {
+      const out = parseInvocation(['--verbose', 'claude', '--debug', '--loop', '#3']);
+      expect(out).toEqual({ tool: 'claude', refs: [{ kind: 'issue', number: 3 }], loop: true });
+    });
+  });
 });

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { ArgsError, parseInvocation } from '../src/args.ts';
+import { ArgsError, extractGlobalFlags, parseInvocation } from '../src/args.ts';
 
 describe('parseInvocation', () => {
   it('parses a single #N reference', () => {
@@ -225,5 +225,42 @@ describe('parseInvocation', () => {
       const out = parseInvocation(['--verbose', 'claude', '--debug', '--loop', '#3']);
       expect(out).toEqual({ tool: 'claude', refs: [{ kind: 'issue', number: 3 }], loop: true });
     });
+  });
+});
+
+describe('extractGlobalFlags', () => {
+  it('detects --verbose before the tool name', () => {
+    expect(extractGlobalFlags(['--verbose', 'claude', '#1'])).toEqual({
+      verbose: true,
+      debug: false,
+    });
+  });
+
+  it('detects --debug between tool name and issue ref', () => {
+    expect(extractGlobalFlags(['claude', '--debug', '#1'])).toEqual({
+      verbose: false,
+      debug: true,
+    });
+  });
+
+  it('does NOT detect --verbose that appears inside a free-form description', () => {
+    // "fix the --verbose flag" → freeform starts at "fix"; --verbose is part
+    // of the description and must not enable verbose mode.
+    expect(extractGlobalFlags(['claude', 'fix', 'the', '--verbose', 'flag'])).toEqual({
+      verbose: false,
+      debug: false,
+    });
+  });
+
+  it('detects flags before freeform starts even when freeform contains them too', () => {
+    // --verbose before "fix" is a flag; --verbose after is freeform text.
+    expect(extractGlobalFlags(['claude', '--verbose', 'fix', 'the', '--verbose', 'flag'])).toEqual({
+      verbose: true,
+      debug: false,
+    });
+  });
+
+  it('returns false/false for empty argv', () => {
+    expect(extractGlobalFlags([])).toEqual({ verbose: false, debug: false });
   });
 });

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -299,6 +299,21 @@ describe('cli integration — global flag routing', () => {
     const exitCode = await cliMain(['--verbose', '--version']);
     expect(exitCode).toBe(0);
   });
+
+  it('flags-only invocation exits 1 (usage error), not 0 via help', async () => {
+    // Regression: `handoff --verbose` used to route to the help path with
+    // exit 0 because firstToken was undefined after stripping flags. Per
+    // the documented EXIT CODES, that's a user error and must be 1.
+    const exitCode = await cliMain(['--verbose']);
+    expect(exitCode).toBe(1);
+  });
+
+  it('empty argv still shows help with exit 0', async () => {
+    // Counterpart to the flags-only case: with no args at all, friendly
+    // help-as-default is the right call.
+    const exitCode = await cliMain([]);
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe('cli integration — cleanup', () => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -245,6 +245,45 @@ describe('cli integration — fleet mode', () => {
   });
 });
 
+describe('cli integration — error exit codes', () => {
+  it('propagates GhError exitCode 2 from a single-ref runHandoffs failure', async () => {
+    // Regression for the "runHandoffs hard-codes exit 1" Copilot review
+    // comment: a non-auth gh failure raises GhError(exitCode=2). Before the
+    // fix, the per-ref catch collapsed every failure to 1; now it reports
+    // the documented operational-error code.
+    const { spawn } = fixtures();
+    spawn.expectGh(REPO_VIEW_ARGV, { defaultBranchRef: { name: 'dev' } });
+    spawn.expect({
+      command: 'gh',
+      argv: ['issue', 'view', '7', '--json', ISSUE_VIEW_FIELDS],
+      response: { exitCode: 1, stderr: 'GraphQL: Could not resolve to an Issue (issue #7)' },
+    });
+
+    const exitCode = await cliMain(['claude', '#7']);
+    expect(exitCode).toBe(2);
+  });
+
+  it('reports the worst exit code across multi-ref failures', async () => {
+    // Two refs, both fail. First with auth error (exitCode 1), second with
+    // non-auth (exitCode 2). The worst (highest) wins.
+    const { spawn } = fixtures();
+    spawn.expectGh(REPO_VIEW_ARGV, { defaultBranchRef: { name: 'dev' } });
+    spawn.expect({
+      command: 'gh',
+      argv: ['issue', 'view', '7', '--json', ISSUE_VIEW_FIELDS],
+      response: { exitCode: 4, stderr: 'authentication required' },
+    });
+    spawn.expect({
+      command: 'gh',
+      argv: ['issue', 'view', '8', '--json', ISSUE_VIEW_FIELDS],
+      response: { exitCode: 1, stderr: 'unknown server error' },
+    });
+
+    const exitCode = await cliMain(['claude', '#7', '#8']);
+    expect(exitCode).toBe(2);
+  });
+});
+
 describe('cli integration — global flag routing', () => {
   it('--verbose --help prints help and exits 0', async () => {
     const exitCode = await cliMain(['--verbose', '--help']);

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -325,4 +325,35 @@ describe('cli integration — cleanup', () => {
     // Branch is gone — show-ref --verify exits non-zero, runGit throws.
     expect(() => repo.git(['show-ref', '--verify', `refs/heads/${branch}`])).toThrow();
   });
+
+  it('returns operational-error exit code 2 when cleanup status is unknown', async () => {
+    // Regression: runCleanup used to map status='unknown' (operational
+    // failure — gh/git step failed) to exit 1, conflicting with the
+    // documented exit-code categories. It should now be 2.
+    const { repo, spawn } = fixtures();
+    const branch = 'claude/issue-99';
+    const wt = expectedWorktreePath('issue-99');
+    repo.git(['worktree', 'add', '-b', branch, wt, 'dev']);
+
+    // Force `gh pr list` to fail — cleanup.ts maps that to status='unknown'.
+    spawn.expect({
+      command: 'gh',
+      argv: [
+        'pr',
+        'list',
+        '--head',
+        branch,
+        '--state',
+        'merged',
+        '--json',
+        'number',
+        '--limit',
+        '1',
+      ],
+      response: { exitCode: 1, stderr: 'API rate limit exceeded' },
+    });
+
+    const exitCode = await cliMain(['cleanup', branch]);
+    expect(exitCode).toBe(2);
+  });
 });

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -245,6 +245,23 @@ describe('cli integration — fleet mode', () => {
   });
 });
 
+describe('cli integration — global flag routing', () => {
+  it('--verbose --help prints help and exits 0', async () => {
+    const exitCode = await cliMain(['--verbose', '--help']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('--debug -h prints help and exits 0', async () => {
+    const exitCode = await cliMain(['--debug', '-h']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('--verbose --version prints version and exits 0', async () => {
+    const exitCode = await cliMain(['--verbose', '--version']);
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe('cli integration — cleanup', () => {
   it('handoff cleanup <branch> removes the worktree and branch when the PR is merged', async () => {
     const { repo, spawn } = fixtures();

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -11,6 +11,8 @@ import {
   removeWorktree,
   repoName,
 } from '../src/git.ts';
+import type { HandoffError } from '../src/errors.ts';
+import { createScriptedSpawn, type ScriptedSpawn } from './helpers/scriptedSpawn.ts';
 import { worktreePath } from '../src/branch.ts';
 import { createTempRepo, type TempRepo } from './helpers/tempRepo.ts';
 
@@ -58,6 +60,33 @@ describe('mainRepoRoot', () => {
 
     process.chdir(linked);
     expect(posix(await mainRepoRoot())).toBe(posix(repo.path));
+  });
+});
+
+describe('mainRepoRoot — outside a git repo', () => {
+  let spawn: ScriptedSpawn;
+  beforeEach(() => {
+    spawn = createScriptedSpawn();
+    spawn.install();
+  });
+  afterEach(() => spawn.uninstall());
+
+  it('throws GitError(exitCode=2) with a recovery hint when git rev-parse fails', async () => {
+    // Simulate being outside a git repo: git exits non-zero.
+    spawn.expect({
+      command: 'git',
+      argv: ['rev-parse', '--git-common-dir'],
+      response: { stderr: 'fatal: not a git repository', exitCode: 128 },
+    });
+    let err: unknown;
+    try {
+      await mainRepoRoot();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(GitError);
+    expect((err as HandoffError).exitCode).toBe(2);
+    expect((err as HandoffError).hint).toMatch(/git repo/i);
   });
 });
 
@@ -121,6 +150,7 @@ describe('createWorktree', () => {
     }
 
     expect(err).toBeInstanceOf(GitError);
+    expect((err as HandoffError).exitCode).toBe(2);
     expect((err as Error).message).toContain("Branch 'feature/x' already exists");
     expect((err as Error).message).toContain('git branch -D feature/x');
     // No partial state on the filesystem — we bailed before `git worktree add`.

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { GhError, defaultBranch, fetchIssue, prMergedFor } from '../src/github.ts';
+import type { HandoffError } from '../src/errors.ts';
 import { createScriptedSpawn, type ScriptedSpawn } from './helpers/scriptedSpawn.ts';
 
 let spawn: ScriptedSpawn;
@@ -69,6 +70,7 @@ describe('fetchIssue', () => {
     }
 
     expect(err).toBeInstanceOf(GhError);
+    expect((err as HandoffError).exitCode).toBe(2);
     expect((err as Error).message).toContain('gh issue view 7');
     expect((err as Error).message).toContain('Could not resolve to an Issue');
     // No auth-hint on a 404 — the regex looks for /authentication/i in stderr.
@@ -93,6 +95,7 @@ describe('fetchIssue', () => {
     }
 
     expect(err).toBeInstanceOf(GhError);
+    expect((err as HandoffError).exitCode).toBe(2);
     expect((err as Error).message).toContain('(run `gh auth login`)');
   });
 

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -95,7 +95,7 @@ describe('fetchIssue', () => {
     }
 
     expect(err).toBeInstanceOf(GhError);
-    expect((err as HandoffError).exitCode).toBe(2);
+    expect((err as HandoffError).exitCode).toBe(1);
     expect((err as Error).message).toContain('(run `gh auth login`)');
   });
 

--- a/tests/runner-bash.integration.test.ts
+++ b/tests/runner-bash.integration.test.ts
@@ -161,12 +161,13 @@ describeBash('handoff-runner.sh', () => {
     TIMEOUT_MS,
   );
 
-  it('cleanup unknown-status (e.g. gh unavailable): runner exits 1, retains worktree', () => {
+  it('cleanup unknown-status (e.g. gh unavailable): runner exits 2 (operational), retains worktree', () => {
     // The 62c1611 contract at the runner level: when cleanup returns
     // status:'unknown' (worktree-removal failure, gh failure, branch
     // deletion failure — all map to the same 'unknown' status), the
-    // runner must exit 1 with the cleanup message intact and *no*
-    // stack-trace dump from the bun process.
+    // runner must propagate cli.ts's operational-error exit code (2)
+    // with the cleanup message intact and *no* stack-trace dump from
+    // the bun process.
     //
     // We drive this through a forced gh failure because the
     // worktree-removal-failure path is hard to set up reliably here
@@ -181,7 +182,7 @@ describeBash('handoff-runner.sh', () => {
 
     const result = runBashRunner(harness, { toolExit: 0, ghFail: true });
 
-    expect(result.status).toBe(1);
+    expect(result.status).toBe(2);
     expect(result.stdout).toContain('Could not check PR status');
     expect(result.stdout).toContain('Re-run `handoff cleanup claude/issue-10`');
     // No raw bun stack trace bleeding to the user. cleanup() catches

--- a/tests/runner-ps1.integration.test.ts
+++ b/tests/runner-ps1.integration.test.ts
@@ -156,7 +156,7 @@ describePwsh('handoff-runner.ps1', () => {
     TIMEOUT_MS,
   );
 
-  it('cleanup unknown-status (e.g. gh unavailable): runner exits 1, retains worktree', () => {
+  it('cleanup unknown-status (e.g. gh unavailable): runner exits 2 (operational), retains worktree', () => {
     // Mirrors the bash-matrix counterpart — same observable contract,
     // but exercised through the PS runner so a regression in either
     // script (e.g. wrong $LASTEXITCODE handling) trips its own test.
@@ -164,7 +164,7 @@ describePwsh('handoff-runner.ps1', () => {
 
     const result = runPwshRunner(harness, { toolExit: 0, ghFail: true });
 
-    expect(result.status).toBe(1);
+    expect(result.status).toBe(2);
     expect(result.stdout).toContain('Could not check PR status');
     expect(result.stdout).toContain('Re-run `handoff cleanup claude/issue-10`');
     expect(result.stderr).not.toMatch(/at .*src[\\/]cleanup\.ts/);


### PR DESCRIPTION
## Summary

- Adds `src/errors.ts` — `HandoffError` base class with `exitCode: 1 | 2 | 3` and optional `hint` for recovery steps
- All 7 custom error classes (`ArgsError`, `GitError`, `GhError`, `TerminalError`, `TelemetryConfigError`, `WorkspaceStateError`, and the runner-script not-found error) now extend `HandoffError` with the appropriate exit code
- `mainRepoRoot()` now wraps the git rev-parse `RunError` in a plain-language `GitError` ("not inside a git repository") with a recovery hint
- Adds `src/logger.ts` — `setVerbose` / `setDebug` / `verbose` / `debug` functions backed by module-level booleans
- `--verbose` prints info-level traces (branch, worktree path, terminal launch) to stderr; `--debug` adds raw subprocess invocations and exit codes (via `run.ts`), implies `--verbose`
- `cliMain()` catches `HandoffError` generically (prints message + hint, uses `exitCode`), `RunError` (exit 2), and anything else (exit 3); args errors still exit 1 (was 64)
- Exit codes documented in `--help` (EXIT CODES section + FLAGS for `--verbose`/`--debug`) and README
- Tests: `exitCode=2` assertions on `GitError` and `GhError` error paths; new test for `mainRepoRoot()` outside a git repo

Closes #26.

## Test plan

- [x] `bun run test` — 183 passed, 0 failed
- [x] `bun run typecheck` — clean
- [ ] CI green on ubuntu / macos / windows
- [ ] Manual smoke: `handoff` outside git dir → "not inside a git repository" + hint; bad args → usage + exit 1; `handoff --verbose claude #1` → traces to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)