### PR TITLE
fix(adapter): copilot CLI needs `-i <prompt>`, not bare positional (#57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,18 @@ When you add a new I/O module: pick a fixture from the matrix, follow the per-fi
 ## How to add a new adapter
 
 1. Add the tool string to `TOOLS` in `src/args.ts`.
-2. Add the tool name to the `case` in `scripts/handoff-runner.sh` and the `ValidateSet` in `scripts/handoff-runner.ps1` (the runner scripts invoke the tool binary directly — currently the tool name == binary name).
+2. Add the tool name to the per-tool invocation table in **both** `scripts/handoff-runner.sh` and `scripts/handoff-runner.ps1`, plus the `ValidateSet` in the latter. The runner scripts invoke the tool binary directly (currently the tool name == binary name) — but the argv shape differs per tool (see table below), so a new adapter must declare which shape it uses.
 3. Update `README.md` requirements list.
 4. Add a test for the new tool path in `tests/args.test.ts`.
+5. Add a per-tool argv-shape case to `tests/runner-bash.integration.test.ts` and `tests/runner-ps1.integration.test.ts` so the contract is pinned end-to-end.
+
+### Per-tool invocation table
+
+| Tool      | Argv shape            | Why                                                                                                                                                                                                                                                                                                                                           |
+| --------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `claude`  | `claude <PROMPT>`     | Accepts a positional `[prompt]` (interactive seeded session).                                                                                                                                                                                                                                                                                 |
+| `codex`   | `codex <PROMPT>`      | Same — `codex [OPTIONS] [PROMPT]`.                                                                                                                                                                                                                                                                                                            |
+| `copilot` | `copilot -i <PROMPT>` | A bare positional is parsed as a subcommand and exits silently (issue #57). `-i, --interactive <prompt>` "starts interactive mode and automatically executes this prompt" — same UX as the others. Avoid `-p/--prompt`: that's non-interactive and exits after completion, which would close the terminal before the user sees what happened. |
 
 ## The `.handoff/` workspace directory
 

--- a/scripts/handoff-runner.ps1
+++ b/scripts/handoff-runner.ps1
@@ -20,7 +20,21 @@ if (-not (Test-Path 'PROMPT.md')) {
 
 $prompt = Get-Content -Path 'PROMPT.md' -Raw
 
-& $Tool $prompt
+# Per-tool invocation table. claude and codex both accept a positional
+# [PROMPT] for interactive seeded sessions. copilot does NOT — it parses
+# a bare positional as a subcommand and exits silently. Use copilot's
+# `-i, --interactive <prompt>` flag, which starts interactive mode and
+# automatically executes the seed prompt — same UX as claude/codex.
+# When you add a new tool, mirror the change in handoff-runner.sh and
+# the per-tool table in CLAUDE.md ("How to add a new adapter").
+switch ($Tool) {
+  { $_ -in 'claude', 'codex' } { & $Tool $prompt }
+  'copilot' { & $Tool -i $prompt }
+  default {
+    Write-Error "handoff-runner: unknown tool '$Tool'"
+    exit 64
+  }
+}
 $toolExit = $LASTEXITCODE
 
 Write-Host ''

--- a/scripts/handoff-runner.sh
+++ b/scripts/handoff-runner.sh
@@ -28,9 +28,19 @@ fi
 
 PROMPT="$(cat PROMPT.md)"
 
+# Per-tool invocation table. claude and codex both accept a positional
+# [PROMPT] for interactive seeded sessions. copilot does NOT — it parses
+# a bare positional as a subcommand and exits silently. Use copilot's
+# `-i, --interactive <prompt>` flag, which starts interactive mode and
+# automatically executes the seed prompt — same UX as claude/codex.
+# When you add a new tool, mirror the change in handoff-runner.ps1 and
+# the per-tool table in CLAUDE.md ("How to add a new adapter").
 case "$TOOL" in
-  claude|codex|copilot)
+  claude|codex)
     "$TOOL" "$PROMPT"
+    ;;
+  copilot)
+    "$TOOL" -i "$PROMPT"
     ;;
   *)
     echo "handoff-runner: unknown tool '$TOOL'" >&2

--- a/tests/helpers/runnerHarness.ts
+++ b/tests/helpers/runnerHarness.ts
@@ -66,9 +66,17 @@ export interface RunnerHarness {
   /** Absolute path to the handoff repo root (passed as the runner's first arg). */
   handoffRepoRoot: string;
   /**
+   * Path the fake tool shim writes its received argv to (one JSON array
+   * per invocation). Tests assert on this to pin the per-tool argv shape
+   * the runner produces — e.g. claude/codex get `[PROMPT]`, copilot gets
+   * `['-i', PROMPT]`.
+   */
+  argvLogPath: string;
+  /**
    * Env to pass to the spawned runner. Already includes:
    *  - `PATH` with `fakeBinDir` prepended (so the shims win)
    *  - `HOME` / `USERPROFILE` redirected to a temp dir
+   *  - `FAKE_TOOL_ARGV_LOG` pointing at `argvLogPath`
    *  - any extra entries the test passes via `extraEnv`
    * Tests typically tweak `FAKE_TOOL_EXIT` / `FAKE_GH_PR_LIST_RESPONSE`
    * here per case.
@@ -106,6 +114,10 @@ export function createRunnerHarness(opts: RunnerHarnessOptions): RunnerHarness {
   // tracking so a test that throws mid-setup still releases them.
   const homeDir = mkdtempSync(join(tmpdir(), 'handoff-runner-home-'));
   const fakeBinDir = mkdtempSync(join(tmpdir(), 'handoff-runner-bin-'));
+  // Pre-allocate the argv-log path so it's stable for the test even
+  // before the fake shim runs. The shim creates the file on first
+  // invocation; tests that don't care about argv simply ignore it.
+  const argvLogPath = join(fakeBinDir, 'tool-argv.log');
 
   let cleanedUp = false;
   const harness: RunnerHarness = {
@@ -119,6 +131,7 @@ export function createRunnerHarness(opts: RunnerHarnessOptions): RunnerHarness {
       opts.target === 'pwsh' ? 'handoff-runner.ps1' : 'handoff-runner.sh',
     ),
     handoffRepoRoot: HANDOFF_REPO_ROOT,
+    argvLogPath,
     env: {},
     cleanup() {
       if (cleanedUp) return;
@@ -176,6 +189,7 @@ export function createRunnerHarness(opts: RunnerHarnessOptions): RunnerHarness {
     // unset) so the shims don't hit a "variable not set" branch.
     env.FAKE_TOOL_EXIT = '0';
     env.FAKE_GH_PR_LIST_RESPONSE = JSON.stringify([{ number: 1 }]);
+    env.FAKE_TOOL_ARGV_LOG = argvLogPath;
     harness.env = env;
 
     return harness;
@@ -236,9 +250,17 @@ function writeFakeShims(opts: { fakeBinDir: string }): void {
   writeFileSync(
     fakeToolImpl,
     [
-      `// Fake tool (claude/codex/copilot): exits with FAKE_TOOL_EXIT.`,
-      `// Argv is ignored — the runner passes PROMPT.md content as one`,
-      `// arg, but tests don't care about the prompt body.`,
+      `// Fake tool (claude/codex/copilot): records its argv to`,
+      `// FAKE_TOOL_ARGV_LOG (one JSON array per invocation, separated by`,
+      `// newlines) and exits with FAKE_TOOL_EXIT. Tests assert on the`,
+      `// log to pin the per-tool argv shape the runner produces — e.g.`,
+      `// claude/codex get [PROMPT], copilot gets ["-i", PROMPT].`,
+      `import { appendFileSync } from 'node:fs';`,
+      `const argv = process.argv.slice(2);`,
+      `const log = process.env.FAKE_TOOL_ARGV_LOG;`,
+      `if (log) {`,
+      `  appendFileSync(log, JSON.stringify(argv) + '\\n', 'utf8');`,
+      `}`,
       `const code = Number(process.env.FAKE_TOOL_EXIT ?? '0');`,
       `process.exit(Number.isFinite(code) ? code : 0);`,
       ``,
@@ -267,25 +289,32 @@ function writeFakeShims(opts: { fakeBinDir: string }): void {
     `#!/usr/bin/env bash\nexec bun "${fakeGhImpl}" "$@"\n`,
     'utf8',
   );
-  writeFileSync(
-    join(opts.fakeBinDir, 'claude'),
-    `#!/usr/bin/env bash\nexec bun "${fakeToolImpl}" "$@"\n`,
-    'utf8',
-  );
+  // Same fake-tool impl for all three tool names — they share the
+  // shim, only the runner's per-tool argv shape differs (which is
+  // exactly what the argv log lets the tests assert on).
+  for (const name of ['claude', 'codex', 'copilot']) {
+    writeFileSync(
+      join(opts.fakeBinDir, name),
+      `#!/usr/bin/env bash\nexec bun "${fakeToolImpl}" "$@"\n`,
+      'utf8',
+    );
+    chmodSync(join(opts.fakeBinDir, name), 0o755);
+  }
   if (isWin) {
     writeFileSync(
       join(opts.fakeBinDir, 'gh.cmd'),
       `@echo off\r\nbun "${fakeGhImpl}" %*\r\n`,
       'utf8',
     );
-    writeFileSync(
-      join(opts.fakeBinDir, 'claude.cmd'),
-      `@echo off\r\nbun "${fakeToolImpl}" %*\r\n`,
-      'utf8',
-    );
+    for (const name of ['claude', 'codex', 'copilot']) {
+      writeFileSync(
+        join(opts.fakeBinDir, `${name}.cmd`),
+        `@echo off\r\nbun "${fakeToolImpl}" %*\r\n`,
+        'utf8',
+      );
+    }
   }
   chmodSync(join(opts.fakeBinDir, 'gh'), 0o755);
-  chmodSync(join(opts.fakeBinDir, 'claude'), 0o755);
 }
 
 /**

--- a/tests/runner-bash.integration.test.ts
+++ b/tests/runner-bash.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 
 import {
   createRunnerHarness,
@@ -26,6 +26,12 @@ interface RunOpts {
   ghPrListResponse?: unknown;
   /** Force the fake gh to exit non-zero (drives cleanup's unknown-status path). */
   ghFail?: boolean;
+  /**
+   * Tool name to invoke through the runner. Defaults to `'claude'` to
+   * keep existing tests untouched; per-tool argv-shape tests pass
+   * `'codex'` / `'copilot'` to exercise the runner's per-tool switch.
+   */
+  tool?: 'claude' | 'codex' | 'copilot';
 }
 
 function runBashRunner(h: RunnerHarness, opts: RunOpts = {}) {
@@ -38,6 +44,7 @@ function runBashRunner(h: RunnerHarness, opts: RunOpts = {}) {
         : JSON.stringify(opts.ghPrListResponse),
     ...(opts.ghFail ? { FAKE_GH_FAIL: '1' } : {}),
   };
+  const tool = opts.tool ?? 'claude';
   // Set cwd by `cd`-ing inside the bash command rather than passing it
   // through `spawnSync({ cwd })`. On Windows, bun's spawnSync holds a
   // handle on the cwd it was given for the duration of its own
@@ -52,7 +59,7 @@ function runBashRunner(h: RunnerHarness, opts: RunOpts = {}) {
   // it. `bash <runner>` works regardless of file mode.
   const wt = h.worktreePath.replace(/\\/g, '/');
   const runner = h.runnerScript.replace(/\\/g, '/');
-  const cmd = `cd "${wt}" && bash "${runner}" "${h.handoffRepoRoot}" claude "${h.branch}"`;
+  const cmd = `cd "${wt}" && bash "${runner}" "${h.handoffRepoRoot}" ${tool} "${h.branch}"`;
   return spawnSync(bash!, ['-c', cmd], {
     env,
     encoding: 'utf8',
@@ -60,6 +67,15 @@ function runBashRunner(h: RunnerHarness, opts: RunOpts = {}) {
     // skips the trailing prompt.
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+}
+
+/** Read the JSON-per-line argv log left by fake-tool-impl.ts. */
+function readArgvLog(path: string): string[][] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as string[]);
 }
 
 function expectExit(
@@ -210,4 +226,44 @@ describeBash('handoff-runner.sh', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('PROMPT.md not found');
   });
+
+  // Per-tool argv shape — the regression behind issue #57. Three tools,
+  // two shapes: claude/codex take the prompt as a positional arg;
+  // copilot needs `-i <prompt>` because a bare positional is parsed as
+  // a subcommand and exits silently. The runner table is the source of
+  // truth; these tests pin the contract.
+  for (const tool of ['claude', 'codex', 'copilot'] as const) {
+    it(
+      `${tool}: runner passes PROMPT.md content with the right argv shape`,
+      () => {
+        const promptBody = `# seed prompt for ${tool}\nDo the thing.\n`;
+        harness = createRunnerHarness({
+          target: 'bash',
+          branch: `${tool}/issue-57`,
+          promptBody,
+        });
+
+        const result = runBashRunner(harness, {
+          tool,
+          toolExit: 0,
+          ghPrListResponse: [{ number: 57 }],
+        });
+        expectExit(result, 0, `bash ${tool} argv`);
+
+        const calls = readArgvLog(harness.argvLogPath);
+        expect(calls.length).toBe(1);
+        const argv = calls[0]!;
+        if (tool === 'copilot') {
+          // Trailing newline is preserved because PROMPT="$(cat …)"
+          // strips trailing newlines in bash (POSIX-mandated for
+          // command substitution). The body the tool sees is the
+          // newline-trimmed prompt.
+          expect(argv).toEqual(['-i', promptBody.replace(/\n+$/, '')]);
+        } else {
+          expect(argv).toEqual([promptBody.replace(/\n+$/, '')]);
+        }
+      },
+      TIMEOUT_MS,
+    );
+  }
 });

--- a/tests/runner-bash.integration.test.ts
+++ b/tests/runner-bash.integration.test.ts
@@ -253,14 +253,15 @@ describeBash('handoff-runner.sh', () => {
         const calls = readArgvLog(harness.argvLogPath);
         expect(calls.length).toBe(1);
         const argv = calls[0]!;
+        // Trailing newlines are stripped: PROMPT="$(cat …)" drops
+        // them (POSIX-mandated for command substitution), so the tool
+        // sees the prompt without its final \n. Internal newlines are
+        // preserved verbatim.
+        const expected = promptBody.replace(/\n+$/, '');
         if (tool === 'copilot') {
-          // Trailing newline is preserved because PROMPT="$(cat …)"
-          // strips trailing newlines in bash (POSIX-mandated for
-          // command substitution). The body the tool sees is the
-          // newline-trimmed prompt.
-          expect(argv).toEqual(['-i', promptBody.replace(/\n+$/, '')]);
+          expect(argv).toEqual(['-i', expected]);
         } else {
-          expect(argv).toEqual([promptBody.replace(/\n+$/, '')]);
+          expect(argv).toEqual([expected]);
         }
       },
       TIMEOUT_MS,

--- a/tests/runner-ps1.integration.test.ts
+++ b/tests/runner-ps1.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { platform } from 'node:os';
 
 import {
@@ -30,6 +30,11 @@ interface RunOpts {
   toolExit?: number;
   ghPrListResponse?: unknown;
   ghFail?: boolean;
+  /**
+   * Tool name to invoke. Defaults to `'claude'` so existing tests stay
+   * untouched; per-tool argv-shape tests pass `'codex'` / `'copilot'`.
+   */
+  tool?: 'claude' | 'codex' | 'copilot';
 }
 
 function runPwshRunner(h: RunnerHarness, opts: RunOpts = {}) {
@@ -42,6 +47,7 @@ function runPwshRunner(h: RunnerHarness, opts: RunOpts = {}) {
         : JSON.stringify(opts.ghPrListResponse),
     ...(opts.ghFail ? { FAKE_GH_FAIL: '1' } : {}),
   };
+  const tool = opts.tool ?? 'claude';
   // -NoProfile keeps the test hermetic against the user's PowerShell
   // profile. -ExecutionPolicy Bypass avoids the unsigned-script block
   // CI runners sometimes hit on first invocation.
@@ -65,7 +71,7 @@ function runPwshRunner(h: RunnerHarness, opts: RunOpts = {}) {
       'Bypass',
       '-Command',
       `Set-Location -LiteralPath '${psQuote(h.worktreePath)}'; ` +
-        `& '${psQuote(h.runnerScript)}' '${psQuote(h.handoffRepoRoot)}' 'claude' '${psQuote(h.branch)}'; ` +
+        `& '${psQuote(h.runnerScript)}' '${psQuote(h.handoffRepoRoot)}' '${tool}' '${psQuote(h.branch)}'; ` +
         `exit $LASTEXITCODE`,
     ],
     {
@@ -80,6 +86,15 @@ function runPwshRunner(h: RunnerHarness, opts: RunOpts = {}) {
 
 function psQuote(s: string): string {
   return s.replace(/'/g, "''");
+}
+
+/** Read the JSON-per-line argv log left by fake-tool-impl.ts. */
+function readArgvLog(path: string): string[][] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as string[]);
 }
 
 function expectExit(
@@ -188,4 +203,48 @@ describePwsh('handoff-runner.ps1', () => {
     const combined = (result.stdout ?? '') + (result.stderr ?? '');
     expect(combined).toContain('PROMPT.md not found');
   });
+
+  // Per-tool argv shape — the regression behind issue #57. claude/codex
+  // take the prompt as a positional arg; copilot needs `-i <prompt>`
+  // because a bare positional is parsed as a subcommand and exits
+  // silently. Mirrors the bash matrix; runs against the .ps1 runner so
+  // a divergence between the two scripts trips here.
+  //
+  // Prompt body is intentionally single-line: the shim chain on Windows
+  // is `pwsh → .cmd → bun → fake-tool-impl.ts`, and `%*` in a .cmd file
+  // is reparsed by cmd.exe, where newlines act as command separators
+  // and truncate multi-line args. Production calls real `copilot.exe`,
+  // which parses its own Win32 command line and is unaffected. The
+  // contract we're pinning is per-tool argv shape (positional vs `-i`),
+  // not multi-line prompt preservation.
+  for (const tool of ['claude', 'codex', 'copilot'] as const) {
+    it(
+      `${tool}: runner passes PROMPT.md content with the right argv shape`,
+      () => {
+        const promptBody = `seed prompt for ${tool}`;
+        harness = createRunnerHarness({
+          target: 'pwsh',
+          branch: `${tool}/issue-57`,
+          promptBody,
+        });
+
+        const result = runPwshRunner(harness, {
+          tool,
+          toolExit: 0,
+          ghPrListResponse: [{ number: 57 }],
+        });
+        expectExit(result, 0, `pwsh ${tool} argv`);
+
+        const calls = readArgvLog(harness.argvLogPath);
+        expect(calls.length).toBe(1);
+        const argv = calls[0]!;
+        if (tool === 'copilot') {
+          expect(argv).toEqual(['-i', promptBody]);
+        } else {
+          expect(argv).toEqual([promptBody]);
+        }
+      },
+      TIMEOUT_MS,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

- Both runner scripts shelled out as `"$TOOL" "$PROMPT"` for all three tools, but `copilot` parses a bare positional as a subcommand and exits silently — `/handoff copilot #N` was a documented no-op.
- Per-tool invocation table in both runners: `claude`/`codex` stay positional; `copilot` becomes `-i <PROMPT>` (`--interactive <prompt>`, "starts interactive mode and automatically executes this prompt"), matching the seeded-interactive UX of the other two.
- Pin the contract end-to-end: `fake-tool-impl.ts` now records argv to `FAKE_TOOL_ARGV_LOG`, the runner harness writes shims for all three tool names, and both bash and pwsh integration suites have a per-tool case asserting argv shape.
- Document the table in `CLAUDE.md` "How to add a new adapter" so new adapters declare their shape.

Closes #57.

## Test plan

- [x] `bun run test` — 212 pass / 0 fail (covers new per-tool argv-shape cases on both runners)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Smoke-tested on Windows 11 (pwsh + Git Bash). The Linux/macOS bash path is exercised by the existing bash-runner suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)