### PR TITLE
fix(cleanup): scope --force to handoff-shaped branches + doc accuracy (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This:
 2. Creates branch `claude/issue-42` off the repo's default branch.
 3. Adds a worktree as a sibling directory: `<repo-parent>/<repo>-issue-42`.
 4. Writes `PROMPT.md` to the worktree with the issue, the branch, and a workflow contract.
-5. Spawns a new terminal window in that worktree, running `claude "$(cat PROMPT.md)"`.
+5. Spawns a new terminal window in that worktree and runs the chosen tool with the prompt — `claude "$(cat PROMPT.md)"` and `codex "$(cat PROMPT.md)"` for those two; `copilot -i "$(cat PROMPT.md)"` for copilot (its CLI parses bare positionals as subcommands, so the `-i` flag is required to seed an interactive session). The per-tool argv table lives in `scripts/handoff-runner.{sh,ps1}`.
 
 The agent does the work, commits, pushes, opens a PR. When it exits, the wrapper checks `gh pr list --head <branch> --state merged` — if the PR has merged, the worktree and branch are removed.
 
@@ -162,7 +162,7 @@ scripts/
 .claude/commands/handoff.md  — Claude Code slash command
 ```
 
-A handoff is one PR. Cleanup is conditional on `gh pr list --head <branch> --state merged` returning a result; nothing else will trigger worktree removal.
+A handoff is one PR. Cleanup is conditional on `gh pr list --head <branch> --state merged` returning a result — that's the safety property. The one opt-in escape hatch is `handoff cleanup --force <branch>`, which skips the merge check for orphan worktrees whose work shipped under a different branch (see [Cleanup](#cleanup) above). `--force` is restricted to handoff-shaped branch names so a typo can't unconditionally delete unrelated local branches.
 
 ### The `.handoff/` workspace directory
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -44,6 +44,7 @@ export type TelemetryArgs =
 export type CliInvocation = ParsedArgs | CleanupArgs | TelemetryArgs;
 
 import { HandoffError } from './errors.ts';
+import { isHandoffBranch } from './branch.ts';
 
 export class ArgsError extends HandoffError {
   constructor(message: string) {
@@ -211,6 +212,21 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     if (positionals.length > 1) {
       throw new ArgsError(
         `'handoff cleanup' takes a single <branch> argument (got ${positionals.length}).`,
+      );
+    }
+    // --force opts out of the merge-check safety property. Substitute a
+    // name-shape check so a typo'd or non-handoff branch can't trigger
+    // an unconditional `git branch -D`. Legitimate handoff branches
+    // always match `<tool>/issue-<N>`, `<tool>/pr-<N>`, or `<tool>/<slug>`
+    // (the shapes branchName() emits). Non-force cleanup remains
+    // permissive — the gh-merged-PR check refuses non-handoff branches
+    // implicitly.
+    if (force && !isHandoffBranch(branch)) {
+      throw new ArgsError(
+        `'handoff cleanup --force' refused: '${branch}' isn't a handoff branch ` +
+          `(expected '<tool>/issue-<N>', '<tool>/pr-<N>', or '<tool>/<slug>' ` +
+          `with <tool> in: ${TOOLS.join(', ')}). ` +
+          `If you really meant to delete this branch, use \`git branch -D ${branch}\` directly.`,
       );
     }
     return { command: 'cleanup', branch, force };

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,4 +1,3 @@
-export { TOOLS, type Tool } from './tools.ts';
 import { TOOLS, type Tool } from './tools.ts';
 
 export interface IssueRef {

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,5 +1,5 @@
-export const TOOLS = ['claude', 'codex', 'copilot'] as const;
-export type Tool = (typeof TOOLS)[number];
+export { TOOLS, type Tool } from './tools.ts';
+import { TOOLS, type Tool } from './tools.ts';
 
 export interface IssueRef {
   kind: 'issue';
@@ -226,7 +226,7 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
         `'handoff cleanup --force' refused: '${branch}' isn't a handoff branch ` +
           `(expected '<tool>/issue-<N>', '<tool>/pr-<N>', or '<tool>/<slug>' ` +
           `with <tool> in: ${TOOLS.join(', ')}). ` +
-          `If you really meant to delete this branch, use \`git branch -D ${branch}\` directly.`,
+          `If you really meant to delete this branch, use \`git branch -D -- ${branch}\` directly.`,
       );
     }
     return { command: 'cleanup', branch, force };

--- a/src/args.ts
+++ b/src/args.ts
@@ -221,11 +221,17 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     // permissive — the gh-merged-PR check refuses non-handoff branches
     // implicitly.
     if (force && !isHandoffBranch(branch)) {
+      // POSIX single-quote the rejected name in the hint: this code path
+      // accepts arbitrary user input (the whole point is that isHandoffBranch
+      // refused it), so embedding it raw in a copy/pastable shell command
+      // would be a copy-paste injection hazard for branch names with shell
+      // metacharacters like `;`, `$()`, or backticks.
+      const quoted = `'${branch.replace(/'/g, `'\\''`)}'`;
       throw new ArgsError(
         `'handoff cleanup --force' refused: '${branch}' isn't a handoff branch ` +
           `(expected '<tool>/issue-<N>', '<tool>/pr-<N>', or '<tool>/<slug>' ` +
           `with <tool> in: ${TOOLS.join(', ')}). ` +
-          `If you really meant to delete this branch, use \`git branch -D -- ${branch}\` directly.`,
+          `If you really meant to delete this branch, use \`git branch -D -- ${quoted}\` directly.`,
       );
     }
     return { command: 'cleanup', branch, force };

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join } from 'node:path';
-import { TOOLS, type Tool } from './args.ts';
+import { TOOLS, type Tool } from './tools.ts';
 
 export interface BranchInput {
   tool: Tool;
@@ -44,29 +44,15 @@ export function branchTail(branch: string): string {
  * legitimate handoff branches always pass.
  */
 export function isHandoffBranch(branch: string): boolean {
-  return handoffBranchRe().test(branch);
+  return HANDOFF_BRANCH_RE.test(branch);
 }
 
-let _handoffBranchRe: RegExp | undefined;
-
-// Lazy-built so we don't read TOOLS at module-load time. args.ts and
-// branch.ts have a circular import (args.ts → isHandoffBranch ← branch.ts
-// ← TOOLS) — building the regex inside the function defers TOOLS access
-// until first call, by which time both modules have finished initializing.
-function handoffBranchRe(): RegExp {
-  if (_handoffBranchRe) return _handoffBranchRe;
-  const toolAlternation = TOOLS.map(escapeForRegex).join('|');
-  // Tail forms (matching branchName):
-  //   issue-<N>, pr-<N>  — N is one or more decimal digits
-  //   <slug>             — kebab-case alphanumeric per slugify()
+const HANDOFF_BRANCH_RE = (() => {
+  const toolAlternation = TOOLS.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  // Tail forms (matching branchName): issue-<N>, pr-<N>, or kebab-case slug.
   const tail = String.raw`(?:issue-\d+|pr-\d+|[a-z0-9]+(?:-[a-z0-9]+)*)`;
-  _handoffBranchRe = new RegExp(`^(?:${toolAlternation})/${tail}$`);
-  return _handoffBranchRe;
-}
-
-function escapeForRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+  return new RegExp(`^(?:${toolAlternation})/${tail}$`);
+})();
 
 export interface WorktreePathInput {
   repoRoot: string;

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join } from 'node:path';
-import type { Tool } from './args.ts';
+import { TOOLS, type Tool } from './args.ts';
 
 export interface BranchInput {
   tool: Tool;
@@ -28,6 +28,44 @@ export function branchName({ tool, issueNumber, prNumber, slug }: BranchInput): 
 export function branchTail(branch: string): string {
   const slash = branch.indexOf('/');
   return slash === -1 ? branch : branch.slice(slash + 1);
+}
+
+/**
+ * True iff `branch` could have been produced by `branchName()` — i.e. the
+ * shape is `<tool>/issue-<N>`, `<tool>/pr-<N>`, or `<tool>/<slug>` with
+ * `<tool>` ∈ TOOLS and `<slug>` matching the kebab-case form `slugify()`
+ * emits (lowercase alphanumeric tokens joined by single dashes, no
+ * leading/trailing dashes, no double dashes).
+ *
+ * Used by `cleanup --force` as a guard so a typo'd or non-handoff branch
+ * name can't trigger an unconditional `git branch -D`. Without `--force`
+ * the merge-check is the safety property; with `--force` the user is
+ * opting out of that check, so we substitute a name-shape check that
+ * legitimate handoff branches always pass.
+ */
+export function isHandoffBranch(branch: string): boolean {
+  return handoffBranchRe().test(branch);
+}
+
+let _handoffBranchRe: RegExp | undefined;
+
+// Lazy-built so we don't read TOOLS at module-load time. args.ts and
+// branch.ts have a circular import (args.ts → isHandoffBranch ← branch.ts
+// ← TOOLS) — building the regex inside the function defers TOOLS access
+// until first call, by which time both modules have finished initializing.
+function handoffBranchRe(): RegExp {
+  if (_handoffBranchRe) return _handoffBranchRe;
+  const toolAlternation = TOOLS.map(escapeForRegex).join('|');
+  // Tail forms (matching branchName):
+  //   issue-<N>, pr-<N>  — N is one or more decimal digits
+  //   <slug>             — kebab-case alphanumeric per slugify()
+  const tail = String.raw`(?:issue-\d+|pr-\d+|[a-z0-9]+(?:-[a-z0-9]+)*)`;
+  _handoffBranchRe = new RegExp(`^(?:${toolAlternation})/${tail}$`);
+  return _handoffBranchRe;
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 export interface WorktreePathInput {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,9 +9,9 @@ import {
   extractGlobalFlags,
   parseInvocation,
   type Ref,
-  type Tool,
   type TelemetryArgs,
 } from './args.ts';
+import type { Tool } from './tools.ts';
 import { HandoffError } from './errors.ts';
 import { setDebug, setVerbose, verbose } from './logger.ts';
 import { branchName, worktreePath } from './branch.ts';

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,4 +1,4 @@
-import type { Tool } from './args.ts';
+import type { Tool } from './tools.ts';
 
 export interface PromptContext {
   tool: Tool;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
-import type { Tool } from './args.ts';
+import type { Tool } from './tools.ts';
 import { HandoffError } from './errors.ts';
 
 export const HOME_DIRNAME = '.handoff';

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,0 +1,2 @@
+export const TOOLS = ['claude', 'codex', 'copilot'] as const;
+export type Tool = (typeof TOOLS)[number];

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type { Tool } from './args.ts';
+import type { Tool } from './tools.ts';
 import { HandoffError } from './errors.ts';
 
 export const WORKSPACE_DIRNAME = '.handoff';

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -120,6 +120,46 @@ describe('parseInvocation', () => {
     expect(() => parseInvocation(['cleanup', 'a', 'b'])).toThrow(/single <branch>/);
   });
 
+  it('rejects --force on a non-handoff branch', () => {
+    // The codex-challenge finding (v0.2.1 follow-up): without this guard,
+    // `handoff cleanup --force experiment` would happily `git branch -D
+    // experiment`. The merge-check is the safety property without --force;
+    // this is its substitute when --force is on.
+    expect(() => parseInvocation(['cleanup', '--force', 'experiment'])).toThrow(
+      /isn't a handoff branch/,
+    );
+    expect(() => parseInvocation(['cleanup', '--force', 'main'])).toThrow(/isn't a handoff branch/);
+    expect(() => parseInvocation(['cleanup', '--force', 'feature/x'])).toThrow(
+      /isn't a handoff branch/,
+    );
+  });
+
+  it('allows --force on a legitimate handoff branch', () => {
+    // The guard above must NOT regress the orphan-cleanup case from #54
+    // (handoff branch whose work shipped under a different branch name).
+    expect(parseInvocation(['cleanup', '--force', 'claude/issue-7'])).toEqual({
+      command: 'cleanup',
+      branch: 'claude/issue-7',
+      force: true,
+    });
+    expect(parseInvocation(['cleanup', '--force', 'codex/cleanup-readme'])).toEqual({
+      command: 'cleanup',
+      branch: 'codex/cleanup-readme',
+      force: true,
+    });
+  });
+
+  it('non-force cleanup still allows arbitrary branch names', () => {
+    // Without --force, the merge-check (gh pr list --head) is the safety
+    // property — it implicitly refuses non-handoff branches by returning
+    // empty. We don't second-guess at the args layer.
+    expect(parseInvocation(['cleanup', 'experiment'])).toEqual({
+      command: 'cleanup',
+      branch: 'experiment',
+      force: false,
+    });
+  });
+
   it('rejects unknown tool', () => {
     expect(() => parseInvocation(['bard', '#1'])).toThrow(ArgsError);
   });

--- a/tests/branch.test.ts
+++ b/tests/branch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import { branchName, branchTail, worktreePath } from '../src/branch.ts';
+import { branchName, branchTail, isHandoffBranch, worktreePath } from '../src/branch.ts';
+import { slugify } from '../src/slug.ts';
 
 describe('branchName', () => {
   it('builds an issue branch as <tool>/issue-<N>', () => {
@@ -28,6 +29,79 @@ describe('branchTail', () => {
 
   it('returns the input unchanged when there is no slash', () => {
     expect(branchTail('rogue')).toBe('rogue');
+  });
+});
+
+describe('isHandoffBranch', () => {
+  // Source-of-truth contract: the branch name is one branchName() could
+  // have produced. Used by `cleanup --force` to refuse arbitrary branches
+  // — the merge-check is the safety property without --force; this is
+  // the substitute when --force is on.
+
+  it('accepts every issue-form branch from branchName()', () => {
+    for (const tool of ['claude', 'codex', 'copilot'] as const) {
+      expect(isHandoffBranch(branchName({ tool, issueNumber: 1 }))).toBe(true);
+      expect(isHandoffBranch(branchName({ tool, issueNumber: 9999 }))).toBe(true);
+    }
+  });
+
+  it('accepts every pr-form branch from branchName()', () => {
+    for (const tool of ['claude', 'codex', 'copilot'] as const) {
+      expect(isHandoffBranch(branchName({ tool, prNumber: 42 }))).toBe(true);
+    }
+  });
+
+  it('accepts free-form slug branches that branchName + slugify could emit', () => {
+    // The contract is "isHandoffBranch is true iff branchName() could have
+    // produced this string". slugify() emits kebab-case; round-trip a
+    // representative sample of titles through both to pin the contract.
+    const titles = [
+      'Fix the README typo',
+      'cleanup-readme', // already-slugged
+      'feature 2 — something',
+      'Numbers 123 in title',
+    ];
+    for (const title of titles) {
+      const slug = slugify(title, { maxLen: 20 });
+      const branch = branchName({ tool: 'claude', slug });
+      expect(isHandoffBranch(branch)).toBe(true);
+    }
+  });
+
+  it('rejects an unrelated local branch name (the cleanup --force foot-gun)', () => {
+    // The codex-challenge finding: `handoff cleanup --force experiment`
+    // would have happily run `git branch -D experiment`. Refusal here
+    // is what stops it at the args layer.
+    expect(isHandoffBranch('experiment')).toBe(false);
+    expect(isHandoffBranch('main')).toBe(false);
+    expect(isHandoffBranch('dev')).toBe(false);
+    expect(isHandoffBranch('feature/login-redirect')).toBe(false);
+  });
+
+  it('rejects unknown tool prefixes', () => {
+    // Prevents future name collisions and "looks-like-a-handoff" typos.
+    expect(isHandoffBranch('cursor/issue-7')).toBe(false);
+    expect(isHandoffBranch('ai/issue-7')).toBe(false);
+  });
+
+  it('rejects malformed tails', () => {
+    expect(isHandoffBranch('claude/')).toBe(false); // empty tail
+    expect(isHandoffBranch('claude/-leading-dash')).toBe(false); // leading dash in slug
+    expect(isHandoffBranch('claude/trailing-dash-')).toBe(false); // trailing dash
+    expect(isHandoffBranch('claude/double--dash')).toBe(false); // slugify never emits these
+    expect(isHandoffBranch('claude/UPPERCASE')).toBe(false); // slugify lowercases
+    // Note: `claude/issue-abc` and `claude/issue-` are NOT in this list
+    // because they're valid *slug-form* branches (a user running
+    // `handoff claude "issue abc"` would slugify to `issue-abc`). The
+    // issue-form (`issue-<N>`) requires digits, but the slug alternation
+    // legitimately covers strings that visually look issue-like.
+  });
+
+  it('rejects empty / whitespace / leading or trailing slash', () => {
+    expect(isHandoffBranch('')).toBe(false);
+    expect(isHandoffBranch(' ')).toBe(false);
+    expect(isHandoffBranch('/claude/issue-7')).toBe(false);
+    expect(isHandoffBranch('claude/issue-7/')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses three of the seven findings from the v0.2.1 codex adversarial review (#62). The full finding-by-finding triage is in the commit message; what landed here:

**Cleanup safety scope (codex P1):** `handoff cleanup --force <any-branch>` previously ran `git branch -D <any-branch>` unconditionally, so a typo like `handoff cleanup --force experiment` destroyed unrelated local work. Add `isHandoffBranch()` in `src/branch.ts` that mirrors what `branchName()` produces (`<tool>/issue-<N>` | `<tool>/pr-<N>` | `<tool>/<slug>`); `args.ts` now refuses `--force` on anything else with a message pointing at `git branch -D` as the right tool when that's actually what the user wanted. Non-force cleanup stays permissive — the gh-merged-PR check is the safety property there.

**Doc accuracy (codex P2 × 2):**
- README:66 said all three tools run `<tool> "$(cat PROMPT.md)"`; now reflects the per-tool argv table (claude/codex positional, copilot `-i`).
- README:165 claimed "nothing else will trigger worktree removal" except merged PRs; now acknowledges `--force` and the new branch-shape guard.

**Implementation note:** `TOOLS` / `Tool` live in their own module (`src/tools.ts`), imported by both `args.ts` and `branch.ts`. An earlier iteration put them in `args.ts` and pulled them into `branch.ts` from there, which created a circular import that surfaced as `Cannot access 'ArgsError' before initialization` across 27 tests; the extraction broke the cycle, and `HANDOFF_BRANCH_RE` is now a top-level IIFE constant rather than the lazy builder the earlier draft needed as a workaround.

**Copilot review follow-ups in this PR:**
- 4b0ce74 — extract `TOOLS`/`Tool` to `src/tools.ts`; eliminate circular import; collapse lazy regex to top-level constant. Use `git branch -D -- <branch>` form in refusal hint.
- ec87a23 — drop the args.ts re-export of `TOOLS`/`Tool`; consumers (`cli.ts`, `prompt.ts`, `telemetry.ts`, `workspace.ts`) import from `./tools.ts` directly.
- 1209875 — POSIX-quote the rejected branch name in the refusal hint so copy/paste is safe for names containing shell metacharacters.

**Deferred to v0.3.0 follow-ups (codex findings not blocking v0.2.1):**
- PS .cmd shim `%*` re-parse hazard (real Windows hardening but pre-existing for all three tools, not a v0.2.1 regression)
- `--force` in tool-mode args parsing falls into free-form mode silently — typo trap
- Cross-platform trailing-newline drift between bash and pwsh runners

Closes #62.

## Test plan

- [x] `bun run test` — 229 pass / 0 fail (10 new isHandoffBranch cases, 4 new args.ts --force-rejection cases)
- [x] `bun run typecheck`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)