### PR TITLE
chore: merge v0.2.1 back + open v0.3.0-dev cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handoff",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Delegate a GitHub issue to claude, codex, or copilot in an isolated git worktree.",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handoff",
-  "version": "0.2.1",
+  "version": "0.3.0-dev",
   "description": "Delegate a GitHub issue to claude, codex, or copilot in an isolated git worktree.",
   "type": "module",
   "private": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for the package version, mirrored from package.json. */
-export const VERSION = '0.2.0';
+export const VERSION = '0.2.1';
 
 export const HELP = `handoff v${VERSION}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for the package version, mirrored from package.json. */
-export const VERSION = '0.2.1';
+export const VERSION = '0.3.0-dev';
 
 export const HELP = `handoff v${VERSION}
 


### PR DESCRIPTION
## Summary

Closes the v0.2.1 release and opens the v0.3.0 development cycle.

Two commits:

1. **`718b3ad chore(release): cut v0.2.1`** — the version-bump commit that was made on `release/v0.2.1` for the v0.2.1 cut. Merging it back here so dev's history contains the bump that ships in `handoff --version`. Fast-forward, no content change.
2. **`bd7d2ea chore(version): bump dev to 0.3.0-dev`** — opens the v0.3.0 cycle. `handoff --version` from dev now reports `0.3.0-dev` so users can tell they're running an unreleased build instead of the previous-shipped `0.2.0`.

### Background

The v0.2.0 release branch was cut from a pre-bumped dev (`b5b0bcf` bumped dev to `0.2.0` *before* `prerelease/v0.2.0` was created), so no merge-back was needed — dev already had the target value. For v0.2.1 the bump happened only on `release/v0.2.1`, leaving dev's `VERSION` stale at `0.2.0` even though dev's content matched the v0.2.1 shipping bits. This PR restores Brian's normal "merge release back" habit and gets us back to a clean baseline.

### Promotion path on the next release (for reference)

```
dev (0.3.0-dev)
  └─ prerelease/v0.3.0 (0.3.0-rc.1)
       └─ release/v0.3.0 (0.3.0)
```

## Test plan

- [x] `bun run test` — 229 pass / 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] CI green on ubuntu/macos/windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)