### PR TITLE
docs(v0.2.1): documentation pass for the patch release (#61)

### DIFF
--- a/docs/implementation-plan.v0.1.0.md
+++ b/docs/implementation-plan.v0.1.0.md
@@ -2,6 +2,8 @@
 
 One PR into `dev` lands all of v0.1.0. Commits below are the intended sequence inside that PR; the PR is opened only after the final commit.
 
+> **Historical document.** This captures the plan as it stood at the v0.1.0 cut. Subsequent releases superseded parts of it: the `src/adapters.ts` module referenced below was removed, and the per-tool invocation shapes diverged from the "all three accept a positional prompt" assumption (copilot needs `-i <PROMPT>`, see #57). For the current truth, see [CLAUDE.md's per-tool invocation table](../CLAUDE.md#per-tool-invocation-table) and `scripts/handoff-runner.{sh,ps1}` — they're the source of record post-v0.1.0.
+
 ## Phase 0 — Repo bootstrap
 
 **Commit:** `chore: bootstrap repo (gitignore, license, editorconfig)`


### PR DESCRIPTION
## Summary

Audit of every doc surface against the v0.2.1 fixes (#54, #55, #57). The result is much smaller than the issue body anticipated because the bug-fix PRs already kept their docs in sync — the only stale doc that remained was the v0.1.0 implementation plan.

**Changes (1 file):**
- `docs/implementation-plan.v0.1.0.md`: prepend a one-paragraph "historical document" note redirecting readers to CLAUDE.md's per-tool table and the runner scripts. The plan currently documents the buggy copilot invocation as the intended shape (line 62 — exactly #57) and references `src/adapters.ts`, which has been deleted. CLAUDE.md tells agents to read this plan first, so a new reader was being silently misled.

**No changes needed (audit findings):**
- `README.md`: `--force` section + `forced` telemetry outcome already landed in the #54 PR.
- `CLAUDE.md`: per-tool invocation table from #57; module-map shape (`{ command:'cleanup', branch, force }`) from #54; no "known issues" sections to remove.
- `src/prompt.ts`: `WORKFLOW_CONTRACT` step 7 hard-stop landed in eaf9f5a (2026-04-26); #55 was a stale carry-over and was closed against that commit.
- `.claude/commands/handoff.md`, `docs/requirements.md`, `docs/initial-prompt.md`: no stale claims; v0.1.0-spec docs read appropriately as historical artifacts.

The audit documented in the commit message gives reviewers (and #62/#63) a complete record of what was checked.

Closes #61.

## Test plan

- [x] `bun run test` — 219 pass / 0 fail (no source changed, sanity check)
- [x] `bun run typecheck`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)