### PR TITLE
harden(runner): keep PROMPT.md content out of argv (#71)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ When you add a new I/O module: pick a fixture from the matrix, follow the per-fi
 
 ## How to add a new adapter
 
-1. Add the tool string to `TOOLS` in `src/args.ts`.
+1. Add the tool string to `TOOLS` in `src/tools.ts` (the source of truth — `src/args.ts` and `src/branch.ts` both import it from there).
 2. Add the tool name to the per-tool invocation table in **both** `scripts/handoff-runner.sh` and `scripts/handoff-runner.ps1`, plus the `ValidateSet` in the latter. The runner scripts invoke the tool binary directly (currently the tool name == binary name) — but the argv shape differs per tool (see table below), so a new adapter must declare which shape it uses.
 3. Update `README.md` requirements list.
 4. Add a test for the new tool path in `tests/args.test.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,17 @@ When you add a new I/O module: pick a fixture from the matrix, follow the per-fi
 
 ### Per-tool invocation table
 
+The `<PROMPT>` slot is **not** PROMPT.md content — it's the fixed `RUNNER_META_PROMPT` string defined in `src/prompt.ts` (and mirrored as a literal in both runner scripts, with the integration tests asserting they agree). PROMPT.md content reaches the agent through its own file-read tool, not through argv; see "Why a fixed pointer" below.
+
 | Tool      | Argv shape            | Why                                                                                                                                                                                                                                                                                                                                           |
 | --------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `claude`  | `claude <PROMPT>`     | Accepts a positional `[prompt]` (interactive seeded session).                                                                                                                                                                                                                                                                                 |
 | `codex`   | `codex <PROMPT>`      | Same — `codex [OPTIONS] [PROMPT]`.                                                                                                                                                                                                                                                                                                            |
 | `copilot` | `copilot -i <PROMPT>` | A bare positional is parsed as a subcommand and exits silently (issue #57). `-i, --interactive <prompt>` "starts interactive mode and automatically executes this prompt" — same UX as the others. Avoid `-p/--prompt`: that's non-interactive and exits after completion, which would close the terminal before the user sees what happened. |
+
+### Why a fixed pointer instead of PROMPT.md content (issue #71)
+
+npm-installed agent CLIs on Windows ship as `.cmd` shims that do `node "...\app.js" %*`, and cmd.exe re-parses `%*` — newlines become command separators and `& | < > ^` are batch metacharacters. Passing untrusted PROMPT.md content (issue body / free-form description) through that re-parse is an argv-injection sink: a payload like `\n& echo OWNED >%TEMP%\handoff-owned` would break out as a second batch command. None of claude/codex/copilot expose a file-input or stdin-in-interactive-mode flag, so we keep PROMPT.md content out of argv entirely and let the agent read the file via its normal file-read tool (CWD is already the worktree root). Both runners use the same shape on POSIX too, even though POSIX shells don't have the same hazard — the consistency makes the contract simpler to reason about and one set of tests to maintain.
 
 ## The `.handoff/` workspace directory
 

--- a/scripts/handoff-runner.ps1
+++ b/scripts/handoff-runner.ps1
@@ -18,7 +18,17 @@ if (-not (Test-Path 'PROMPT.md')) {
   exit 1
 }
 
-$prompt = Get-Content -Path 'PROMPT.md' -Raw
+# Fixed pointer prompt — never pass PROMPT.md content through argv
+# (issue #71). On Windows, npm-installed agent CLIs ship as .cmd
+# shims that do `node "...\app.js" %*`, and cmd.exe re-parses %* with
+# newlines as command separators and `& | < > ^` as metacharacters.
+# A malicious PROMPT.md could break out as a batch command. We sidestep
+# the entire class by keeping PROMPT.md content out of argv and letting
+# the agent read the file via its own file-read tool. SOURCE OF TRUTH:
+# `RUNNER_META_PROMPT` in src/prompt.ts — keep this literal in sync;
+# the runner integration tests import the TS constant and assert this
+# exact string reaches the tool's argv.
+$metaPrompt = 'Your initial task is in PROMPT.md in this directory. Read it and follow it. It contains your task description and the workflow contract you must follow.'
 
 # Per-tool invocation table. claude and codex both accept a positional
 # [PROMPT] for interactive seeded sessions. copilot does NOT — it parses
@@ -28,8 +38,8 @@ $prompt = Get-Content -Path 'PROMPT.md' -Raw
 # When you add a new tool, mirror the change in handoff-runner.sh and
 # the per-tool table in CLAUDE.md ("How to add a new adapter").
 switch ($Tool) {
-  { $_ -in 'claude', 'codex' } { & $Tool $prompt }
-  'copilot' { & $Tool -i $prompt }
+  { $_ -in 'claude', 'codex' } { & $Tool $metaPrompt }
+  'copilot' { & $Tool -i $metaPrompt }
   default {
     Write-Error "handoff-runner: unknown tool '$Tool'"
     exit 64

--- a/scripts/handoff-runner.sh
+++ b/scripts/handoff-runner.sh
@@ -26,7 +26,19 @@ if [ ! -f "PROMPT.md" ]; then
   exit 1
 fi
 
-PROMPT="$(cat PROMPT.md)"
+# Fixed pointer prompt — never pass PROMPT.md content through argv
+# (issue #71). On Windows, npm-installed agent CLIs ship as .cmd
+# shims that do `node "...\app.js" %*`, and cmd.exe re-parses %* with
+# newlines as command separators and `& | < > ^` as metacharacters.
+# A malicious PROMPT.md could break out as a batch command. We sidestep
+# the entire class by keeping PROMPT.md content out of argv and letting
+# the agent read the file via its own file-read tool. POSIX shells
+# don't have the same hazard, but we use the same shape on both
+# runners for consistency. SOURCE OF TRUTH: `RUNNER_META_PROMPT` in
+# src/prompt.ts — keep this literal in sync; the runner integration
+# tests import the TS constant and assert this exact string reaches
+# the tool's argv.
+META_PROMPT="Your initial task is in PROMPT.md in this directory. Read it and follow it. It contains your task description and the workflow contract you must follow."
 
 # Per-tool invocation table. claude and codex both accept a positional
 # [PROMPT] for interactive seeded sessions. copilot does NOT — it parses
@@ -37,10 +49,10 @@ PROMPT="$(cat PROMPT.md)"
 # the per-tool table in CLAUDE.md ("How to add a new adapter").
 case "$TOOL" in
   claude|codex)
-    "$TOOL" "$PROMPT"
+    "$TOOL" "$META_PROMPT"
     ;;
   copilot)
-    "$TOOL" -i "$PROMPT"
+    "$TOOL" -i "$META_PROMPT"
     ;;
   *)
     echo "handoff-runner: unknown tool '$TOOL'" >&2

--- a/scripts/handoff-runner.sh
+++ b/scripts/handoff-runner.sh
@@ -6,9 +6,11 @@
 # lives) — NOT the user's project repo. The cwd of this script is the worktree
 # of the user's project; PROMPT.md sits there.
 #
-# Runs the chosen tool with PROMPT.md as the seed prompt, then on exit invokes
-# `bun <handoff-repo>/src/cli.ts cleanup <branch>` which removes the worktree
-# iff the PR has been merged.
+# Launches the chosen tool with a fixed RUNNER_META_PROMPT pointer string
+# (the agent reads PROMPT.md via its own file-read tool — see issue #71
+# and src/prompt.ts for why content never goes through argv). On exit
+# invokes `bun <handoff-repo>/src/cli.ts cleanup <branch>` which removes
+# the worktree iff the PR has been merged.
 
 set -uo pipefail
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,5 +1,27 @@
 import type { Tool } from './tools.ts';
 
+/**
+ * The fixed argv string the runner scripts pass to the agent CLI's
+ * interactive-seeded-prompt slot. The agent reads PROMPT.md (which is
+ * already in the worktree CWD) and proceeds from there.
+ *
+ * Why a fixed pointer instead of the file content (issue #71):
+ * npm-installed agent CLIs on Windows ship as `.cmd` shims that do
+ * `node "...\app.js" %*`, and cmd.exe re-parses %* — newlines split
+ * the command line and `& | < > ^` are batch metacharacters. Passing
+ * untrusted PROMPT.md content (issue body / free-form text) through
+ * that re-parse is an argv injection sink: a prompt containing
+ * `\n& echo OWNED >%TEMP%\handoff-owned` breaks out as a second batch
+ * command. None of claude/codex/copilot expose a file-input or
+ * stdin-in-interactive-mode flag, so we keep the prompt content out
+ * of argv entirely and route it through the agent's own file-read
+ * tool. This constant must match the hard-coded literal in both
+ * `scripts/handoff-runner.sh` and `scripts/handoff-runner.ps1`;
+ * the runner integration tests import it from here as the contract.
+ */
+export const RUNNER_META_PROMPT =
+  'Your initial task is in PROMPT.md in this directory. Read it and follow it. It contains your task description and the workflow contract you must follow.';
+
 export interface PromptContext {
   tool: Tool;
   repoName: string;

--- a/tests/runner-bash.integration.test.ts
+++ b/tests/runner-bash.integration.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 
+import { RUNNER_META_PROMPT } from '../src/prompt.ts';
 import {
   createRunnerHarness,
   findInterpreter,
@@ -236,9 +237,14 @@ describeBash('handoff-runner.sh', () => {
   // copilot needs `-i <prompt>` because a bare positional is parsed as
   // a subcommand and exits silently. The runner table is the source of
   // truth; these tests pin the contract.
+  //
+  // Since #71, the prompt slot carries the fixed RUNNER_META_PROMPT
+  // pointer instead of PROMPT.md content. The agent reads PROMPT.md
+  // via its own file-read tool in the worktree CWD. PROMPT.md content
+  // never reaches the tool's argv — which is what this test pins.
   for (const tool of ['claude', 'codex', 'copilot'] as const) {
     it(
-      `${tool}: runner passes PROMPT.md content with the right argv shape`,
+      `${tool}: runner passes RUNNER_META_PROMPT with the right argv shape`,
       () => {
         const promptBody = `# seed prompt for ${tool}\nDo the thing.\n`;
         harness = createRunnerHarness({
@@ -257,18 +263,60 @@ describeBash('handoff-runner.sh', () => {
         const calls = readArgvLog(harness.argvLogPath);
         expect(calls.length).toBe(1);
         const argv = calls[0]!;
-        // Trailing newlines are stripped: PROMPT="$(cat …)" drops
-        // them (POSIX-mandated for command substitution), so the tool
-        // sees the prompt without its final \n. Internal newlines are
-        // preserved verbatim.
-        const expected = promptBody.replace(/\n+$/, '');
         if (tool === 'copilot') {
-          expect(argv).toEqual(['-i', expected]);
+          expect(argv).toEqual(['-i', RUNNER_META_PROMPT]);
         } else {
-          expect(argv).toEqual([expected]);
+          expect(argv).toEqual([RUNNER_META_PROMPT]);
+        }
+        // Belt-and-suspenders: ensure PROMPT.md content didn't leak
+        // into argv via any path. If a future change re-introduces
+        // `$(cat PROMPT.md)`-style content passing, this catches it.
+        for (const a of argv) {
+          expect(a).not.toContain('seed prompt for');
+          expect(a).not.toContain('Do the thing');
         }
       },
       TIMEOUT_MS,
     );
   }
+
+  // #71: argv-injection regression guard. A PROMPT.md with cmd.exe
+  // metacharacters (& | < > ^ and newlines) used to break out as a
+  // batch command when piped through a `.cmd` shim's `%*` re-parse.
+  // The fix puts a fixed pointer string in argv and keeps PROMPT.md
+  // content out of the command line entirely. Even on bash (no
+  // re-parse hazard) we pin the same shape so a regression here
+  // is loud on every platform.
+  it(
+    'malicious PROMPT.md content stays out of the tool argv (#71)',
+    () => {
+      const malicious =
+        'title line\n& echo OWNED >/tmp/handoff-owned-bash-test\n' + 'plus | a < pipe > ^ caret\n';
+      harness = createRunnerHarness({
+        target: 'bash',
+        branch: 'claude/issue-71',
+        promptBody: malicious,
+      });
+
+      const result = runBashRunner(harness, {
+        tool: 'claude',
+        toolExit: 0,
+        ghPrListResponse: [{ number: 71 }],
+      });
+      expectExit(result, 0, 'bash #71 argv');
+
+      const calls = readArgvLog(harness.argvLogPath);
+      expect(calls.length).toBe(1);
+      const argv = calls[0]!;
+      expect(argv).toEqual([RUNNER_META_PROMPT]);
+      // Distinctive substrings of the attack payload must NOT appear
+      // anywhere in the argv the tool actually saw.
+      for (const a of argv) {
+        expect(a).not.toContain('OWNED');
+        expect(a).not.toContain('handoff-owned-bash-test');
+        expect(a).not.toContain('caret');
+      }
+    },
+    TIMEOUT_MS,
+  );
 });

--- a/tests/runner-ps1.integration.test.ts
+++ b/tests/runner-ps1.integration.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { platform } from 'node:os';
 
+import { RUNNER_META_PROMPT } from '../src/prompt.ts';
 import {
   createRunnerHarness,
   findInterpreter,
@@ -213,16 +214,13 @@ describePwsh('handoff-runner.ps1', () => {
   // silently. Mirrors the bash matrix; runs against the .ps1 runner so
   // a divergence between the two scripts trips here.
   //
-  // Prompt body is intentionally single-line: the shim chain on Windows
-  // is `pwsh → .cmd → bun → fake-tool-impl.ts`, and `%*` in a .cmd file
-  // is reparsed by cmd.exe, where newlines act as command separators
-  // and truncate multi-line args. Production calls real `copilot.exe`,
-  // which parses its own Win32 command line and is unaffected. The
-  // contract we're pinning is per-tool argv shape (positional vs `-i`),
-  // not multi-line prompt preservation.
+  // Since #71, the prompt slot carries the fixed RUNNER_META_PROMPT
+  // pointer string (single-line, ASCII-safe) instead of PROMPT.md
+  // content. PROMPT.md content stays out of the .cmd shim's `%*`
+  // re-parse — that's the safety property this test pins.
   for (const tool of ['claude', 'codex', 'copilot'] as const) {
     it(
-      `${tool}: runner passes PROMPT.md content with the right argv shape`,
+      `${tool}: runner passes RUNNER_META_PROMPT with the right argv shape`,
       () => {
         const promptBody = `seed prompt for ${tool}`;
         harness = createRunnerHarness({
@@ -242,12 +240,57 @@ describePwsh('handoff-runner.ps1', () => {
         expect(calls.length).toBe(1);
         const argv = calls[0]!;
         if (tool === 'copilot') {
-          expect(argv).toEqual(['-i', promptBody]);
+          expect(argv).toEqual(['-i', RUNNER_META_PROMPT]);
         } else {
-          expect(argv).toEqual([promptBody]);
+          expect(argv).toEqual([RUNNER_META_PROMPT]);
+        }
+        // Belt-and-suspenders: PROMPT.md content didn't leak into argv.
+        for (const a of argv) {
+          expect(a).not.toContain('seed prompt for');
         }
       },
       TIMEOUT_MS,
     );
   }
+
+  // #71: argv-injection regression guard. On Windows, npm-installed
+  // agent CLIs ship as `.cmd` shims that do `node "...\app.js" %*`,
+  // and cmd.exe re-parses %* — newlines are command separators and
+  // `& | < > ^` are batch metacharacters. PROMPT.md content piped
+  // through that re-parse could break out (e.g. `\n& echo OWNED ...`).
+  // The fix routes the prompt content through the file system (agent
+  // reads PROMPT.md via its file-read tool) and puts a fixed pointer
+  // in argv. This test runs the exact attack payload through the PS
+  // runner and asserts the tool's argv contains only the meta-prompt.
+  it(
+    'malicious PROMPT.md content stays out of the tool argv (#71)',
+    () => {
+      const malicious =
+        'title line\r\n& echo OWNED >%TEMP%\\handoff-owned-pwsh-test\r\n' +
+        'plus | a < pipe > ^ caret\r\n';
+      harness = createRunnerHarness({
+        target: 'pwsh',
+        branch: 'claude/issue-71',
+        promptBody: malicious,
+      });
+
+      const result = runPwshRunner(harness, {
+        tool: 'claude',
+        toolExit: 0,
+        ghPrListResponse: [{ number: 71 }],
+      });
+      expectExit(result, 0, 'pwsh #71 argv');
+
+      const calls = readArgvLog(harness.argvLogPath);
+      expect(calls.length).toBe(1);
+      const argv = calls[0]!;
+      expect(argv).toEqual([RUNNER_META_PROMPT]);
+      for (const a of argv) {
+        expect(a).not.toContain('OWNED');
+        expect(a).not.toContain('handoff-owned-pwsh-test');
+        expect(a).not.toContain('caret');
+      }
+    },
+    TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

Closes #71.

On Windows, npm-installed agent CLIs ship as `.cmd` shims that do `node "...\app.js" %*`, and cmd.exe re-parses `%*` — newlines become command separators and `& | < > ^` are batch metacharacters. Passing untrusted PROMPT.md content (issue body / free-form description) through that re-parse is an argv-injection sink: a payload like `\n& echo OWNED >%TEMP%\handoff-owned` breaks out as a second batch command.

## Investigation

Probed each tool's CLI for a safer input path:

| Tool      | Interactive prompt source | File-input flag | Stdin (interactive)? |
| --------- | ------------------------- | --------------- | -------------------- |
| `claude`  | Positional `[prompt]`     | None            | No (needs TTY)       |
| `codex`   | Positional `[PROMPT]`     | None            | No (needs TTY)       |
| `copilot` | `-i <prompt>`             | None            | No                   |

Issue options 1 (file flag) and 2 (stdin) both require tool-side support we don't have. Option 3 (sanitize/refuse) doesn't fit — newlines are the breakout vector and every prompt has them.

## Fix

Stop passing PROMPT.md content as the prompt argv. Pass a fixed, single-line, ASCII-only pointer string instead (`RUNNER_META_PROMPT` in `src/prompt.ts`):

> Your initial task is in PROMPT.md in this directory. Read it and follow it. It contains your task description and the workflow contract you must follow.

The agent reads PROMPT.md via its own file-read tool in the worktree CWD. PROMPT.md content never reaches cmd.exe's parser, so the entire class of argv-injection-via-shim disappears. No per-tool engineering, no shim parsing, no escape ceremonies.

Both runners (bash + ps1) use the same shape for consistency, even though POSIX shells don't have the re-parse hazard — same fixture, simpler mental model.

## Source-of-truth pinning

`RUNNER_META_PROMPT` is exported from `src/prompt.ts`. Both runner scripts hard-code the matching literal with comments pointing at the TS constant. The runner integration tests `import { RUNNER_META_PROMPT }` and assert it appears verbatim in the tool's argv — so a drift between TS and either runner trips loudly on every push.

## Acceptance criteria (from #71)

- [x] PowerShell runner does not pass PROMPT.md content through `.cmd` shim re-parse — argv is a fixed ASCII pointer string.
- [x] Bash runner does not regress — same fixed pointer (POSIX wasn't vulnerable but is now also auditable).
- [x] Test that asserts PROMPT.md containing `& echo OWNED ...` does NOT reach the tool's argv. Two of them, one per runner.

## Test plan

- [x] `bun run test` — 235 pass / 0 fail (2 new #71 argv-injection regression tests, plus belt-and-suspenders content-leak checks on the existing per-tool shape tests)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Smoke-tested locally on Windows (pwsh)
- [ ] CI green on ubuntu/macos/windows

## Out of scope (filed separately)

This obsoletes #73 — the bash-vs-ps1 trailing-newline drift in PROMPT.md becomes irrelevant once neither runner reads PROMPT.md into argv. Will close #73 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)