### PR TITLE
feat(args): default tool to claude when omitted (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Delegate a GitHub issue (or a free-form task) to **`claude`**, **`codex`**, or **`copilot`** in an isolated git worktree, with a generated `PROMPT.md` as the starting context. The agent works to completion (commits, push, PR) in its own terminal window. When the PR merges, the worktree self-cleans.
 
 ```
-/handoff codex #1
+/handoff #1                       # claude (default) on issue #1
+/handoff codex #1                 # explicit tool
 /handoff copilot Issue #2
-/handoff claude #3 #4 #5          # fleet — three parallel worktrees
-/handoff claude "fix login redirect bug"
+/handoff #3 #4 #5                 # fleet — three parallel claude worktrees
+/handoff "fix login redirect bug" # free-form, default tool
 ```
 
 ## Why
@@ -54,39 +55,45 @@ Pass `--no-link` to skip the CLI link and install only the slash command. Re-run
 ### Single issue
 
 ```bash
-handoff claude #42
+handoff #42          # claude is the default tool
+handoff claude #42   # equivalent — explicit
+handoff codex #42    # different agent
 ```
 
 This:
 
 1. Resolves the GitHub issue title + body via `gh issue view 42`.
-2. Creates branch `claude/issue-42` off the repo's default branch.
+2. Creates branch `<tool>/issue-42` off the repo's default branch (e.g. `claude/issue-42`).
 3. Adds a worktree as a sibling directory: `<repo-parent>/<repo>-issue-42`.
 4. Writes `PROMPT.md` to the worktree with the issue, the branch, and a workflow contract.
-5. Spawns a new terminal window in that worktree and runs the chosen tool with the prompt — `claude "$(cat PROMPT.md)"` and `codex "$(cat PROMPT.md)"` for those two; `copilot -i "$(cat PROMPT.md)"` for copilot (its CLI parses bare positionals as subcommands, so the `-i` flag is required to seed an interactive session). The per-tool argv table lives in `scripts/handoff-runner.{sh,ps1}`.
+5. Spawns a new terminal window in that worktree and runs the chosen tool, instructing the agent to read `PROMPT.md` and follow it. (The agent reads the file via its own file tool rather than receiving the content via argv; see `src/prompt.ts` and issue #71 for why.) The per-tool argv table lives in `scripts/handoff-runner.{sh,ps1}`.
 
 The agent does the work, commits, pushes, opens a PR. When it exits, the wrapper checks `gh pr list --head <branch> --state merged` — if the PR has merged, the worktree and branch are removed.
 
 ### Fleet
 
 ```bash
-handoff claude #1 #2 #3
+handoff #1 #2 #3
 ```
 
-Three independent worktrees + three terminal windows, in parallel. Each opens its own PR.
+Three independent worktrees + three terminal windows, in parallel. Each opens its own PR. Add a tool prefix (`handoff codex #1 #2 #3`) to use a different agent.
 
 ### Free-form
 
 ```bash
+handoff "tighten error messages in the API client"
 handoff codex "tighten error messages in the API client"
 ```
 
-No issue lookup. The text is passed as the task description in `PROMPT.md`. The branch becomes `codex/<short-slug>` (slug capped at 20 chars).
+No issue lookup. The text is passed as the task description in `PROMPT.md`. The branch becomes `<tool>/<short-slug>` (slug capped at 20 chars).
+
+> **Quote free-form descriptions to avoid typo ambiguity.** Without quotes, an unquoted typo like `handoff calude #1` is treated as a free-form task ("calude #1") for the default tool instead of erroring on the unknown tool name. Quoting (`handoff "calude #1"`) makes the intent explicit; the bare-token form is convenient when you mean it.
 
 ### Loop mode (`--loop`, claude only)
 
 ```bash
-handoff claude --loop #7
+handoff --loop #7        # default tool is claude, so this is fine
+handoff claude --loop #7 # equivalent
 ```
 
 By default the agent stops the moment `gh pr create` returns. With `--loop`, the prompt instructs Claude Code to **stay resident** after the PR is open and self-drive the review cycle:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ handoff codex "tighten error messages in the API client"
 
 No issue lookup. The text is passed as the task description in `PROMPT.md`. The branch becomes `<tool>/<short-slug>` (slug capped at 20 chars).
 
-> **Quote free-form descriptions to avoid typo ambiguity.** Without quotes, an unquoted typo like `handoff calude #1` is treated as a free-form task ("calude #1") for the default tool instead of erroring on the unknown tool name. Quoting (`handoff "calude #1"`) makes the intent explicit; the bare-token form is convenient when you mean it.
+> **Quote free-form descriptions to avoid typo ambiguity.** A leading token that isn't a known tool name (`claude` / `codex` / `copilot`) or subcommand (`cleanup` / `telemetry`) parses as the start of a free-form description for the default tool. So an unquoted typo like `handoff calude #1` becomes the free-form task `"calude #1"` (for claude) instead of being caught. Quoting intentional free-form (`handoff "fix the bug"`) makes the intent unambiguous.
 
 ### Loop mode (`--loop`, claude only)
 
@@ -142,7 +142,7 @@ Both write to stderr so they don't pollute scriptable stdout. They can sit befor
 | Code | Meaning                                                                  |
 | ---- | ------------------------------------------------------------------------ |
 | `0`  | success                                                                  |
-| `1`  | user error — bad args, unknown tool, unauthenticated `gh`                |
+| `1`  | user error — bad args, missing reference, unauthenticated `gh`           |
 | `2`  | operational failure — worktree already exists, `git`/`gh` command failed |
 | `3`  | internal / unexpected error                                              |
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,4 +1,4 @@
-import { TOOLS, type Tool } from './tools.ts';
+import { DEFAULT_TOOL, TOOLS, type Tool } from './tools.ts';
 
 export interface IssueRef {
   kind: 'issue';
@@ -117,13 +117,20 @@ export function extractGlobalFlags(argv: readonly string[]): { verbose: boolean;
     i++;
   }
 
-  // Skip the tool/command name token.
   if (i >= argv.length) return { verbose, debug };
-  const head = argv[i];
-  i++;
+  const head = argv[i]!;
+
+  // Only consume the head token when it's a real tool name or a
+  // subcommand. With the default-tool support (issue #58), a leading
+  // ref like `#7` or a free-form word IS the first ref; the ref-scan
+  // loop below must see it.
+  const isSubcommand = head === 'cleanup' || head === 'telemetry';
+  if (isTool(head) || isSubcommand) {
+    i++;
+  }
 
   // No free-form mode under cleanup / telemetry — scan the whole tail.
-  if (head === 'cleanup' || head === 'telemetry') {
+  if (isSubcommand) {
     while (i < argv.length) {
       const tok = argv[i]!;
       if (tok === '--verbose') verbose = true;
@@ -180,7 +187,8 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
 
   if (trimmed.length === 0) {
     throw new ArgsError(
-      'No arguments provided. Usage: handoff <tool> <ref...> | handoff cleanup <branch>',
+      `No arguments provided. Usage: handoff [<tool>] <ref...> | handoff cleanup <branch> ` +
+        `(<tool> defaults to ${DEFAULT_TOOL}).`,
     );
   }
 
@@ -243,17 +251,31 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     return parseTelemetry(stripGlobalFlags(trimmed.slice(1)));
   }
 
-  if (!isTool(head)) {
-    throw new ArgsError(
-      `Unknown tool '${head}'. Expected one of: ${TOOLS.join(', ')}, 'cleanup', or 'telemetry'.`,
-    );
+  // Default-tool resolution (#58): if argv[0] isn't a known tool name,
+  // treat the whole trimmed argv as the refs region and use DEFAULT_TOOL.
+  // Subcommands (`cleanup`, `telemetry`) were already matched above; we
+  // intentionally don't refuse "unknown tool" anymore — the dominant case
+  // is bare `handoff #N` (claude implied), so any non-tool head becomes
+  // part of the refs/free-form region. Side-effect: `handoff calude #1`
+  // (typo) parses as free-form text "calude #1" instead of erroring.
+  // Documented in README; quoting the description (`handoff "<task>"`)
+  // is the recommended way to disambiguate intentional free-form from
+  // a tool-name typo.
+  let tool: Tool;
+  let rest: string[];
+  if (isTool(head)) {
+    tool = head;
+    rest = trimmed.slice(1);
+  } else {
+    tool = DEFAULT_TOOL;
+    rest = [...trimmed];
   }
 
-  const rest = trimmed.slice(1);
   if (rest.length === 0) {
     throw new ArgsError(
-      `Missing reference. Usage: handoff ${head} <ref...> ` +
-        `(<ref> = #N, "Issue #N", or a free-form task description).`,
+      `Missing reference. Usage: handoff [<tool>] <ref...> ` +
+        `(<tool> defaults to ${DEFAULT_TOOL}; ` +
+        `<ref> = #N, "Issue #N", or a free-form task description).`,
     );
   }
 
@@ -305,21 +327,21 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     break;
   }
 
-  if (loop && head !== 'claude') {
+  if (loop && tool !== 'claude') {
     throw new ArgsError(
-      `--loop is only supported for the 'claude' tool (got '${head}'). ` +
+      `--loop is only supported for the 'claude' tool (got '${tool}'). ` +
         `codex and copilot run as ephemeral sessions and don't support staying resident for review cycles.`,
     );
   }
 
   if (refs.length === 0) {
     throw new ArgsError(
-      `Missing reference. Usage: handoff ${head} <ref...> ` +
+      `Missing reference. Usage: handoff ${tool} <ref...> ` +
         `(<ref> = #N, "Issue #N", or a free-form task description).`,
     );
   }
 
-  return { tool: head, refs, loop };
+  return { tool, refs, loop };
 }
 
 function isTelemetrySubcommand(value: string): value is TelemetrySubcommand {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,29 @@
+import { DEFAULT_TOOL } from './tools.ts';
+
 /** Single source of truth for the package version, mirrored from package.json. */
 export const VERSION = '0.3.0-dev';
+
+// Build the TOOLS section with a `(default when omitted)` marker on the
+// row that matches DEFAULT_TOOL. Centralizes the default so a future
+// change to DEFAULT_TOOL (or to its source in #20's config work) doesn't
+// require a parallel edit to HELP. Two-space gap before the marker
+// matches the existing column rhythm in this section.
+const TOOL_ROWS: Record<string, string> = {
+  claude: '  claude    Anthropic Claude Code CLI',
+  codex: '  codex     OpenAI Codex CLI',
+  copilot: '  copilot   GitHub Copilot CLI',
+};
+const TOOLS_SECTION = Object.entries(TOOL_ROWS)
+  .map(([tool, row]) => (tool === DEFAULT_TOOL ? `${row}  (default when omitted)` : row))
+  .join('\n');
 
 export const HELP = `handoff v${VERSION}
 
 USAGE
   handoff [<tool>] <ref...>        spawn a worktree per ref and launch <tool>
-                                   (<tool> defaults to claude when omitted)
-  handoff [claude] [--loop] <ref...>
-                                   claude (or default): stay resident through review (see FLAGS)
+                                   (<tool> defaults to ${DEFAULT_TOOL} when omitted)
+  handoff [${DEFAULT_TOOL}] [--loop] <ref...>
+                                   ${DEFAULT_TOOL} (or default): stay resident through review (see FLAGS)
   handoff cleanup [--force] <branch>
                                    remove a worktree if its PR has merged
                                    (--force skips the merge check; see FLAGS)
@@ -16,9 +32,7 @@ USAGE
   handoff --version                show version
 
 TOOLS
-  claude    Anthropic Claude Code CLI  (default when omitted)
-  codex     OpenAI Codex CLI
-  copilot   GitHub Copilot CLI
+${TOOLS_SECTION}
 
 REFS
   #N             a GitHub issue number (resolved via \`gh issue view\`)
@@ -54,10 +68,10 @@ TELEMETRY
                                                 populate it)
 
 EXAMPLES
-  handoff #1                                 # claude (default) on issue #1
+  handoff #1                                 # ${DEFAULT_TOOL} (default) on issue #1
   handoff codex #1                           # explicit tool
   handoff copilot Issue #2
-  handoff #1 #2 #3                           # fleet: 3 parallel claude worktrees
+  handoff #1 #2 #3                           # fleet: 3 parallel ${DEFAULT_TOOL} worktrees
   handoff --loop #7                          # implement and self-drive review
   handoff "tidy up the README"               # free-form, default tool
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,7 @@ EXAMPLES
 
 EXIT CODES
   0  success
-  1  user error (bad args, unknown tool, unauthenticated gh)
+  1  user error (bad args, missing reference, unauthenticated gh)
   2  operational failure (worktree exists, git/gh command failed)
   3  internal / unexpected error
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,10 @@ export const VERSION = '0.3.0-dev';
 export const HELP = `handoff v${VERSION}
 
 USAGE
-  handoff <tool> <ref...>          spawn a worktree per ref and launch <tool>
-  handoff claude [--loop] <ref...> claude only: stay resident through review (see FLAGS)
+  handoff [<tool>] <ref...>        spawn a worktree per ref and launch <tool>
+                                   (<tool> defaults to claude when omitted)
+  handoff [claude] [--loop] <ref...>
+                                   claude (or default): stay resident through review (see FLAGS)
   handoff cleanup [--force] <branch>
                                    remove a worktree if its PR has merged
                                    (--force skips the merge check; see FLAGS)
@@ -14,7 +16,7 @@ USAGE
   handoff --version                show version
 
 TOOLS
-  claude    Anthropic Claude Code CLI
+  claude    Anthropic Claude Code CLI  (default when omitted)
   codex     OpenAI Codex CLI
   copilot   GitHub Copilot CLI
 
@@ -52,11 +54,12 @@ TELEMETRY
                                                 populate it)
 
 EXAMPLES
-  handoff codex #1
+  handoff #1                                 # claude (default) on issue #1
+  handoff codex #1                           # explicit tool
   handoff copilot Issue #2
-  handoff claude #1 #2 #3                    # fleet: 3 parallel worktrees
-  handoff claude --loop #7                   # implement and self-drive review
-  handoff claude "tidy up the README"
+  handoff #1 #2 #3                           # fleet: 3 parallel claude worktrees
+  handoff --loop #7                          # implement and self-drive review
+  handoff "tidy up the README"               # free-form, default tool
 
 EXIT CODES
   0  success

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TOOL } from './tools.ts';
+import { DEFAULT_TOOL, type Tool } from './tools.ts';
 
 /** Single source of truth for the package version, mirrored from package.json. */
 export const VERSION = '0.3.0-dev';
@@ -7,13 +7,15 @@ export const VERSION = '0.3.0-dev';
 // row that matches DEFAULT_TOOL. Centralizes the default so a future
 // change to DEFAULT_TOOL (or to its source in #20's config work) doesn't
 // require a parallel edit to HELP. Two-space gap before the marker
-// matches the existing column rhythm in this section.
-const TOOL_ROWS: Record<string, string> = {
+// matches the existing column rhythm in this section. `satisfies
+// Record<Tool, string>` makes adding a new entry to TOOLS in
+// src/tools.ts without a matching row here a compile error.
+const TOOL_ROWS = {
   claude: '  claude    Anthropic Claude Code CLI',
   codex: '  codex     OpenAI Codex CLI',
   copilot: '  copilot   GitHub Copilot CLI',
-};
-const TOOLS_SECTION = Object.entries(TOOL_ROWS)
+} satisfies Record<Tool, string>;
+const TOOLS_SECTION = (Object.entries(TOOL_ROWS) as [Tool, string][])
   .map(([tool, row]) => (tool === DEFAULT_TOOL ? `${row}  (default when omitted)` : row))
   .join('\n');
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,2 +1,12 @@
 export const TOOLS = ['claude', 'codex', 'copilot'] as const;
 export type Tool = (typeof TOOLS)[number];
+
+/**
+ * Tool used when `<tool>` is omitted from the command line
+ * (e.g. `handoff #5` → `handoff claude #5`). Claude is the dominant
+ * use case, so optimizing for the bare invocation is the win.
+ * Configurable default lives in #20's broader config-surface work —
+ * when that lands, this constant becomes the fallback for users
+ * with no override set.
+ */
+export const DEFAULT_TOOL: Tool = 'claude';

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -202,8 +202,78 @@ describe('parseInvocation', () => {
     });
   });
 
-  it('rejects unknown tool', () => {
-    expect(() => parseInvocation(['bard', '#1'])).toThrow(ArgsError);
+  // #58: default-tool resolution — bare `handoff #N` / `handoff <free-form>`
+  // dispatches to claude. The previous "Unknown tool" hard refusal is gone:
+  // any non-tool, non-subcommand argv[0] is now the start of the refs
+  // region for DEFAULT_TOOL. See the docs/README for the typo trade-off.
+  it('defaults to claude when the tool is omitted with a #N ref', () => {
+    expect(parseInvocation(['#5'])).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'issue', number: 5 }],
+      loop: false,
+    });
+  });
+
+  it('defaults to claude when omitted with an "Issue N" ref', () => {
+    expect(parseInvocation(['Issue', '5'])).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'issue', number: 5 }],
+      loop: false,
+    });
+  });
+
+  it('defaults to claude when omitted with multiple #N refs', () => {
+    expect(parseInvocation(['#1', '#2', '#3'])).toEqual({
+      tool: 'claude',
+      refs: [
+        { kind: 'issue', number: 1 },
+        { kind: 'issue', number: 2 },
+        { kind: 'issue', number: 3 },
+      ],
+      loop: false,
+    });
+  });
+
+  it('defaults to claude for a quoted free-form description', () => {
+    expect(parseInvocation(['fix the readme typo'])).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'freeform', text: 'fix the readme typo' }],
+      loop: false,
+    });
+  });
+
+  it('defaults to claude for a multi-token free-form description', () => {
+    // `handoff fix the readme typo` — argv[0] isn't a tool, so the whole
+    // argv joins into the free-form description for the default tool.
+    expect(parseInvocation(['fix', 'the', 'readme', 'typo'])).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'freeform', text: 'fix the readme typo' }],
+      loop: false,
+    });
+  });
+
+  it('accepts --loop with the default tool', () => {
+    // The --loop rejection guard is "loop && tool !== 'claude'" — and the
+    // default tool IS claude, so --loop works in bare invocations.
+    expect(parseInvocation(['--loop', '#7'])).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'issue', number: 7 }],
+      loop: true,
+    });
+  });
+
+  it('a typo for a tool name parses as free-form (documented trade-off)', () => {
+    // `handoff calude #1` is unfortunately not detected as a typo for
+    // `claude` — it parses as free-form "calude #1" for the default tool.
+    // README documents quoting (`handoff "<task>"`) as the way to keep
+    // intent unambiguous. This test pins the trade-off so a future
+    // typo-guard PR has to update both the behavior and this test
+    // together.
+    expect(parseInvocation(['calude', '#1'])).toEqual({
+      tool: 'claude',
+      refs: [{ kind: 'freeform', text: 'calude #1' }],
+      loop: false,
+    });
   });
 
   it('rejects empty argv', () => {

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -489,4 +489,42 @@ describe('extractGlobalFlags', () => {
       extractGlobalFlags(['telemetry', 'enable', '--verbose', '--endpoint', 'https://x.test/t']),
     ).toEqual({ verbose: true, debug: false });
   });
+
+  // #58: extractGlobalFlags must handle invocations where the tool token is
+  // omitted (argv[0] is a ref or free-form word). The function decides
+  // whether to consume argv[0] based on isTool/isSubcommand, so the
+  // omitted-tool case feeds the head into the ref-scan loop.
+  it('detects --verbose before an omitted-tool #N ref', () => {
+    // handoff --verbose #1   → claude (default), --verbose extracted
+    expect(extractGlobalFlags(['--verbose', '#1'])).toEqual({
+      verbose: true,
+      debug: false,
+    });
+  });
+
+  it('detects --debug after an omitted-tool #N ref', () => {
+    // handoff #1 --debug   → claude (default), --debug extracted from refs region
+    expect(extractGlobalFlags(['#1', '--debug'])).toEqual({
+      verbose: false,
+      debug: true,
+    });
+  });
+
+  it('does NOT detect --verbose embedded in an omitted-tool free-form description', () => {
+    // handoff fix the --verbose flag   → claude (default), free-form starts
+    // at "fix"; --verbose inside the description must not toggle logging.
+    expect(extractGlobalFlags(['fix', 'the', '--verbose', 'flag'])).toEqual({
+      verbose: false,
+      debug: false,
+    });
+  });
+
+  it('detects --verbose before omitted-tool free-form starts', () => {
+    // handoff --verbose fix the --verbose flag   → --verbose before "fix"
+    // is a flag; --verbose after is free-form text.
+    expect(extractGlobalFlags(['--verbose', 'fix', 'the', '--verbose', 'flag'])).toEqual({
+      verbose: true,
+      debug: false,
+    });
+  });
 });

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -205,7 +205,8 @@ describe('parseInvocation', () => {
   // #58: default-tool resolution — bare `handoff #N` / `handoff <free-form>`
   // dispatches to claude. The previous "Unknown tool" hard refusal is gone:
   // any non-tool, non-subcommand argv[0] is now the start of the refs
-  // region for DEFAULT_TOOL. See the docs/README for the typo trade-off.
+  // region for DEFAULT_TOOL. See README.md ("Free-form" section) for the
+  // typo trade-off and the recommended quoting habit.
   it('defaults to claude when the tool is omitted with a #N ref', () => {
     expect(parseInvocation(['#5'])).toEqual({
       tool: 'claude',


### PR DESCRIPTION
## Summary

Closes #58.

Makes the `<tool>` positional optional. `handoff #5` now does what `handoff claude #5` did. The dominant use case (claude) gets the shorthand; other tools stay explicit.

```
handoff #1                    # claude (default) on issue #1
handoff #1 #2 #3              # fleet, claude
handoff "fix the typo"        # free-form, claude
handoff --loop #7             # --loop with default-tool claude
handoff codex #5              # explicit tool, unchanged
handoff cleanup foo           # subcommand path, unchanged
```

## `DEFAULT_TOOL`

Lives in `src/tools.ts` alongside `TOOLS` / `Tool` (single source of truth for tool registration). Per #58's "decide on one config surface" requirement: configurability is **deferred to #20** (broader `.handoffrc.json` / env-var / package.json surface decision). The constant becomes the fallback for unconfigured users once that lands; this PR ships only the constant.

## Trade-off: no typo guard

A leading token that isn't a known tool/subcommand parses as free-form for the default tool — so `handoff calude #1` becomes a free-form description (`"calude #1"`) for claude rather than erroring on the typo. README documents this and recommends quoting (`handoff "<task>"`) for intentional free-form. A pinned test in `tests/args.test.ts` documents the trade-off so any future typo-guard PR has to update both behavior and test together.

## Acceptance criteria (from #58)

- [x] `parseInvocation` accepts a leading ref token without a tool prefix
- [x] Default tool defined in one place (`src/tools.ts`)
- [x] Tests for: bare `#N`, bare "Issue N", multi-ref, free-form, multi-token free-form, `--loop` with default, typo trade-off (7 new cases)
- [x] Configurability decision made (deferred to #20; constant ships for v0.3.0)
- [x] README + help text updated; CLAUDE.md didn't need touching (no tool-prefix usage examples there)

## Test plan

- [x] `bun run test` — 241 pass / 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] CI green on ubuntu/macos/windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)