### PR TITLE
docs + chore: --verbose/--debug + HandoffError follow-up; bump 0.2.0 (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@
 | `src/run.ts`                 | `spawn` wrapper with structured errors                                    | I/O   |
 | `src/workspace.ts`           | `.handoff/state.json` read/write + schema-version guard                   | I/O   |
 | `src/telemetry.ts`           | `~/.handoff/config.json`, event constructors, fire-and-forget emit        | mixed |
+| `src/errors.ts`              | `HandoffError` base — exit-code + recovery-hint contract                  | yes   |
+| `src/logger.ts`              | `--verbose`/`--debug` toggles + stderr log helpers                        | mixed |
 | `src/config.ts`              | `VERSION`, `HELP`                                                         | yes   |
 | `scripts/handoff-runner.sh`  | Bash wrapper: run tool, then `bun … cli.ts cleanup <branch>`              | shell |
 | `scripts/handoff-runner.ps1` | PowerShell equivalent for Windows                                         | shell |
@@ -31,6 +33,7 @@ Tests live in `tests/`. Pure modules are covered directly with `bun:test`. I/O m
 - **TypeScript strict + `noUncheckedIndexedAccess`.** `argv[i]` is `string | undefined`; handle it.
 - **No shell interpolation in TS.** Use `run.ts` (which uses `spawn` with an argv array). The only places shell strings exist are the runner scripts under `scripts/`.
 - **Pure modules import only `node:` builtins and other pure modules.** I/O modules can import `run.ts`.
+- **Errors extend `HandoffError`** (`src/errors.ts`) with an `exitCode` (1 = user, 2 = operational, 3 = internal/unexpected) and optionally a recovery `hint`. `cliMain()` uses the exit code as-is and prints the hint on a `hint:` line; `runHandoffs` aggregates the highest per-ref exit code so multi-ref failures still surface the documented category. Don't throw bare `Error` from CLI-reachable code — wrap it.
 - **Conventional Commits**, one logical commit per concern.
 - **Pre-commit hook** runs prettier + eslint via husky + lint-staged. Don't bypass with `--no-verify`.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ handoff cleanup claude/issue-42
 
 This re-checks the PR state and removes the worktree + branch if merged.
 
+### Verbose / debug logging
+
+Two global flags for when you want to see what `handoff` is doing under the hood:
+
+```bash
+handoff --verbose claude #7    # info traces (branch, worktree path, terminal launch)
+handoff --debug claude #7      # subprocess invocations + exit codes (implies --verbose)
+```
+
+Both write to stderr so they don't pollute scriptable stdout. They can sit before the tool, after it, or before/after subcommands (`handoff cleanup --verbose <branch>`); they're stripped from free-form descriptions verbatim, so `handoff claude "fix the --verbose flag"` still works.
+
 ## Exit codes
 
 | Code | Meaning                                                                  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handoff",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Delegate a GitHub issue to claude, codex, or copilot in an isolated git worktree.",
   "type": "module",
   "private": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for the package version, mirrored from package.json. */
-export const VERSION = '0.1.0';
+export const VERSION = '0.2.0';
 
 export const HELP = `handoff v${VERSION}
 


### PR DESCRIPTION
## Summary

Post-merge follow-up to #26 / #51:

- `README.md`: new "Verbose / debug logging" subsection covering both flags, where they can sit in argv, and free-form preservation
- `CLAUDE.md`: module map gains `src/errors.ts` and `src/logger.ts`; Conventions gain the `HandoffError` contract (exitCode 1/2/3 + optional hint) so future agents wrap errors instead of throwing bare `Error`
- `chore`: bump VERSION 0.1.0 → 0.2.0 in `src/config.ts` and `package.json`. PR #51 added new public surface (--verbose/--debug, exit-code categories, hint plumbing) — pre-1.0, that's a minor bump

Historical "v0.1.0 spec" references in CLAUDE.md / TODO.md / docs/ are intentionally left alone — they describe the original MVP target, not the shipping version.

## Test plan

- [x] `bun src/cli.ts --version` prints `0.2.0`
- [x] `bun run typecheck && bun run lint` clean
- [ ] Reviewer: confirm minor bump (vs patch) is the right call for #51's surface area

🤖 Generated with [Claude Code](https://claude.com/claude-code)