### PR TITLE
fix(args): reject --force in tool mode (#72)

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -272,6 +272,18 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
       i += 1;
       continue;
     }
+    // `--force` is a cleanup-only flag. Without this explicit rejection it
+    // would fall through to the free-form catch-all below, so a typo like
+    // `handoff claude --force #57` (intending `handoff cleanup --force
+    // claude/issue-57`) silently slugifies "--force #57" into a branch
+    // name and dispatches an agent with an unparseable prompt. Mirrors the
+    // --loop rejection pattern for non-claude tools.
+    if (tok === '--force') {
+      throw new ArgsError(
+        `'--force' is only valid for 'handoff cleanup'. ` +
+          `Did you mean 'handoff cleanup --force <branch>'?`,
+      );
+    }
     // Global flags consumed silently in scanning mode; main() reads them via
     // extractGlobalFlags() before this function is called.
     if (isGlobalFlag(tok!)) {

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -96,6 +96,48 @@ describe('parseInvocation', () => {
     });
   });
 
+  // #72: `handoff <tool> --force ...` used to slugify "--force <rest>" into a
+  // branch name and dispatch an agent with an unparseable prompt. The catch
+  // is that --force is a real flag (cleanup-only); rejecting it in tool mode
+  // mirrors the --loop rejection above.
+  it("rejects --force in tool mode (it's cleanup-only)", () => {
+    for (const tool of ['claude', 'codex', 'copilot'] as const) {
+      expect(() => parseInvocation([tool, '--force', '#1'])).toThrow(
+        /'--force' is only valid for 'handoff cleanup'/,
+      );
+    }
+  });
+
+  it('rejects --force in tool mode even with no other args', () => {
+    // Without --force a bare tool invocation throws "Missing reference"; the
+    // explicit --force rejection should preempt that since the user's intent
+    // was clearly the cleanup subcommand.
+    expect(() => parseInvocation(['claude', '--force'])).toThrow(
+      /'--force' is only valid for 'handoff cleanup'/,
+    );
+  });
+
+  it('keeps --force literal once free-form text has started', () => {
+    // Free-form catch-all wins as soon as a non-flag/non-ref token appears,
+    // so a description like "fix the --force flag" is preserved verbatim.
+    const out = parseInvocation(['claude', 'fix', 'the', '--force', 'flag']);
+    expect(out).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'freeform', text: 'fix the --force flag' }],
+      loop: false,
+    });
+  });
+
+  it('keeps a quoted --force literal in a free-form description', () => {
+    // Single quoted-string argv element — never matches the bare `--force` token.
+    const out = parseInvocation(['claude', 'fix the --force flag']);
+    expect(out).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'freeform', text: 'fix the --force flag' }],
+      loop: false,
+    });
+  });
+
   it('parses cleanup subcommand', () => {
     const out = parseInvocation(['cleanup', 'claude/issue-1']);
     expect(out).toEqual({ command: 'cleanup', branch: 'claude/issue-1', force: false });


### PR DESCRIPTION
## Summary

Closes #72.

`handoff <tool> --force ...` (a typo for `handoff cleanup --force ...`) previously slipped through the tool-mode parser's free-form catch-all and silently slugified `"--force <rest>"` into a branch name like `claude/-force-57`, dispatching an agent with an unparseable prompt. The user then had to clean up two artifacts (worktree + branch) and possibly revert agent work.

Reject the bare `--force` token explicitly in `parseInvocation`'s flag-or-ref scanning region, mirroring the existing `--loop` rejection pattern for non-claude tools. Once free-form mode begins (first non-flag/non-ref token), `--force` is still preserved verbatim, so `handoff claude "fix the --force flag"` still works.

## Acceptance criteria (from #72)

- [x] `handoff claude --force #1` throws ArgsError (exit 1) with a helpful message
- [x] Free-form descriptions can still contain `--force` as part of natural text
- [x] Test in `tests/args.test.ts` for both the rejection and the free-form preservation

## Test plan

- [x] `bun run test` — 233 pass / 0 fail (4 new cases)
- [x] `bun run typecheck`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)