### PR TITLE
feat(cli): handoff doctor — preflight environment check (#27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@
 | `src/git.ts`                 | `git` wrappers: worktree create/remove, branch ops                        | I/O   |
 | `src/terminal.ts`            | Platform-aware terminal spawn (`buildLaunchSpec` is pure)                 | mixed |
 | `src/cleanup.ts`             | PR-merged check → remove worktree + branch                                | I/O   |
+| `src/doctor.ts`              | Preflight environment checks (bun/git/gh/auth/terminal/tools)             | mixed |
 | `src/run.ts`                 | `spawn` wrapper with structured errors                                    | I/O   |
 | `src/workspace.ts`           | `.handoff/state.json` read/write + schema-version guard                   | I/O   |
 | `src/telemetry.ts`           | `~/.handoff/config.json`, event constructors, fire-and-forget emit        | mixed |
@@ -65,6 +66,7 @@ When you add a new I/O module: pick a fixture from the matrix, follow the per-fi
 3. Update `README.md` requirements list.
 4. Add a test for the new tool path in `tests/args.test.ts`.
 5. Add a per-tool argv-shape case to `tests/runner-bash.integration.test.ts` and `tests/runner-ps1.integration.test.ts` so the contract is pinned end-to-end.
+6. Add a per-tool install hint to `HINTS` in `src/doctor.ts` so `handoff doctor` can point users at where to install the new agent.
 
 ### Per-tool invocation table
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Pass `--no-link` to skip the CLI link and install only the slash command. Re-run
 
 > **Restart Claude Code after installing.** Slash commands under `~/.claude/commands/` are read at session start, so any sessions that were already open won't see `/handoff` until they're restarted.
 
+### Verify the install
+
+```bash
+handoff doctor          # checks bun, git, gh, gh auth, terminal, all agents
+handoff doctor claude   # narrow the per-tool check to one agent
+handoff doctor --json   # machine-readable
+```
+
+Exit code is `0` when every error-severity check passes (warnings are informational and don't fail the run). Run this first thing after install to surface missing prereqs before they ambush a real handoff.
+
 ## Usage
 
 ### Single issue

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Pass `--no-link` to skip the CLI link and install only the slash command. Re-run
 ### Verify the install
 
 ```bash
-handoff doctor          # checks bun, git, gh, gh auth, terminal, all agents
+handoff doctor          # checks bun, git, gh, gh auth, git working tree, terminal, all agents
 handoff doctor claude   # narrow the per-tool check to one agent
 handoff doctor --json   # machine-readable
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Pass `--no-link` to skip the CLI link and install only the slash command. Re-run
 ### Verify the install
 
 ```bash
-handoff doctor          # checks bun, git, gh, gh auth, git working tree, terminal, all agents
+handoff doctor          # checks bun, git, gh, gh auth, git working tree, terminal + shell, all agents
 handoff doctor claude   # narrow the per-tool check to one agent
 handoff doctor --json   # machine-readable
 ```

--- a/src/args.ts
+++ b/src/args.ts
@@ -40,7 +40,19 @@ export type TelemetryArgs =
   | { command: 'telemetry'; sub: 'status' }
   | { command: 'telemetry'; sub: 'log' };
 
-export type CliInvocation = ParsedArgs | CleanupArgs | TelemetryArgs;
+export interface DoctorArgs {
+  command: 'doctor';
+  /**
+   * Tools to include in the per-tool PATH check. Empty list means "all
+   * known tools" — `handoff doctor` alone checks everything; `handoff
+   * doctor claude` narrows the tool check to just claude.
+   */
+  tools: Tool[];
+  /** Emit a machine-readable JSON report to stdout instead of plain text. */
+  json: boolean;
+}
+
+export type CliInvocation = ParsedArgs | CleanupArgs | TelemetryArgs | DoctorArgs;
 
 import { HandoffError } from './errors.ts';
 import { isHandoffBranch } from './branch.ts';
@@ -124,12 +136,12 @@ export function extractGlobalFlags(argv: readonly string[]): { verbose: boolean;
   // subcommand. With the default-tool support (issue #58), a leading
   // ref like `#7` or a free-form word IS the first ref; the ref-scan
   // loop below must see it.
-  const isSubcommand = head === 'cleanup' || head === 'telemetry';
+  const isSubcommand = head === 'cleanup' || head === 'telemetry' || head === 'doctor';
   if (isTool(head) || isSubcommand) {
     i++;
   }
 
-  // No free-form mode under cleanup / telemetry — scan the whole tail.
+  // No free-form mode under cleanup / telemetry / doctor — scan the whole tail.
   if (isSubcommand) {
     while (i < argv.length) {
       const tok = argv[i]!;
@@ -249,6 +261,36 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     // Same reasoning as cleanup: telemetry has no free-form mode, so global
     // flags can be filtered out anywhere in the subcommand args.
     return parseTelemetry(stripGlobalFlags(trimmed.slice(1)));
+  }
+
+  if (head === 'doctor') {
+    // Same scanning model as cleanup/telemetry: no free-form mode, so global
+    // flags + the doctor-specific `--json` flag can appear anywhere in the
+    // tail. Positionals are zero or more tool names (`claude` / `codex` /
+    // `copilot`); the bare invocation checks all known tools.
+    const tail = stripGlobalFlags(trimmed.slice(1));
+    let json = false;
+    const tools: Tool[] = [];
+    const seen = new Set<Tool>();
+    for (const tok of tail) {
+      if (tok === '--json') {
+        json = true;
+        continue;
+      }
+      if (isTool(tok)) {
+        // De-dup so `handoff doctor claude claude` runs the check once.
+        if (!seen.has(tok)) {
+          seen.add(tok);
+          tools.push(tok);
+        }
+        continue;
+      }
+      throw new ArgsError(
+        `Unknown argument '${tok}' to 'handoff doctor'. ` +
+          `Expected zero or more of: ${TOOLS.join(', ')} (optionally '--json').`,
+      );
+    }
+    return { command: 'doctor', tools, json };
   }
 
   // Default-tool resolution (#58): if argv[0] isn't a known tool name,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,9 +8,11 @@ import {
   ArgsError,
   extractGlobalFlags,
   parseInvocation,
+  type DoctorArgs,
   type Ref,
   type TelemetryArgs,
 } from './args.ts';
+import { formatReport, runDoctor } from './doctor.ts';
 import type { Tool } from './tools.ts';
 import { HandoffError } from './errors.ts';
 import { setDebug, setVerbose, verbose } from './logger.ts';
@@ -94,6 +96,9 @@ async function main(rawArgv: readonly string[]): Promise<number> {
     if (invocation.command === 'telemetry') {
       return await runTelemetry(invocation);
     }
+    if (invocation.command === 'doctor') {
+      return await runDoctorCommand(invocation);
+    }
     showFirstRunBanner();
     return await runCleanup(invocation.branch, invocation.force);
   }
@@ -167,6 +172,24 @@ function safeReadState(path: string) {
   } catch {
     return null;
   }
+}
+
+async function runDoctorCommand(invocation: DoctorArgs): Promise<number> {
+  const report = await runDoctor({ tools: invocation.tools });
+  if (invocation.json) {
+    // Stable, sorted-keys output so test snapshots and downstream
+    // consumers (CI gates, dashboards) don't churn on field-order
+    // changes. Two-space indent matches the rest of our JSON outputs
+    // (.handoff/state.json, ~/.handoff/config.json).
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatReport(report));
+  }
+  // Warnings don't bump the exit code — only error-severity failures
+  // do, matching the issue #27 acceptance criteria. Exit 1 is the
+  // "user error" category (missing prereqs, unauthenticated gh), which
+  // is exactly what doctor surfaces.
+  return report.errors > 0 ? 1 : 0;
 }
 
 async function runTelemetry(invocation: TelemetryArgs): Promise<number> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,10 +177,13 @@ function safeReadState(path: string) {
 async function runDoctorCommand(invocation: DoctorArgs): Promise<number> {
   const report = await runDoctor({ tools: invocation.tools });
   if (invocation.json) {
-    // Stable, sorted-keys output so test snapshots and downstream
-    // consumers (CI gates, dashboards) don't churn on field-order
-    // changes. Two-space indent matches the rest of our JSON outputs
-    // (.handoff/state.json, ~/.handoff/config.json).
+    // Two-space indent matches the rest of our JSON outputs
+    // (.handoff/state.json, ~/.handoff/config.json). Field order is
+    // the construction order in src/doctor.ts (CheckResult), which is
+    // stable across releases — JSON.stringify preserves insertion order
+    // for plain objects, so consumers can rely on `name`/`severity`/
+    // `status`/`message`/`hint` always appearing in that sequence
+    // without us doing any explicit key sort.
     console.log(JSON.stringify(report, null, 2));
   } else {
     console.log(formatReport(report));

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,9 @@ USAGE
   handoff cleanup [--force] <branch>
                                    remove a worktree if its PR has merged
                                    (--force skips the merge check; see FLAGS)
+  handoff doctor [<tool>...] [--json]
+                                   preflight environment check; with no
+                                   <tool>, checks all known agents
   handoff telemetry <subcommand>   manage opt-in usage telemetry (see TELEMETRY)
   handoff --help                   show this message
   handoff --version                show version

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,323 @@
+import { run, RunError } from './run.ts';
+import { TOOLS, type Tool } from './tools.ts';
+
+export type Severity = 'error' | 'warning';
+export type CheckStatus = 'pass' | 'fail';
+
+export interface CheckResult {
+  /** Stable machine identifier (kebab-case, used as `--json` key). */
+  name: string;
+  /**
+   * Whether a fail here is a hard error (bumps the process exit code)
+   * or a warning (informational; exit 0 still possible).
+   */
+  severity: Severity;
+  status: CheckStatus;
+  /** Human-readable result line, with the discovered value if any. */
+  message: string;
+  /** What the user should do if `status === 'fail'`. Omitted on pass. */
+  hint?: string;
+}
+
+/**
+ * Dependency-injection seam for the per-check probes. Each check is a
+ * pure async function over this interface, so tests stub the probe
+ * and assert the CheckResult without spawning real subprocesses.
+ *
+ * Default impl: `defaultProbe()` below uses Bun.which + `run.ts`.
+ */
+export interface DoctorProbe {
+  /** Resolve `cmd` on PATH. Returns the absolute path or null. */
+  which(cmd: string): Promise<string | null>;
+  /** Run `cmd args` and capture exit code + streams. Never throws. */
+  invoke(
+    cmd: string,
+    args: readonly string[],
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  platform: NodeJS.Platform;
+}
+
+export function defaultProbe(): DoctorProbe {
+  return {
+    async which(cmd) {
+      return Bun.which(cmd) ?? null;
+    },
+    async invoke(cmd, args) {
+      try {
+        return await run(cmd, [...args]);
+      } catch (err) {
+        if (err instanceof RunError) {
+          return { stdout: err.stdout, stderr: err.stderr, exitCode: err.exitCode };
+        }
+        return {
+          stdout: '',
+          stderr: err instanceof Error ? err.message : String(err),
+          exitCode: -1,
+        };
+      }
+    },
+    platform: process.platform,
+  };
+}
+
+const MIN_BUN_VERSION = '1.1.0';
+
+function parseSemver(s: string): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(s.trim());
+  if (!m || m[1] === undefined || m[2] === undefined || m[3] === undefined) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function gte(actual: [number, number, number], min: [number, number, number]): boolean {
+  for (let i = 0; i < 3; i++) {
+    if (actual[i]! > min[i]!) return true;
+    if (actual[i]! < min[i]!) return false;
+  }
+  return true;
+}
+
+export type CheckFn = (probe: DoctorProbe) => Promise<CheckResult>;
+
+async function checkBunOnPath(probe: DoctorProbe): Promise<CheckResult> {
+  const path = await probe.which('bun');
+  if (!path) {
+    return {
+      name: 'bun-on-path',
+      severity: 'error',
+      status: 'fail',
+      message: '`bun` not found on PATH',
+      hint: 'Install bun: https://bun.sh',
+    };
+  }
+  const versionRun = await probe.invoke('bun', ['--version']);
+  const parsed = parseSemver(versionRun.stdout);
+  const min = parseSemver(MIN_BUN_VERSION)!;
+  if (versionRun.exitCode !== 0 || !parsed) {
+    return {
+      name: 'bun-on-path',
+      severity: 'error',
+      status: 'fail',
+      message: `bun found at ${path} but \`bun --version\` failed (exit ${versionRun.exitCode})`,
+      hint: 'Reinstall bun or check that the binary is not corrupted.',
+    };
+  }
+  const actual = `${parsed[0]}.${parsed[1]}.${parsed[2]}`;
+  if (!gte(parsed, min)) {
+    return {
+      name: 'bun-on-path',
+      severity: 'error',
+      status: 'fail',
+      message: `bun ${actual} found at ${path}, but handoff requires >=${MIN_BUN_VERSION}`,
+      hint: `Upgrade bun to >=${MIN_BUN_VERSION}: \`bun upgrade\` or reinstall from https://bun.sh`,
+    };
+  }
+  return {
+    name: 'bun-on-path',
+    severity: 'error',
+    status: 'pass',
+    message: `bun ${actual} at ${path}`,
+  };
+}
+
+async function checkGitOnPath(probe: DoctorProbe): Promise<CheckResult> {
+  const path = await probe.which('git');
+  if (!path) {
+    return {
+      name: 'git-on-path',
+      severity: 'error',
+      status: 'fail',
+      message: '`git` not found on PATH',
+      hint: 'Install git: https://git-scm.com/downloads',
+    };
+  }
+  return {
+    name: 'git-on-path',
+    severity: 'error',
+    status: 'pass',
+    message: `git at ${path}`,
+  };
+}
+
+async function checkGhOnPath(probe: DoctorProbe): Promise<CheckResult> {
+  const path = await probe.which('gh');
+  if (!path) {
+    return {
+      name: 'gh-on-path',
+      severity: 'error',
+      status: 'fail',
+      message: '`gh` not found on PATH',
+      hint: 'Install GitHub CLI: https://cli.github.com',
+    };
+  }
+  return {
+    name: 'gh-on-path',
+    severity: 'error',
+    status: 'pass',
+    message: `gh at ${path}`,
+  };
+}
+
+async function checkGhAuth(probe: DoctorProbe): Promise<CheckResult> {
+  const result = await probe.invoke('gh', ['auth', 'status']);
+  if (result.exitCode === 0) {
+    return {
+      name: 'gh-auth',
+      severity: 'error',
+      status: 'pass',
+      message: 'gh is authenticated',
+    };
+  }
+  return {
+    name: 'gh-auth',
+    severity: 'error',
+    status: 'fail',
+    message: 'gh is not authenticated',
+    hint: 'Run `gh auth login` and complete the browser flow.',
+  };
+}
+
+async function checkInsideGitRepo(probe: DoctorProbe): Promise<CheckResult> {
+  const result = await probe.invoke('git', ['rev-parse', '--is-inside-work-tree']);
+  if (result.exitCode === 0 && result.stdout.trim() === 'true') {
+    return {
+      name: 'inside-git-repo',
+      severity: 'error',
+      status: 'pass',
+      message: 'cwd is inside a git working tree',
+    };
+  }
+  return {
+    name: 'inside-git-repo',
+    severity: 'error',
+    status: 'fail',
+    message: 'cwd is not inside a git working tree',
+    hint: "cd into a git repo before running handoff. (handoff dispatches issues from the caller's repo.)",
+  };
+}
+
+async function checkTerminal(probe: DoctorProbe): Promise<CheckResult> {
+  const candidates =
+    probe.platform === 'win32'
+      ? ['wt', 'cmd']
+      : probe.platform === 'darwin'
+        ? ['osascript']
+        : ['gnome-terminal', 'konsole', 'xterm'];
+
+  const found: string[] = [];
+  for (const c of candidates) {
+    if (await probe.which(c)) found.push(c);
+  }
+  if (found.length === 0) {
+    return {
+      name: 'terminal',
+      severity: 'warning',
+      status: 'fail',
+      message: `no terminal emulator detected (tried: ${candidates.join(', ')})`,
+      hint: 'Install one of the supported terminals, or open the agent in your existing terminal manually.',
+    };
+  }
+  return {
+    name: 'terminal',
+    severity: 'warning',
+    status: 'pass',
+    message: `terminal emulator: ${found[0]} (also available: ${found.slice(1).join(', ') || 'none'})`,
+  };
+}
+
+function checkTool(tool: Tool): CheckFn {
+  return async (probe) => {
+    const path = await probe.which(tool);
+    if (!path) {
+      return {
+        name: `tool-${tool}`,
+        severity: 'error',
+        status: 'fail',
+        message: `\`${tool}\` not found on PATH`,
+        hint: HINTS[tool],
+      };
+    }
+    return {
+      name: `tool-${tool}`,
+      severity: 'error',
+      status: 'pass',
+      message: `${tool} at ${path}`,
+    };
+  };
+}
+
+const HINTS: Record<Tool, string> = {
+  claude: 'Install Claude Code: https://docs.anthropic.com/en/docs/agents-and-tools/claude-code',
+  codex: 'Install Codex CLI: https://github.com/openai/codex',
+  copilot:
+    'Install GitHub Copilot CLI: https://docs.github.com/en/copilot/github-copilot-in-the-cli',
+};
+
+const COMMON_CHECKS: readonly CheckFn[] = [
+  checkBunOnPath,
+  checkGitOnPath,
+  checkGhOnPath,
+  checkGhAuth,
+  checkInsideGitRepo,
+  checkTerminal,
+];
+
+export interface DoctorOptions {
+  /**
+   * Tools to include in the per-tool PATH checks. Empty list means
+   * "all known tools" (the bare `handoff doctor` invocation).
+   */
+  tools: readonly Tool[];
+}
+
+export interface DoctorReport {
+  results: CheckResult[];
+  errors: number;
+  warnings: number;
+  passed: number;
+}
+
+export async function runDoctor(
+  opts: DoctorOptions,
+  probe: DoctorProbe = defaultProbe(),
+): Promise<DoctorReport> {
+  const toolList = opts.tools.length === 0 ? [...TOOLS] : opts.tools;
+  const checks: CheckFn[] = [...COMMON_CHECKS, ...toolList.map(checkTool)];
+
+  const results: CheckResult[] = [];
+  for (const check of checks) {
+    results.push(await check(probe));
+  }
+
+  let errors = 0;
+  let warnings = 0;
+  let passed = 0;
+  for (const r of results) {
+    if (r.status === 'pass') {
+      passed++;
+    } else if (r.severity === 'error') {
+      errors++;
+    } else {
+      warnings++;
+    }
+  }
+  return { results, errors, warnings, passed };
+}
+
+export function formatReport(report: DoctorReport): string {
+  const lines: string[] = [];
+  for (const r of report.results) {
+    const glyph = r.status === 'pass' ? '[ ok ]' : r.severity === 'error' ? '[fail]' : '[warn]';
+    lines.push(`${glyph} ${r.message}`);
+    if (r.status === 'fail' && r.hint) {
+      lines.push(`       hint: ${r.hint}`);
+    }
+  }
+  lines.push('');
+  const summary: string[] = [];
+  summary.push(`${report.passed} passed`);
+  if (report.errors > 0) summary.push(`${report.errors} error${report.errors === 1 ? '' : 's'}`);
+  if (report.warnings > 0)
+    summary.push(`${report.warnings} warning${report.warnings === 1 ? '' : 's'}`);
+  lines.push(summary.join(', '));
+  return lines.join('\n');
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -255,16 +255,24 @@ async function checkTerminal(probe: DoctorProbe): Promise<CheckResult> {
       hint: 'Install one of the supported terminals, or open the agent in your existing terminal manually.',
     };
   }
+  // On darwin, openTerminalOn dispatches to Terminal.app via osascript
+  // — `osascript` is the launcher we probe, but the user-facing
+  // terminal emulator is Terminal.app. On win32/linux the probed name
+  // IS the emulator, so we surface it directly.
+  const primary =
+    probe.platform === 'darwin' && found[0] === 'osascript'
+      ? 'Terminal.app via osascript'
+      : found[0];
   return {
     name: 'terminal',
     severity: 'warning',
     status: 'pass',
-    message: `terminal emulator: ${found[0]} (also available: ${found.slice(1).join(', ') || 'none'})`,
+    message: `terminal emulator: ${primary} (also available: ${found.slice(1).join(', ') || 'none'})`,
   };
 }
 
 /**
- * The inner shell each terminal launcher exec's to actually run the
+ * The inner shell each terminal launcher execs to actually run the
  * runner script. Mirror what `buildLaunchSpec` in src/terminal.ts uses:
  *   win32 → `powershell.exe -NoExit -File <runner.ps1>`
  *   darwin → `bash <runner.sh>` (via osascript)

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -263,6 +263,41 @@ async function checkTerminal(probe: DoctorProbe): Promise<CheckResult> {
   };
 }
 
+/**
+ * The inner shell each terminal launcher exec's to actually run the
+ * runner script. Mirror what `buildLaunchSpec` in src/terminal.ts uses:
+ *   win32 → `powershell.exe -NoExit -File <runner.ps1>`
+ *   darwin → `bash <runner.sh>` (via osascript)
+ *   linux → `bash <runner.sh>`
+ * If the inner shell is missing, the terminal window opens and immediately
+ * fails — the launch succeeds at the OS level but the runner never starts.
+ * Splitting this off from `terminal` (the launcher check) means each
+ * failure mode gets a distinct line in the report and consumers can
+ * pin them independently via the `name` field.
+ */
+async function checkTerminalShell(probe: DoctorProbe): Promise<CheckResult> {
+  const shell = probe.platform === 'win32' ? 'powershell.exe' : 'bash';
+  const path = await probe.which(shell);
+  if (!path) {
+    return {
+      name: 'terminal-shell',
+      severity: 'warning',
+      status: 'fail',
+      message: `terminal shell missing — \`${shell}\` not on PATH`,
+      hint:
+        probe.platform === 'win32'
+          ? 'PowerShell ships with Windows; if it is missing, the WindowsApps PATH entry is likely broken — restore it from System Properties → Environment Variables.'
+          : 'Install bash (the runner scripts target POSIX bash).',
+    };
+  }
+  return {
+    name: 'terminal-shell',
+    severity: 'warning',
+    status: 'pass',
+    message: `terminal shell: ${shell} at ${path}`,
+  };
+}
+
 function checkTool(tool: Tool): CheckFn {
   return async (probe) => {
     const path = await probe.which(tool);
@@ -298,6 +333,7 @@ const COMMON_CHECKS: readonly CheckFn[] = [
   checkGhAuth,
   checkInsideGitRepo,
   checkTerminal,
+  checkTerminalShell,
 ];
 
 export interface DoctorOptions {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -5,7 +5,13 @@ export type Severity = 'error' | 'warning';
 export type CheckStatus = 'pass' | 'fail';
 
 export interface CheckResult {
-  /** Stable machine identifier (kebab-case, used as `--json` key). */
+  /**
+   * Stable machine identifier (kebab-case). Surfaced verbatim in the
+   * `--json` output so consumers (CI gates, dashboards) can pin a
+   * specific check by name. The JSON shape is a flat array of these
+   * records under `results[]`, not a map keyed by name — duplicate
+   * names would be a bug, but the format is array-of-objects.
+   */
   name: string;
   /**
    * Whether a fail here is a hard error (bumps the process exit code)
@@ -158,6 +164,25 @@ async function checkGhOnPath(probe: DoctorProbe): Promise<CheckResult> {
 }
 
 async function checkGhAuth(probe: DoctorProbe): Promise<CheckResult> {
+  // Short-circuit if gh isn't on PATH — otherwise the `gh auth status`
+  // spawn fails with exitCode -1 and we'd report a misleading "gh is
+  // not authenticated" alongside the upstream `gh-on-path` error.
+  // Status stays 'fail' so the doctor surface flags the missing prereq,
+  // but the message tells the user the real cause and we skip the
+  // `gh auth login` hint (which presumes gh is installed). Severity
+  // stays 'error' for consistency with the rest of the gh checks; the
+  // total error count reflects two distinct fail lines (one per check),
+  // which is the intended granularity — fixing one doesn't fix the other.
+  const gh = await probe.which('gh');
+  if (!gh) {
+    return {
+      name: 'gh-auth',
+      severity: 'error',
+      status: 'fail',
+      message: 'cannot check gh auth — gh not on PATH',
+      hint: 'See the `gh-on-path` check above.',
+    };
+  }
   const result = await probe.invoke('gh', ['auth', 'status']);
   if (result.exitCode === 0) {
     return {
@@ -177,6 +202,20 @@ async function checkGhAuth(probe: DoctorProbe): Promise<CheckResult> {
 }
 
 async function checkInsideGitRepo(probe: DoctorProbe): Promise<CheckResult> {
+  // Same short-circuit pattern as gh-auth: if git isn't on PATH, the
+  // rev-parse spawn fails with exit -1 and "not inside a working tree"
+  // would be misleading. Surface the real cause and let the user fix
+  // the upstream `git-on-path` failure first.
+  const git = await probe.which('git');
+  if (!git) {
+    return {
+      name: 'inside-git-repo',
+      severity: 'error',
+      status: 'fail',
+      message: 'cannot check git working tree — git not on PATH',
+      hint: 'See the `git-on-path` check above.',
+    };
+  }
   const result = await probe.invoke('git', ['rev-parse', '--is-inside-work-tree']);
   if (result.exitCode === 0 && result.stdout.trim() === 'true') {
     return {

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -143,6 +143,74 @@ describe('parseInvocation', () => {
     expect(out).toEqual({ command: 'cleanup', branch: 'claude/issue-1', force: false });
   });
 
+  // #27: doctor subcommand
+  it('parses bare `doctor` as all-tools, plain-text', () => {
+    expect(parseInvocation(['doctor'])).toEqual({
+      command: 'doctor',
+      tools: [],
+      json: false,
+    });
+  });
+
+  it('parses `doctor <tool>` as single-tool filter', () => {
+    expect(parseInvocation(['doctor', 'claude'])).toEqual({
+      command: 'doctor',
+      tools: ['claude'],
+      json: false,
+    });
+  });
+
+  it('parses multi-tool doctor invocations', () => {
+    expect(parseInvocation(['doctor', 'claude', 'codex'])).toEqual({
+      command: 'doctor',
+      tools: ['claude', 'codex'],
+      json: false,
+    });
+  });
+
+  it('parses `doctor --json` (flag before tools)', () => {
+    expect(parseInvocation(['doctor', '--json'])).toEqual({
+      command: 'doctor',
+      tools: [],
+      json: true,
+    });
+  });
+
+  it('parses `doctor <tool> --json` (flag after tools)', () => {
+    // Same position-independence as cleanup's --force; doctor has no
+    // free-form mode so --json can sit anywhere in the tail.
+    expect(parseInvocation(['doctor', 'claude', '--json'])).toEqual({
+      command: 'doctor',
+      tools: ['claude'],
+      json: true,
+    });
+  });
+
+  it('deduplicates repeated tool args under doctor', () => {
+    // `handoff doctor claude claude` would otherwise run the per-tool
+    // check twice and double-count any failure. De-dup at parse time.
+    expect(parseInvocation(['doctor', 'claude', 'claude'])).toEqual({
+      command: 'doctor',
+      tools: ['claude'],
+      json: false,
+    });
+  });
+
+  it('rejects unknown positional args to doctor', () => {
+    expect(() => parseInvocation(['doctor', 'bard'])).toThrow(
+      /Unknown argument 'bard' to 'handoff doctor'/,
+    );
+  });
+
+  it('strips --verbose anywhere in doctor args', () => {
+    // Global flags can interleave with doctor args (cleanup pattern).
+    expect(parseInvocation(['doctor', '--verbose', 'claude', '--json'])).toEqual({
+      command: 'doctor',
+      tools: ['claude'],
+      json: true,
+    });
+  });
+
   it('parses cleanup --force <branch>', () => {
     const out = parseInvocation(['cleanup', '--force', 'claude/issue-1']);
     expect(out).toEqual({ command: 'cleanup', branch: 'claude/issue-1', force: true });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -73,7 +73,7 @@ describe('runDoctor', () => {
   });
 
   it('narrows the per-tool checks when tools is non-empty', async () => {
-    // `handoff doctor claude` → 6 common + 1 tool. The other two tools
+    // `handoff doctor claude` → 7 common + 1 tool. The other two tools
     // are not checked even if they happen to be missing.
     const probe = fakeProbe({
       ...{
@@ -217,6 +217,23 @@ describe('individual checks', () => {
     expect(term.status).toBe('pass');
     expect(term.message).toContain('gnome-terminal');
     expect(term.message).toContain('xterm');
+  });
+
+  it('terminal: darwin label is "Terminal.app via osascript", not "osascript"', async () => {
+    // The probe binary is osascript, but the emulator the user sees
+    // is Terminal.app — openTerminalOn dispatches to it via
+    // `tell application "Terminal" to do script ...`. Pin the
+    // user-facing label so the doctor output matches the CLI's actual
+    // launch model.
+    const probe = fakeProbe({
+      paths: { osascript: '/usr/bin/osascript', bash: '/bin/bash' },
+      platform: 'darwin',
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const term = report.results.find((r) => r.name === 'terminal')!;
+    expect(term.status).toBe('pass');
+    expect(term.message).toContain('Terminal.app via osascript');
+    expect(term.message).not.toMatch(/terminal emulator: osascript\b/);
   });
 
   it('terminal-shell: missing bash on linux → warning', async () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'bun:test';
+
+import { defaultProbe, formatReport, runDoctor, type DoctorProbe } from '../src/doctor.ts';
+
+interface ProbeOpts {
+  /** Map of cmd → resolved path. Missing key = which() returns null. */
+  paths?: Record<string, string>;
+  /**
+   * Map of `cmd args.join(' ')` → run result. Missing key returns
+   * exit -1 (simulating spawn failure / not on PATH).
+   */
+  runs?: Record<string, { exitCode: number; stdout?: string; stderr?: string }>;
+  platform?: NodeJS.Platform;
+}
+
+function fakeProbe(opts: ProbeOpts = {}): DoctorProbe {
+  return {
+    async which(cmd) {
+      return opts.paths?.[cmd] ?? null;
+    },
+    async invoke(cmd, args) {
+      const key = [cmd, ...args].join(' ');
+      const r = opts.runs?.[key];
+      if (!r) return { exitCode: -1, stdout: '', stderr: `not in fixture: ${key}` };
+      return { exitCode: r.exitCode, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    },
+    platform: opts.platform ?? 'linux',
+  };
+}
+
+// All-pass fixture used as a baseline — individual tests then drop one
+// expectation at a time to exercise the per-check failure paths.
+function happyProbe(): DoctorProbe {
+  return fakeProbe({
+    paths: {
+      bun: '/usr/local/bin/bun',
+      git: '/usr/bin/git',
+      gh: '/usr/local/bin/gh',
+      'gnome-terminal': '/usr/bin/gnome-terminal',
+      claude: '/home/u/.local/bin/claude',
+      codex: '/home/u/.local/bin/codex',
+      copilot: '/home/u/.local/bin/copilot',
+    },
+    runs: {
+      'bun --version': { exitCode: 0, stdout: '1.2.21\n' },
+      'gh auth status': { exitCode: 0, stdout: 'Logged in to github.com\n' },
+      'git rev-parse --is-inside-work-tree': { exitCode: 0, stdout: 'true\n' },
+    },
+    platform: 'linux',
+  });
+}
+
+describe('runDoctor', () => {
+  it('reports all-pass on a fully provisioned environment', async () => {
+    const report = await runDoctor({ tools: [] }, happyProbe());
+    expect(report.errors).toBe(0);
+    expect(report.warnings).toBe(0);
+    // 6 common + 3 tools = 9 checks total when tools=[] (all tools).
+    expect(report.passed).toBe(9);
+    expect(report.results.map((r) => r.name)).toEqual([
+      'bun-on-path',
+      'git-on-path',
+      'gh-on-path',
+      'gh-auth',
+      'inside-git-repo',
+      'terminal',
+      'tool-claude',
+      'tool-codex',
+      'tool-copilot',
+    ]);
+  });
+
+  it('narrows the per-tool checks when tools is non-empty', async () => {
+    // `handoff doctor claude` → 6 common + 1 tool. The other two tools
+    // are not checked even if they happen to be missing.
+    const probe = fakeProbe({
+      ...{
+        paths: {
+          bun: '/usr/local/bin/bun',
+          git: '/usr/bin/git',
+          gh: '/usr/local/bin/gh',
+          'gnome-terminal': '/usr/bin/gnome-terminal',
+          claude: '/home/u/.local/bin/claude',
+          // codex + copilot intentionally absent
+        },
+        runs: {
+          'bun --version': { exitCode: 0, stdout: '1.2.21\n' },
+          'gh auth status': { exitCode: 0, stdout: 'ok' },
+          'git rev-parse --is-inside-work-tree': { exitCode: 0, stdout: 'true' },
+        },
+      },
+    });
+    const report = await runDoctor({ tools: ['claude'] }, probe);
+    expect(report.errors).toBe(0);
+    expect(report.passed).toBe(7);
+    expect(report.results.map((r) => r.name).filter((n) => n.startsWith('tool-'))).toEqual([
+      'tool-claude',
+    ]);
+  });
+});
+
+describe('individual checks', () => {
+  it('bun missing → error', async () => {
+    const probe = fakeProbe({});
+    const report = await runDoctor({ tools: [] }, probe);
+    const bun = report.results.find((r) => r.name === 'bun-on-path')!;
+    expect(bun.status).toBe('fail');
+    expect(bun.severity).toBe('error');
+    expect(bun.hint).toMatch(/bun\.sh/);
+  });
+
+  it('bun present but below minimum version → error', async () => {
+    const probe = fakeProbe({
+      paths: { bun: '/usr/local/bin/bun' },
+      runs: { 'bun --version': { exitCode: 0, stdout: '1.0.5\n' } },
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const bun = report.results.find((r) => r.name === 'bun-on-path')!;
+    expect(bun.status).toBe('fail');
+    expect(bun.message).toContain('1.0.5');
+    expect(bun.message).toContain('>=1.1.0');
+  });
+
+  it('bun present and version OK → pass', async () => {
+    const probe = fakeProbe({
+      paths: { bun: '/usr/local/bin/bun' },
+      runs: { 'bun --version': { exitCode: 0, stdout: '1.2.21\n' } },
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const bun = report.results.find((r) => r.name === 'bun-on-path')!;
+    expect(bun.status).toBe('pass');
+    expect(bun.message).toMatch(/bun 1\.2\.21 at /);
+  });
+
+  it('gh unauthenticated → error with `gh auth login` hint', async () => {
+    const probe = fakeProbe({
+      paths: { gh: '/usr/local/bin/gh' },
+      runs: { 'gh auth status': { exitCode: 1, stderr: 'You are not logged in.' } },
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const auth = report.results.find((r) => r.name === 'gh-auth')!;
+    expect(auth.status).toBe('fail');
+    expect(auth.hint).toMatch(/gh auth login/);
+  });
+
+  it('not inside a git working tree → error', async () => {
+    const probe = fakeProbe({
+      paths: { git: '/usr/bin/git' },
+      runs: {
+        'git rev-parse --is-inside-work-tree': {
+          exitCode: 128,
+          stderr: 'fatal: not a git repository',
+        },
+      },
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const repo = report.results.find((r) => r.name === 'inside-git-repo')!;
+    expect(repo.status).toBe('fail');
+    expect(repo.hint).toMatch(/cd into a git repo/);
+  });
+
+  it('no terminal emulator → warning, not error', async () => {
+    // Warnings don't bump the exit code — pin that contract.
+    const probe = fakeProbe({ platform: 'linux' });
+    const report = await runDoctor({ tools: [] }, probe);
+    const term = report.results.find((r) => r.name === 'terminal')!;
+    expect(term.status).toBe('fail');
+    expect(term.severity).toBe('warning');
+    expect(report.warnings).toBeGreaterThan(0);
+    // The errors counter still reflects missing bun/git/gh, but the
+    // terminal failure itself is a warning.
+  });
+
+  it('terminal report names the first-available candidate', async () => {
+    // Mirror openTerminal()'s fallback chain: when both gnome-terminal
+    // and xterm exist, gnome-terminal wins. (Pinning the order here
+    // means changing src/terminal.ts's candidates list trips this
+    // test, prompting a doctor update to match.)
+    const probe = fakeProbe({
+      paths: {
+        'gnome-terminal': '/usr/bin/gnome-terminal',
+        xterm: '/usr/bin/xterm',
+      },
+      platform: 'linux',
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const term = report.results.find((r) => r.name === 'terminal')!;
+    expect(term.status).toBe('pass');
+    expect(term.message).toContain('gnome-terminal');
+    expect(term.message).toContain('xterm');
+  });
+
+  it('tool missing → error with install URL hint', async () => {
+    const probe = fakeProbe({});
+    const report = await runDoctor({ tools: ['claude'] }, probe);
+    const tool = report.results.find((r) => r.name === 'tool-claude')!;
+    expect(tool.status).toBe('fail');
+    expect(tool.hint).toMatch(/anthropic\.com/);
+  });
+});
+
+describe('exit code semantics', () => {
+  it("errors=0 + warnings>0 still allows exit 0 (warnings don't fail)", async () => {
+    // Pin that doctor's contract is "exit 0 if no error-severity
+    // failures". A warning-only run should still let the caller
+    // proceed (issue #27 acceptance criteria).
+    const probe = fakeProbe({
+      paths: {
+        bun: '/usr/local/bin/bun',
+        git: '/usr/bin/git',
+        gh: '/usr/local/bin/gh',
+        claude: '/u/claude',
+        codex: '/u/codex',
+        copilot: '/u/copilot',
+        // No terminal emulators on PATH → warning, not error.
+      },
+      runs: {
+        'bun --version': { exitCode: 0, stdout: '1.2.21\n' },
+        'gh auth status': { exitCode: 0 },
+        'git rev-parse --is-inside-work-tree': { exitCode: 0, stdout: 'true' },
+      },
+      platform: 'linux',
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    expect(report.errors).toBe(0);
+    expect(report.warnings).toBe(1);
+  });
+});
+
+describe('formatReport', () => {
+  it('uses ASCII glyphs and a summary line', async () => {
+    const report = await runDoctor({ tools: ['claude'] }, happyProbe());
+    const text = formatReport(report);
+    expect(text).toContain('[ ok ]');
+    expect(text).not.toContain('[fail]');
+    expect(text).toMatch(/\d+ passed/);
+  });
+
+  it('includes the hint on failure', async () => {
+    const probe = fakeProbe({
+      paths: { bun: '/usr/local/bin/bun', git: '/usr/bin/git' },
+      runs: {
+        'bun --version': { exitCode: 0, stdout: '1.2.21\n' },
+        'git rev-parse --is-inside-work-tree': { exitCode: 0, stdout: 'true' },
+      },
+      platform: 'linux',
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const text = formatReport(report);
+    expect(text).toContain('[fail]');
+    expect(text).toMatch(/^ +hint: /m);
+    expect(text).toContain('cli.github.com');
+  });
+});
+
+describe('defaultProbe', () => {
+  // The defaultProbe is the only non-pure surface in this module —
+  // its existence is asserted, but the actual subprocess invocations
+  // live in run.ts and are covered by run.test.ts. This test just
+  // pins the shape so refactors that drop one of the three methods
+  // are caught.
+  it('exposes which / invoke / platform', () => {
+    const p = defaultProbe();
+    expect(typeof p.which).toBe('function');
+    expect(typeof p.invoke).toBe('function');
+    expect(typeof p.platform).toBe('string');
+  });
+});

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -37,6 +37,7 @@ function happyProbe(): DoctorProbe {
       git: '/usr/bin/git',
       gh: '/usr/local/bin/gh',
       'gnome-terminal': '/usr/bin/gnome-terminal',
+      bash: '/bin/bash',
       claude: '/home/u/.local/bin/claude',
       codex: '/home/u/.local/bin/codex',
       copilot: '/home/u/.local/bin/copilot',
@@ -55,8 +56,8 @@ describe('runDoctor', () => {
     const report = await runDoctor({ tools: [] }, happyProbe());
     expect(report.errors).toBe(0);
     expect(report.warnings).toBe(0);
-    // 6 common + 3 tools = 9 checks total when tools=[] (all tools).
-    expect(report.passed).toBe(9);
+    // 7 common + 3 tools = 10 checks total when tools=[] (all tools).
+    expect(report.passed).toBe(10);
     expect(report.results.map((r) => r.name)).toEqual([
       'bun-on-path',
       'git-on-path',
@@ -64,6 +65,7 @@ describe('runDoctor', () => {
       'gh-auth',
       'inside-git-repo',
       'terminal',
+      'terminal-shell',
       'tool-claude',
       'tool-codex',
       'tool-copilot',
@@ -80,6 +82,7 @@ describe('runDoctor', () => {
           git: '/usr/bin/git',
           gh: '/usr/local/bin/gh',
           'gnome-terminal': '/usr/bin/gnome-terminal',
+          bash: '/bin/bash',
           claude: '/home/u/.local/bin/claude',
           // codex + copilot intentionally absent
         },
@@ -92,7 +95,7 @@ describe('runDoctor', () => {
     });
     const report = await runDoctor({ tools: ['claude'] }, probe);
     expect(report.errors).toBe(0);
-    expect(report.passed).toBe(7);
+    expect(report.passed).toBe(8);
     expect(report.results.map((r) => r.name).filter((n) => n.startsWith('tool-'))).toEqual([
       'tool-claude',
     ]);
@@ -216,6 +219,49 @@ describe('individual checks', () => {
     expect(term.message).toContain('xterm');
   });
 
+  it('terminal-shell: missing bash on linux → warning', async () => {
+    // Mirrors checkTerminal: the inner shell is what buildLaunchSpec
+    // actually exec's, so a missing bash on linux/darwin (or missing
+    // powershell.exe on win32) means the terminal opens but the runner
+    // script never starts. Warning severity (not error) keeps the
+    // existing "warnings don't fail the exit" contract intact.
+    const probe = fakeProbe({
+      paths: {
+        'gnome-terminal': '/usr/bin/gnome-terminal',
+        // bash intentionally absent
+      },
+      platform: 'linux',
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const shell = report.results.find((r) => r.name === 'terminal-shell')!;
+    expect(shell.status).toBe('fail');
+    expect(shell.severity).toBe('warning');
+    expect(shell.message).toContain('bash');
+  });
+
+  it('terminal-shell: missing powershell.exe on win32 → warning', async () => {
+    const probe = fakeProbe({
+      paths: { wt: 'C:\\WINDOWS\\system32\\wt.exe' },
+      platform: 'win32',
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const shell = report.results.find((r) => r.name === 'terminal-shell')!;
+    expect(shell.status).toBe('fail');
+    expect(shell.message).toContain('powershell.exe');
+    expect(shell.hint).toMatch(/WindowsApps PATH/);
+  });
+
+  it('terminal-shell: present → pass', async () => {
+    const probe = fakeProbe({
+      paths: { bash: '/bin/bash', 'gnome-terminal': '/usr/bin/gnome-terminal' },
+      platform: 'linux',
+    });
+    const report = await runDoctor({ tools: [] }, probe);
+    const shell = report.results.find((r) => r.name === 'terminal-shell')!;
+    expect(shell.status).toBe('pass');
+    expect(shell.message).toContain('bash at /bin/bash');
+  });
+
   it('tool missing → error with install URL hint', async () => {
     const probe = fakeProbe({});
     const report = await runDoctor({ tools: ['claude'] }, probe);
@@ -235,6 +281,7 @@ describe('exit code semantics', () => {
         bun: '/usr/local/bin/bun',
         git: '/usr/bin/git',
         gh: '/usr/local/bin/gh',
+        bash: '/bin/bash',
         claude: '/u/claude',
         codex: '/u/codex',
         copilot: '/u/copilot',
@@ -249,6 +296,9 @@ describe('exit code semantics', () => {
     });
     const report = await runDoctor({ tools: [] }, probe);
     expect(report.errors).toBe(0);
+    // Only the emulator check fails (warning); terminal-shell passes
+    // because bash is on PATH. Pinning this so any future merge of
+    // the two checks back into one trips here.
     expect(report.warnings).toBe(1);
   });
 });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -143,6 +143,21 @@ describe('individual checks', () => {
     expect(auth.hint).toMatch(/gh auth login/);
   });
 
+  it('gh missing → gh-auth short-circuits with a pointer to gh-on-path', async () => {
+    // No `gh` on PATH: gh-auth must not run `gh auth status` (which would
+    // return exit -1 and report "gh is not authenticated" — misleading).
+    // Two distinct fail lines is the intended granularity (one per check),
+    // but the gh-auth message points at the real root cause.
+    const probe = fakeProbe({});
+    const report = await runDoctor({ tools: [] }, probe);
+    const auth = report.results.find((r) => r.name === 'gh-auth')!;
+    expect(auth.status).toBe('fail');
+    expect(auth.message).toMatch(/gh not on PATH/);
+    expect(auth.hint).toMatch(/gh-on-path/);
+    // The misleading legacy message must NOT appear.
+    expect(auth.message).not.toContain('not authenticated');
+  });
+
   it('not inside a git working tree → error', async () => {
     const probe = fakeProbe({
       paths: { git: '/usr/bin/git' },
@@ -157,6 +172,17 @@ describe('individual checks', () => {
     const repo = report.results.find((r) => r.name === 'inside-git-repo')!;
     expect(repo.status).toBe('fail');
     expect(repo.hint).toMatch(/cd into a git repo/);
+  });
+
+  it('git missing → inside-git-repo short-circuits with a pointer to git-on-path', async () => {
+    // Same short-circuit as gh-auth: don't run rev-parse when git isn't
+    // installed; surface the real cause.
+    const probe = fakeProbe({});
+    const report = await runDoctor({ tools: [] }, probe);
+    const repo = report.results.find((r) => r.name === 'inside-git-repo')!;
+    expect(repo.status).toBe('fail');
+    expect(repo.message).toMatch(/git not on PATH/);
+    expect(repo.hint).toMatch(/git-on-path/);
   });
 
   it('no terminal emulator → warning, not error', async () => {


### PR DESCRIPTION
## Summary

Closes #27.

`handoff doctor` runs a preflight environment check so missing prereqs surface before they ambush a real handoff. Seven common checks (bun + version, git, gh, gh auth, inside a git working tree, terminal emulator, terminal shell) plus a per-tool PATH check for each known agent.

```
handoff doctor                # all common checks + every known tool
handoff doctor claude         # narrow per-tool to claude
handoff doctor codex copilot  # multi-tool filter
handoff doctor --json         # machine-readable
```

Exit code `0` if every error-severity check passes. The terminal-emulator and terminal-shell checks are warnings (don't bump the exit code) because the runtime fallback chain in `openTerminal` may still succeed even when the doctor's PATH lookup misses a candidate.

## Architecture

`src/doctor.ts` is a new module with a `DoctorProbe` injection seam:

```ts
interface DoctorProbe {
  which(cmd: string): Promise<string | null>;
  invoke(cmd: string, args: readonly string[]): Promise<{ exitCode, stdout, stderr }>;
  platform: NodeJS.Platform;
}
```

Each check is an async function over the probe that returns a structured `CheckResult`. `defaultProbe()` wires the production impl (`Bun.which` + `run()` from `src/run.ts`); the test suite stubs the probe with fixture data. Checks run sequentially for deterministic output ordering.

Plumbing in `src/args.ts` mirrors cleanup/telemetry — no free-form mode, global flags + `--json` can interleave with tool positionals. Dispatch in `src/cli.ts` is a single `runDoctorCommand` function.

## Acceptance criteria (from #27)

- [x] `handoff doctor` runs all checks and prints a pass/fail line per check
- [x] `handoff doctor <tool>` filters tool-specific checks
- [x] `--json` emits structured results
- [x] Exit code 0 if all pass, non-zero if any error-severity check fails
- [x] Each check is a pure function over (env, PATH-lookup, fs-stat) — `DoctorProbe`
- [x] Tests cover each check's pass + fail path
- [x] README mentions running `handoff doctor` first thing after install

Deferred (per the issue's "Pairs with"):
- `.handoffrc.json` parse check — pairs with #20 (config-surface decision)

## Test plan

- [x] `bun run test` — 273 pass / 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Smoke-tested on Windows: `bun src/cli.ts doctor` reports passes across the common + tool checks; `--json` emits well-formed structured output
- [ ] CI green on ubuntu/macos/windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)