### PR TITLE
feat: PR-as-ref handoff — complete an existing PR (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,12 +95,13 @@ Every worktree carries a small per-session metadata directory at its root:
 
 ```jsonc
 {
-  "version": 1,
+  "version": 2,
   "tool": "claude" | "codex" | "copilot",
   "ref": { "type": "issue", "number": 7 } |
-         { "type": "freeform", "text": "..." },
-  // A `{ "type": "pr", "number": 12 }` variant will be added when #10 lands
-  // first-class PR handoffs end-to-end.
+         { "type": "freeform", "text": "..." } |
+         { "type": "pr", "number": 12 },
+  // For a `pr` ref, `branch` is the PR's own head branch (not a synthesized
+  // `<tool>/...` name) — cleanup keeps that branch instead of deleting it.
   "branch": "claude/issue-7",
   "loop": false,
   "createdAt": "2026-04-28T12:00:00.000Z",
@@ -136,7 +137,14 @@ When you add a new event:
 
 Edit the `WORKFLOW_CONTRACT` constant in `src/prompt.ts`. The template is intentionally one big string so it's reviewable as a unit — don't split it into per-tool variants without a strong reason.
 
-There is a second constant, `WORKFLOW_CONTRACT_LOOP`, used when `--loop` is passed (claude only). Keep both as full strings rather than splicing — easier to review the agent's instructions for each mode in one place.
+`src/prompt.ts` carries **four** contract constants, one per (ref-kind × loop) mode `renderPrompt` selects between:
+
+- `WORKFLOW_CONTRACT` — issue / free-form, one-shot (implement → open PR → stop).
+- `WORKFLOW_CONTRACT_LOOP` — issue / free-form with `--loop` (claude only): implement → open PR → stay resident through review.
+- `WORKFLOW_CONTRACT_PR` — a `PR #N` ref: complete an existing PR in place, push to its branch, never `gh pr create`.
+- `WORKFLOW_CONTRACT_PR_LOOP` — a `PR #N` ref with `--loop`: complete the PR, then the review loop.
+
+Keep all four as full strings rather than splicing — easier to review the agent's instructions for each mode in one place. The `_LOOP` and `_PR_LOOP` variants intentionally duplicate the review-loop body for that reason.
 
 ## Out of scope until later
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # handoff
 
-Delegate a GitHub issue (or a free-form task) to **`claude`**, **`codex`**, or **`copilot`** in an isolated git worktree, with a generated `PROMPT.md` as the starting context. The agent works to completion (commits, push, PR) in its own terminal window. When the PR merges, the worktree self-cleans.
+Delegate a GitHub issue, an existing PR, or a free-form task to **`claude`**, **`codex`**, or **`copilot`** in an isolated git worktree, with a generated `PROMPT.md` as the starting context. The agent works to completion (commits, push, PR) in its own terminal window. When the PR merges, the worktree self-cleans.
 
 ```
 /handoff #1                       # claude (default) on issue #1
 /handoff codex #1                 # explicit tool
 /handoff copilot Issue #2
 /handoff #3 #4 #5                 # fleet — three parallel claude worktrees
+/handoff PR #5                    # complete an existing PR in place
 /handoff "fix login redirect bug" # free-form, default tool
 ```
 
@@ -89,6 +90,24 @@ No issue lookup. The text is passed as the task description in `PROMPT.md`. The 
 
 > **Quote free-form descriptions to avoid typo ambiguity.** A leading token that isn't a known tool name (`claude` / `codex` / `copilot`) or subcommand (`cleanup` / `telemetry`) parses as the start of a free-form description for the default tool. So an unquoted typo like `handoff calude #1` becomes the free-form task `"calude #1"` (for claude) instead of being caught. Quoting intentional free-form (`handoff "fix the bug"`) makes the intent unambiguous.
 
+### PR handoff
+
+```bash
+handoff PR #5          # complete an existing PR (any tool)
+handoff codex PR #5    # explicit tool
+handoff pr#5           # shorthand — pr#N, case-insensitive
+```
+
+Hand off an **existing pull request** for an agent to **finish** — not to review-loop on, and not to replace. Instead of branching off the default branch, `handoff`:
+
+1. Resolves the PR via `gh pr view 5` (title, body, head/base branch, state).
+2. Creates a detached worktree and runs `gh pr checkout 5` into it, so the worktree sits on the PR's **own head branch** with push tracking already wired.
+3. Writes a PR-flavored `PROMPT.md`: review the existing diff and conversation, finish the work, push to the **same branch**. The agent does **not** open a new PR.
+
+On cleanup the worktree is removed but the PR's head branch is **kept** — it belongs to the PR, not to `handoff`.
+
+Scope limits: the PR must be **open** (a closed or merged PR is refused), and its head branch must live in **this repo** — PRs from a fork are refused with a clear error, since the agent may not be able to push to a fork. `--loop` works with a `PR #N` ref (claude only): the agent completes the PR and then stays resident through the review cycle.
+
 ### Loop mode (`--loop`, claude only)
 
 ```bash
@@ -103,6 +122,8 @@ By default the agent stops the moment `gh pr create` returns. With `--loop`, the
 - Triage review comments. **Bot reviewers (Copilot, Codex, github-actions) are default-deny** — the agent reads each comment, decides if there's a real underlying problem, and fixes at the source rather than blindly applying suggested patches.
 - Commit and push fixes per round.
 - Bail with a `[handoff loop] bailing` PR comment if it hits 5 rounds, an unresolvable CI failure, or a merge conflict.
+
+With an issue or free-form ref the loop begins once `gh pr create` returns. With a [`PR #N`](#pr-handoff) ref the PR already exists, so the agent finishes the work, pushes to the PR's branch, and goes straight into the cycle — it never runs `gh pr create`.
 
 The agent does **not** merge — that's still your call. Once you (or repo automation) merge, it exits and the wrapper cleans up the worktree as usual.
 
@@ -207,7 +228,7 @@ What we collect (and only this — by construction):
 | `handoff.cleanup` | `{ tool, outcome, durationMs }`             |
 | `handoff.error`   | `{ code, module, exitCode }`                |
 
-`refType` is `issue` or `freeform`; `outcome` is `merged` / `forced` / `retained` / `failed` (`forced` is when the user passed `handoff cleanup --force` — distinguished so analytics can track how often the merge-check safety is bypassed); `sessionId` is a per-handoff random UUID. There is **no PII**: no issue titles, branch names, repo paths, or usernames are ever transmitted. Event delivery is async fire-and-forget: the CLI never awaits a send at the call site, so a slow or down endpoint doesn't gate user-visible work. The process does wait briefly on exit for any in-flight requests to drain, bounded by a 1s `AbortController` timeout per request. Failures (transport errors, non-2xx, timeout) are dropped silently.
+`refType` is `issue`, `freeform`, or `pr`; `outcome` is `merged` / `forced` / `retained` / `failed` (`forced` is when the user passed `handoff cleanup --force` — distinguished so analytics can track how often the merge-check safety is bypassed); `sessionId` is a per-handoff random UUID. There is **no PII**: no issue titles, branch names, repo paths, or usernames are ever transmitted. Event delivery is async fire-and-forget: the CLI never awaits a send at the call site, so a slow or down endpoint doesn't gate user-visible work. The process does wait briefly on exit for any in-flight requests to drain, bounded by a 1s `AbortController` timeout per request. Failures (transport errors, non-2xx, timeout) are dropped silently.
 
 Trust through transparency: set `HANDOFF_TELEMETRY_DEBUG=1` in your environment to capture every event you would have sent to `~/.handoff/telemetry-debug.log`. The log is written **whether or not telemetry is enabled**, so you can audit what the tool would send before turning it on. `handoff telemetry log` prints the file.
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -10,7 +10,17 @@ export interface FreeFormRef {
   text: string;
 }
 
-export type Ref = IssueRef | FreeFormRef;
+/**
+ * An existing GitHub PR to *complete* (#60). The handoff checks out the PR's
+ * own head branch — see `fetchPullRequest` / `checkoutPullRequest` — so the
+ * agent finishes the work in place rather than opening a new PR.
+ */
+export interface PrRef {
+  kind: 'pr';
+  number: number;
+}
+
+export type Ref = IssueRef | FreeFormRef | PrRef;
 
 export interface ParsedArgs {
   tool: Tool;
@@ -56,27 +66,47 @@ function isTool(value: string): value is Tool {
   return (TOOLS as readonly string[]).includes(value);
 }
 
-function parseIssueToken(
-  tokens: string[],
+/**
+ * Recognize an issue or PR ref starting at `tokens[index]`. Returns the parsed
+ * `Ref` and how many tokens it consumed (1 or 2), or `null` if the token isn't
+ * a ref. Shared by `parseInvocation` and `extractGlobalFlags` so the two
+ * scanners can't drift on what counts as a ref.
+ *
+ * Forms: `#N` (issue), `pr#N` (PR shorthand), `Issue #N` / `PR #N` (two-token,
+ * case-insensitive — the keyword token plus an optionally-`#`-prefixed number).
+ */
+function parseRefToken(
+  tokens: readonly string[],
   index: number,
-): { ref: IssueRef; consumed: number } | null {
+): { ref: Ref; consumed: number } | null {
   const tok = tokens[index];
   if (tok === undefined) return null;
 
-  // "#N"
-  const hashMatch = tok.match(/^#(\d+)$/);
-  if (hashMatch && hashMatch[1] !== undefined) {
-    return { ref: { kind: 'issue', number: Number(hashMatch[1]) }, consumed: 1 };
+  // "#N" — issue, single token
+  const issueHash = tok.match(/^#(\d+)$/);
+  if (issueHash && issueHash[1] !== undefined) {
+    return { ref: { kind: 'issue', number: Number(issueHash[1]) }, consumed: 1 };
   }
 
-  // "Issue #N" → two tokens
+  // "pr#N" / "PR#N" — PR shorthand, single token
+  const prHash = tok.match(/^pr#(\d+)$/i);
+  if (prHash && prHash[1] !== undefined) {
+    return { ref: { kind: 'pr', number: Number(prHash[1]) }, consumed: 1 };
+  }
+
+  // "Issue #N" — issue, two tokens
   if (/^issue$/i.test(tok)) {
-    const next = tokens[index + 1];
-    if (next !== undefined) {
-      const m = next.match(/^#?(\d+)$/);
-      if (m && m[1] !== undefined) {
-        return { ref: { kind: 'issue', number: Number(m[1]) }, consumed: 2 };
-      }
+    const m = tokens[index + 1]?.match(/^#?(\d+)$/);
+    if (m && m[1] !== undefined) {
+      return { ref: { kind: 'issue', number: Number(m[1]) }, consumed: 2 };
+    }
+  }
+
+  // "PR #N" — PR, two tokens (parallel to "Issue #N")
+  if (/^pr$/i.test(tok)) {
+    const m = tokens[index + 1]?.match(/^#?(\d+)$/);
+    if (m && m[1] !== undefined) {
+      return { ref: { kind: 'pr', number: Number(m[1]) }, consumed: 2 };
     }
   }
 
@@ -98,8 +128,8 @@ function stripGlobalFlags(tokens: readonly string[]): string[] {
  * literal `--verbose` inside a free-form task description.
  *
  * Mirrors the scanning loop in parseInvocation: leading flags, then
- * `--loop`/`--verbose`/`--debug`/issue-refs in any order, stopping at the
- * first token that triggers free-form mode.
+ * `--loop`/`--verbose`/`--debug`/issue-or-PR-refs in any order, stopping at
+ * the first token that triggers free-form mode.
  *
  * For `cleanup` and `telemetry` heads there is no free-form mode, so global
  * flags can appear anywhere in the remaining argv — scan to the end. (This
@@ -157,18 +187,12 @@ export function extractGlobalFlags(argv: readonly string[]): { verbose: boolean;
       i++;
       continue;
     }
-    // Issue ref: #N
-    if (/^#\d+$/.test(tok)) {
-      i++;
+    // Issue or PR ref — share parseInvocation's recognizer so the two
+    // scanners can't drift (#N, pr#N, "Issue #N", "PR #N").
+    const parsedRef = parseRefToken(argv, i);
+    if (parsedRef) {
+      i += parsedRef.consumed;
       continue;
-    }
-    // Issue ref: "Issue #N" (two tokens)
-    if (/^issue$/i.test(tok)) {
-      const next = argv[i + 1];
-      if (next !== undefined && /^#?\d+$/.test(next)) {
-        i += 2;
-        continue;
-      }
     }
     // Anything else is the start of free-form mode — stop.
     break;
@@ -275,14 +299,14 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     throw new ArgsError(
       `Missing reference. Usage: handoff [<tool>] <ref...> ` +
         `(<tool> defaults to ${DEFAULT_TOOL}; ` +
-        `<ref> = #N, "Issue #N", or a free-form task description).`,
+        `<ref> = #N, "Issue #N", "PR #N", or a free-form task description).`,
     );
   }
 
   // Walk tokens once. While we're still in "flag-or-ref" mode, `--loop`,
-  // `--verbose`, and `--debug` may appear anywhere among the issue refs.
-  // The first token that is neither a flag nor an issue-ref pattern flips us
-  // into free-form mode, and from there everything (including a literal
+  // `--verbose`, and `--debug` may appear anywhere among the issue/PR refs.
+  // The first token that is neither a flag nor an issue/PR-ref pattern flips
+  // us into free-form mode, and from there everything (including a literal
   // `--loop` or `--verbose`) becomes part of the description verbatim.
   let loop = false;
   const refs: Ref[] = [];
@@ -312,10 +336,10 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
       i += 1;
       continue;
     }
-    const issue = parseIssueToken(rest, i);
-    if (issue) {
-      refs.push(issue.ref);
-      i += issue.consumed;
+    const parsedRef = parseRefToken(rest, i);
+    if (parsedRef) {
+      refs.push(parsedRef.ref);
+      i += parsedRef.consumed;
       continue;
     }
     // Free-form description: collect all remaining tokens verbatim.
@@ -337,7 +361,7 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
   if (refs.length === 0) {
     throw new ArgsError(
       `Missing reference. Usage: handoff ${tool} <ref...> ` +
-        `(<ref> = #N, "Issue #N", or a free-form task description).`,
+        `(<ref> = #N, "Issue #N", "PR #N", or a free-form task description).`,
     );
   }
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -224,7 +224,7 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
     // --force opts out of the merge-check safety property. Substitute a
     // name-shape check so a typo'd or non-handoff branch can't trigger
     // an unconditional `git branch -D`. Legitimate handoff branches
-    // always match `<tool>/issue-<N>`, `<tool>/pr-<N>`, or `<tool>/<slug>`
+    // always match `<tool>/issue-<N>` or `<tool>/<slug>`
     // (the shapes branchName() emits). Non-force cleanup remains
     // permissive — the gh-merged-PR check refuses non-handoff branches
     // implicitly.
@@ -237,7 +237,7 @@ export function parseInvocation(argv: readonly string[]): CliInvocation {
       const quoted = `'${branch.replace(/'/g, `'\\''`)}'`;
       throw new ArgsError(
         `'handoff cleanup --force' refused: '${branch}' isn't a handoff branch ` +
-          `(expected '<tool>/issue-<N>', '<tool>/pr-<N>', or '<tool>/<slug>' ` +
+          `(expected '<tool>/issue-<N>' or '<tool>/<slug>' ` +
           `with <tool> in: ${TOOLS.join(', ')}). ` +
           `If you really meant to delete this branch, use \`git branch -D -- ${quoted}\` directly.`,
       );

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -5,21 +5,21 @@ export interface BranchInput {
   tool: Tool;
   /** Issue number → branch tail `issue-<N>`. */
   issueNumber?: number;
-  /** PR number → branch tail `pr-<N>`. */
-  prNumber?: number;
-  /** Free-form slug (already slugified). Used when neither issueNumber nor prNumber is set. */
+  /** Free-form slug (already slugified). Used when issueNumber is not set. */
   slug?: string;
 }
 
-export function branchName({ tool, issueNumber, prNumber, slug }: BranchInput): string {
+/**
+ * Note: PR-as-ref handoffs (issue #60) do **not** synthesize a branch here —
+ * they check out the PR's own head branch so the agent's pushes land on the
+ * PR. `branchName` only covers issue and free-form refs.
+ */
+export function branchName({ tool, issueNumber, slug }: BranchInput): string {
   if (issueNumber !== undefined) {
     return `${tool}/issue-${issueNumber}`;
   }
-  if (prNumber !== undefined) {
-    return `${tool}/pr-${prNumber}`;
-  }
   if (!slug) {
-    throw new Error('branchName: must provide issueNumber, prNumber, or slug');
+    throw new Error('branchName: must provide issueNumber or slug');
   }
   return `${tool}/${slug}`;
 }
@@ -32,7 +32,7 @@ export function branchTail(branch: string): string {
 
 /**
  * True iff `branch` could have been produced by `branchName()` — i.e. the
- * shape is `<tool>/issue-<N>`, `<tool>/pr-<N>`, or `<tool>/<slug>` with
+ * shape is `<tool>/issue-<N>` or `<tool>/<slug>` with
  * `<tool>` ∈ TOOLS and `<slug>` matching the kebab-case form `slugify()`
  * emits (lowercase alphanumeric tokens joined by single dashes, no
  * leading/trailing dashes, no double dashes).
@@ -49,8 +49,8 @@ export function isHandoffBranch(branch: string): boolean {
 
 const HANDOFF_BRANCH_RE = (() => {
   const toolAlternation = TOOLS.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
-  // Tail forms (matching branchName): issue-<N>, pr-<N>, or kebab-case slug.
-  const tail = String.raw`(?:issue-\d+|pr-\d+|[a-z0-9]+(?:-[a-z0-9]+)*)`;
+  // Tail forms (matching branchName): issue-<N> or kebab-case slug.
+  const tail = String.raw`(?:issue-\d+|[a-z0-9]+(?:-[a-z0-9]+)*)`;
   return new RegExp(`^(?:${toolAlternation})/${tail}$`);
 })();
 

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -53,6 +53,14 @@ export interface CleanupOpts {
    */
   force?: boolean;
   /**
+   * Remove the worktree but leave the branch in place. Set for PR-as-ref
+   * handoffs (#60): the worktree was checked out onto the PR's *own* head
+   * branch, which isn't ours to delete — the PR still owns it. cli.ts
+   * derives this from `.handoff/state.json` (`ref.type === 'pr'`). Defaults
+   * to `false` so issue / free-form handoffs still delete their branch.
+   */
+  keepBranch?: boolean;
+  /**
    * @internal Test-only injection seam. Production callers should rely on the
    * default deps wired to `git.ts` / `github.ts` / `node:fs`. All-or-nothing
    * by design: a partial set used to silently fall back to the real impls,
@@ -65,6 +73,7 @@ export async function cleanup(branch: string, opts: CleanupOpts): Promise<Cleanu
   const deps: CleanupDeps = opts.deps ?? buildDefaultDeps(opts.repoRoot);
   const path = worktreePath({ repoRoot: opts.repoRoot, branch });
   const force = opts.force ?? false;
+  const keepBranch = opts.keepBranch ?? false;
 
   if (!force) {
     let merged: boolean;
@@ -109,28 +118,33 @@ export async function cleanup(branch: string, opts: CleanupOpts): Promise<Cleanu
     }
   }
 
-  let removedBranch = false;
-  if (await deps.branchExists(branch)) {
-    try {
-      await deps.deleteBranch(branch);
-      removedBranch = true;
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      return {
-        status: 'unknown',
-        message:
-          `${worktreeExisted ? `Removed worktree ${path}, but ` : ''}` +
-          `failed to delete branch ${branch}: ${reason}. ` +
-          `Delete it manually with \`git branch -D ${branch}\`.`,
-      };
-    }
-  }
-
   const parts: string[] = [];
   if (worktreeExisted) parts.push(`Removed worktree ${path}`);
   else parts.push(`Worktree ${path} was not present`);
-  if (removedBranch) parts.push(`deleted branch ${branch}`);
-  else parts.push(`branch ${branch} was already gone`);
+
+  if (keepBranch) {
+    // PR-as-ref handoff (#60): the worktree was checked out onto the PR's
+    // own head branch. Drop the worktree, but the branch belongs to the PR.
+    parts.push(`retained branch ${branch} (PR head branch)`);
+  } else {
+    let removedBranch = false;
+    if (await deps.branchExists(branch)) {
+      try {
+        await deps.deleteBranch(branch);
+        removedBranch = true;
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        return {
+          status: 'unknown',
+          message:
+            `${worktreeExisted ? `Removed worktree ${path}, but ` : ''}` +
+            `failed to delete branch ${branch}: ${reason}. ` +
+            `Delete it manually with \`git branch -D ${branch}\`.`,
+        };
+      }
+    }
+    parts.push(removedBranch ? `deleted branch ${branch}` : `branch ${branch} was already gone`);
+  }
 
   const reason = force ? 'forced — merge check skipped' : 'PR merged';
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,8 +16,21 @@ import { HandoffError } from './errors.ts';
 import { setDebug, setVerbose, verbose } from './logger.ts';
 import { branchName, worktreePath } from './branch.ts';
 import { cleanup, type CleanupResult } from './cleanup.ts';
-import { createWorktree, mainRepoRoot, repoName } from './git.ts';
-import { defaultBranch, fetchIssue, type IssueDetails } from './github.ts';
+import {
+  createDetachedWorktree,
+  createWorktree,
+  mainRepoRoot,
+  removeWorktree,
+  repoName,
+} from './git.ts';
+import {
+  checkoutPullRequest,
+  defaultBranch,
+  fetchIssue,
+  fetchPullRequest,
+  type IssueDetails,
+  type PullRequestDetails,
+} from './github.ts';
 import { renderPrompt } from './prompt.ts';
 import { RunError } from './run.ts';
 import { slugify } from './slug.ts';
@@ -125,9 +138,18 @@ async function runCleanup(branch: string, force: boolean): Promise<number> {
     }
   }
 
-  verbose(`cleanup: branch = ${branch}, worktree = ${path}, force = ${force}`);
+  // A PR handoff checked the worktree out onto the PR's own head branch —
+  // cleanup must remove the worktree but leave that branch for the PR. The
+  // signal is `.handoff/state.json`; if it's missing/unreadable (safeReadState
+  // returned null) we fall back to deleting, which is correct for the issue /
+  // free-form worktrees that are the only ones a pre-#60 state could describe.
+  const keepBranch = state?.ref.type === 'pr';
+
+  verbose(
+    `cleanup: branch = ${branch}, worktree = ${path}, force = ${force}, keepBranch = ${keepBranch}`,
+  );
   const t0 = Date.now();
-  const result = await cleanup(branch, { repoRoot, force });
+  const result = await cleanup(branch, { repoRoot, force, keepBranch });
   verbose(`cleanup: result = ${result.status}`);
   console.log(result.message);
 
@@ -302,14 +324,27 @@ interface SpawnInput {
 }
 
 async function spawnHandoff(input: SpawnInput): Promise<void> {
+  const ref = input.ref;
   let issue: IssueDetails | undefined;
+  let pr: PullRequestDetails | undefined;
   let branch: string;
-  if (input.ref.kind === 'issue') {
-    verbose(`fetching issue #${input.ref.number}`);
-    issue = await fetchIssue(input.ref.number);
+  // For issue / free-form refs this is the repo's default branch (the worktree
+  // base). For a PR ref it's the PR's *base* branch — the worktree itself is
+  // the PR's head branch, so the agent's pushes land on the PR.
+  let parentBranch = input.parentBranch;
+
+  if (ref.kind === 'issue') {
+    verbose(`fetching issue #${ref.number}`);
+    issue = await fetchIssue(ref.number);
     branch = branchName({ tool: input.tool, issueNumber: issue.number });
+  } else if (ref.kind === 'pr') {
+    verbose(`fetching PR #${ref.number}`);
+    pr = await fetchPullRequest(ref.number);
+    assertPrHandoffable(pr);
+    branch = pr.headRefName;
+    parentBranch = pr.baseRefName;
   } else {
-    const slug = slugify(input.ref.text, { maxLen: 20 });
+    const slug = slugify(ref.text, { maxLen: 20 });
     branch = branchName({ tool: input.tool, slug });
   }
   verbose(`branch: ${branch}`);
@@ -319,18 +354,49 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
   console.log(`[handoff] ${input.tool} → ${branch}`);
   console.log(`           worktree: ${path}`);
 
-  verbose(`creating worktree at ${path}`);
-  await createWorktree({ branch, path, base: input.parentBranch });
+  if (pr) {
+    // A PR handoff checks out the PR's *existing* head branch — create the
+    // worktree detached, then let `gh pr checkout` switch it onto that branch
+    // (it also wires up push tracking so the agent's `git push` hits the PR).
+    verbose(`creating detached worktree at ${path}`);
+    await createDetachedWorktree(path);
+    try {
+      verbose(`checking out PR #${pr.number} into ${path}`);
+      await checkoutPullRequest(pr.number, path);
+    } catch (err) {
+      // The checkout failed after the worktree was created — don't strand a
+      // detached orphan with no branch and no state.json. Best-effort remove.
+      verbose(`PR checkout failed; removing partial worktree ${path}`);
+      await removeWorktree(path).catch(() => {});
+      throw err;
+    }
+  } else {
+    verbose(`creating worktree at ${path}`);
+    await createWorktree({ branch, path, base: parentBranch });
+  }
 
   const promptCtx = {
     tool: input.tool,
     repoName: input.repo,
     branch,
-    parentBranch: input.parentBranch,
+    parentBranch,
     worktreePath: path,
     loop: input.loop,
     ...(issue ? { issue } : {}),
-    ...(input.ref.kind === 'freeform' ? { freeformDescription: input.ref.text } : {}),
+    ...(pr
+      ? {
+          pr: {
+            number: pr.number,
+            title: pr.title,
+            body: pr.body,
+            url: pr.url,
+            headBranch: pr.headRefName,
+            baseBranch: pr.baseRefName,
+            isDraft: pr.isDraft,
+          },
+        }
+      : {}),
+    ...(ref.kind === 'freeform' ? { freeformDescription: ref.text } : {}),
   };
   const promptBody = renderPrompt(promptCtx);
   writeFileSync(join(path, 'PROMPT.md'), promptBody, 'utf8');
@@ -339,7 +405,7 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
   writeState(path, {
     version: STATE_VERSION,
     tool: input.tool,
-    ref: refRecord(input.ref, issue),
+    ref: refRecord(ref, issue),
     branch,
     loop: input.loop,
     createdAt: now,
@@ -357,12 +423,36 @@ async function spawnHandoff(input: SpawnInput): Promise<void> {
   emitFireAndForget(
     eventStart({
       tool: input.tool,
-      refType: input.ref.kind === 'issue' ? 'issue' : 'freeform',
+      refType: ref.kind,
       fleet: input.fleet,
       loop: input.loop,
       sessionId: newSessionId(),
     }),
   );
+}
+
+/**
+ * Refuse PR refs handoff can't work on. A non-open PR has no live branch to
+ * complete; a fork PR's head branch isn't reliably pushable (#60 scopes to
+ * same-repo PRs). Both are user errors — the ref is wrong for a handoff.
+ */
+function assertPrHandoffable(pr: PullRequestDetails): void {
+  if (pr.state !== 'OPEN') {
+    throw new HandoffError(
+      `PR #${pr.number} is ${pr.state}, not open — nothing to complete.`,
+      1,
+      pr.state === 'MERGED'
+        ? 'This PR already merged; hand off a follow-up issue instead.'
+        : 'Reopen the PR, or hand the work off as an issue or free-form task.',
+    );
+  }
+  if (pr.isCrossRepository) {
+    throw new HandoffError(
+      `PR #${pr.number} is from a fork — cross-repo PR handoff isn't supported yet.`,
+      1,
+      "Check the PR's head branch out yourself, or hand the work off as an issue.",
+    );
+  }
 }
 
 function resolveHandoffRoot(): string {
@@ -384,14 +474,25 @@ function resolveRunnerScript(handoffRoot: string): string {
 }
 
 function describeRef(ref: Ref): string {
-  return ref.kind === 'issue' ? `#${ref.number}` : `"${ref.text.slice(0, 40)}"`;
+  switch (ref.kind) {
+    case 'issue':
+      return `#${ref.number}`;
+    case 'pr':
+      return `PR #${ref.number}`;
+    case 'freeform':
+      return `"${ref.text.slice(0, 40)}"`;
+  }
 }
 
 function refRecord(ref: Ref, issue: IssueDetails | undefined): RefRecord {
-  if (ref.kind === 'issue') {
-    return { type: 'issue', number: issue?.number ?? ref.number };
+  switch (ref.kind) {
+    case 'issue':
+      return { type: 'issue', number: issue?.number ?? ref.number };
+    case 'pr':
+      return { type: 'pr', number: ref.number };
+    case 'freeform':
+      return { type: 'freeform', text: ref.text };
   }
-  return { type: 'freeform', text: ref.text };
 }
 
 function errorCode(err: unknown): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,12 +39,16 @@ ${TOOLS_SECTION}
 REFS
   #N             a GitHub issue number (resolved via \`gh issue view\`)
   Issue #N       same as #N
+  PR #N          an existing pull request to complete in place (resolved via
+                 \`gh pr view\`); \`pr#N\` is accepted as shorthand. The agent
+                 works on the PR's own head branch and does not open a new PR.
   <free text>    a free-form task description (no issue created)
 
 FLAGS
-  --loop         (claude only) keep the agent resident after \`gh pr create\`
-                 to triage review feedback and CI, push fixes, and iterate
-                 until the PR is merged (or a bail condition trips).
+  --loop         (claude only) keep the agent resident through the review
+                 cycle — triage feedback and CI, push fixes, and iterate
+                 until the PR is merged (or a bail condition trips). Works
+                 with an issue, a free-form task, or a \`PR #N\` ref.
   --force        (cleanup only) skip the merged-PR safety check and tear
                  down the worktree + branch unconditionally. Use when the
                  work shipped under a different branch (rebased, renamed,
@@ -75,6 +79,7 @@ EXAMPLES
   handoff copilot Issue #2
   handoff #1 #2 #3                           # fleet: 3 parallel ${DEFAULT_TOOL} worktrees
   handoff --loop #7                          # implement and self-drive review
+  handoff PR #5                              # complete an existing PR in place
   handoff "tidy up the README"               # free-form, default tool
 
 EXIT CODES

--- a/src/git.ts
+++ b/src/git.ts
@@ -87,6 +87,18 @@ export async function createWorktree(input: CreateWorktreeInput): Promise<void> 
   await run('git', ['worktree', 'add', '-b', input.branch, input.path, input.base]);
 }
 
+/**
+ * Create a linked worktree in detached-HEAD state at `path`.
+ *
+ * Used by PR-as-ref handoffs (#60): the worktree is created detached, then
+ * `gh pr checkout` switches it onto the PR's own head branch. Unlike
+ * `createWorktree`, this neither creates nor names a branch — the PR already
+ * owns one, and we want the agent's pushes to land on it.
+ */
+export async function createDetachedWorktree(path: string): Promise<void> {
+  await run('git', ['worktree', 'add', '--detach', path]);
+}
+
 export async function removeWorktree(path: string, opts: GitOpts = {}): Promise<void> {
   await run('git', ['worktree', 'remove', '--force', path], cwdOpts(opts));
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -74,6 +74,92 @@ export async function fetchIssue(number: number): Promise<IssueDetails> {
   };
 }
 
+export type PullRequestState = 'OPEN' | 'CLOSED' | 'MERGED';
+
+export interface PullRequestDetails {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  state: PullRequestState;
+  /** The PR's head branch — the branch the agent's commits push back onto. */
+  headRefName: string;
+  /** The PR's base branch — what it merges into. */
+  baseRefName: string;
+  isDraft: boolean;
+  /** True when the head branch lives on a fork. handoff refuses these (#60). */
+  isCrossRepository: boolean;
+}
+
+/**
+ * `gh pr view --json` field list. A module-level constant so the test fixture
+ * can assert the exact argv (scriptedSpawn matches argv element-for-element).
+ */
+const PR_VIEW_JSON_FIELDS =
+  'number,title,body,url,state,headRefName,baseRefName,isDraft,isCrossRepository';
+
+interface RawPullRequestPayload {
+  number?: number;
+  title?: string;
+  body?: string;
+  url?: string;
+  state?: string;
+  headRefName?: string;
+  baseRefName?: string;
+  isDraft?: boolean;
+  isCrossRepository?: boolean;
+}
+
+function isPullRequestState(value: unknown): value is PullRequestState {
+  return value === 'OPEN' || value === 'CLOSED' || value === 'MERGED';
+}
+
+/**
+ * Resolve an existing PR's metadata for a PR-as-ref handoff (#60). The agent
+ * works *on the PR's own head branch* — `headRefName` — so its pushes land on
+ * the PR rather than a synthesized branch.
+ */
+export async function fetchPullRequest(number: number): Promise<PullRequestDetails> {
+  const stdout = await gh(['pr', 'view', String(number), '--json', PR_VIEW_JSON_FIELDS]);
+  const parsed = JSON.parse(stdout) as RawPullRequestPayload;
+  if (
+    typeof parsed.number !== 'number' ||
+    typeof parsed.title !== 'string' ||
+    typeof parsed.body !== 'string' ||
+    typeof parsed.url !== 'string' ||
+    !isPullRequestState(parsed.state) ||
+    typeof parsed.headRefName !== 'string' ||
+    parsed.headRefName.length === 0 ||
+    typeof parsed.baseRefName !== 'string' ||
+    parsed.baseRefName.length === 0 ||
+    typeof parsed.isDraft !== 'boolean' ||
+    typeof parsed.isCrossRepository !== 'boolean'
+  ) {
+    throw new GhError(`Unexpected gh pr payload: ${stdout.slice(0, 200)}`);
+  }
+  return {
+    number: parsed.number,
+    title: parsed.title,
+    body: parsed.body,
+    url: parsed.url,
+    state: parsed.state,
+    headRefName: parsed.headRefName,
+    baseRefName: parsed.baseRefName,
+    isDraft: parsed.isDraft,
+    isCrossRepository: parsed.isCrossRepository,
+  };
+}
+
+/**
+ * Check the PR's head branch out into the worktree at `cwd` (which must
+ * already be a freshly-created detached worktree). `gh pr checkout` handles
+ * the fetch, local-branch creation, and push/upstream tracking so the agent's
+ * `git push` updates the PR.
+ */
+export async function checkoutPullRequest(number: number, cwd: string): Promise<void> {
+  await gh(['pr', 'checkout', String(number)], { cwd });
+}
+
 export async function defaultBranch(): Promise<string> {
   const stdout = await gh(['repo', 'view', '--json', 'defaultBranchRef']);
   const parsed = JSON.parse(stdout) as { defaultBranchRef?: { name?: string } };

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -36,6 +36,20 @@ export interface PromptContext {
     url: string;
     labels?: string[];
   };
+  /**
+   * Set for a PR-as-ref handoff (#60). The worktree is checked out on the
+   * PR's own `headBranch`; `parentBranch` above carries the PR's base.
+   * Mutually exclusive with `issue` / `freeformDescription`.
+   */
+  pr?: {
+    number: number;
+    title: string;
+    body: string;
+    url: string;
+    headBranch: string;
+    baseBranch: string;
+    isDraft: boolean;
+  };
   freeformDescription?: string;
 }
 
@@ -154,6 +168,132 @@ hook removes the worktree.
   in a PR comment, and exit.
 `;
 
+const WORKFLOW_CONTRACT_PR = `## Workflow contract (PR completion mode)
+
+You are working in a dedicated git worktree, checked out on an **existing PR's own head
+branch** (shown above). The user has handed off an open pull request for you to
+**finish** — not to re-open or replace. Follow this sequence:
+
+1. **Review the current state.** This PR already has commits, and may have review
+   feedback. Before changing anything:
+   - \`gh pr view <number> --comments\` — read the PR description and every review and
+     discussion comment.
+   - \`gh pr diff <number>\` — see what has already been done.
+   Re-read the PR description above. If what's left to do is ambiguous, ask the user
+   (in this terminal) one focused question before starting.
+2. **Finish the implementation.** Make the smallest set of changes that completes the
+   PR's stated goal and addresses any unresolved review feedback. Keep the diff focused —
+   do not refactor unrelated code, do not introduce new abstractions.
+3. **Verify.** Run the project's test suite, type checker, and linter. Fix anything you
+   broke.
+4. **Commit.** Use Conventional Commits style. One logical commit per concern, small
+   enough to review. Add new commits — do **not** rewrite, squash, or amend the PR's
+   existing history.
+5. **Push.** \`git push\`. The branch already tracks the PR's head, so a plain push
+   updates the PR in place.
+6. **Stop.** The moment your commits are pushed, your job is done. Print exactly one
+   line — \`PR updated: <url>\` — and exit the session. Do **not** call any more tools
+   after this point. The terminal wrapper takes over, detects whether the PR has been
+   merged, and cleans up the worktree.
+
+**Boundaries.**
+- Do **not** open a new PR. \`gh pr create\` is wrong here — the PR already exists and
+  your commits land on its head branch.
+- Do **not** \`gh pr merge\` — the human or repo automation merges.
+- Do **not** force-push or rewrite history — others may have the branch checked out, and
+  the PR's review history must stay intact.
+- Do **not** touch files outside the scope of this PR.
+- Do **not** delete or rewrite the worktree yourself — the wrapper handles that.
+- If you cannot complete the work, leave the branch in a clean state, push what you have,
+  and summarize what's left in a PR comment before exiting.
+`;
+
+const WORKFLOW_CONTRACT_PR_LOOP = `## Workflow contract (PR completion + review loop)
+
+You are working in a dedicated git worktree, checked out on an **existing PR's own head
+branch** (shown above). The user has handed off an open pull request for you to
+**finish** and then **stay resident** through the review cycle until it merges. Follow
+this sequence:
+
+1. **Review the current state.** This PR already has commits, and may have review
+   feedback. Before changing anything:
+   - \`gh pr view <number> --comments\` — read the PR description and every review and
+     discussion comment.
+   - \`gh pr diff <number>\` — see what has already been done.
+   Re-read the PR description above. If what's left to do is ambiguous, ask the user
+   (in this terminal) one focused question before starting.
+2. **Finish the implementation.** Make the smallest set of changes that completes the
+   PR's stated goal and addresses any unresolved review feedback. Keep the diff focused.
+3. **Verify.** Run the project's test suite, type checker, and linter. Fix anything you
+   broke.
+4. **Commit.** Use Conventional Commits style. One logical commit per concern. Add new
+   commits — do **not** rewrite, squash, or amend the PR's existing history.
+5. **Push.** \`git push\`. The branch already tracks the PR's head, so a plain push
+   updates the PR in place. Do **not** \`gh pr create\` — the PR already exists.
+6. **Enter the review loop.** Once your commits are pushed, do **not** exit. Iterate up
+   to **5 rounds** of: poll → triage → fix → push. Each round:
+   - **Poll.** Wait 60–180 seconds, then check PR state with
+     \`gh pr view <number> --json state,mergeable,mergeStateStatus,statusCheckRollup,reviews,comments\`
+     and \`gh pr checks <number>\`.
+   - **Exit if merged.** If \`state == "MERGED"\`, print \`PR merged: <url>\` and exit. The
+     wrapper will clean up the worktree.
+   - **Triage CI.** If checks failed, read the failing logs (\`gh run view --log-failed\`) and
+     fix the underlying issue. Don't paper over a flaky test by retrying — investigate.
+   - **Triage comments.** Track the latest \`updated_at\` you've already triaged and only
+     look at comments newer than that — the REST endpoints below don't expose thread
+     resolution state, so re-scanning everything every round will burn cycles re-deciding
+     the same comments. The three relevant feeds:
+     - Line/review comments: \`gh api repos/{owner}/{repo}/pulls/<n>/comments?since=<iso8601>\`
+     - Top-level discussion comments: \`gh api repos/{owner}/{repo}/issues/<n>/comments?since=<iso8601>\`
+     - Review summaries (approve / request-changes bodies): \`gh pr view <n> --json reviews\`
+     For each new comment:
+     - **Bot reviewers (\`Copilot\`, \`copilot-pull-request-reviewer\`, \`github-actions\`, etc.)
+       are default-deny.** Do not apply suggested patches verbatim. Read the comment, decide
+       if there is a *real* underlying problem, and if so fix it at the source. If the
+       comment is noise (style nit you disagree with, false positive, hallucinated reference),
+       leave a brief reply explaining why you're not acting on it and move on.
+     - **Human reviewers** get the benefit of the doubt — address their concerns directly,
+       but still implement at the source rather than copy-pasting suggestions blindly.
+     - If you genuinely need thread-resolution state (rare), fall back to the GraphQL
+       \`reviewThreads\` connection — REST doesn't surface it.
+   - **Commit and push.** New commits per round, conventional style. Do **not** force-push
+     unless a reviewer explicitly asked you to rebase.
+   - **Re-request review.** If you pushed fixes addressing a specific reviewer, re-request
+     them with \`gh pr edit <number> --add-reviewer <login>\`, or leave a brief comment
+     summarising what changed.
+7. **Bail conditions.** Exit the loop (and the session) with a status comment on the PR
+   explaining what's blocking, in any of these cases:
+   - Iteration cap reached (5 rounds without merging).
+   - CI failing for a reason you can't resolve (infra outage, secrets you don't have, a
+     test that needs human judgment).
+   - Merge conflict you can't cleanly resolve.
+   - GitHub reports the PR is non-mergeable after a round — \`mergeable\` is the string
+     \`"CONFLICTING"\` (or \`"UNKNOWN"\` that doesn't clear on the next poll), or
+     \`mergeStateStatus\` is \`"DIRTY"\` / \`"BEHIND"\` / \`"BLOCKED"\` for reasons you can't
+     resolve. (\`mergeable\` is a tri-state enum, not a boolean — don't compare to \`false\`.)
+   - Reviewer asks for a change that contradicts the PR's stated goal — surface the
+     conflict, ask the user, then exit.
+   When bailing, leave a single comment on the PR whose first line is
+   \`[handoff loop] bailing\` (PR comments don't have titles — the marker has to live in
+   the body so it's searchable). Below that, give the reason and what you tried, then
+   exit. Do **not** close the PR.
+
+**You do not merge the PR.** The human or repo automation merges. Your job is to finish
+the work and keep the branch in a mergeable state through review. Once the merge happens,
+the cleanup hook removes the worktree.
+
+**Boundaries.**
+- Do **not** open a new PR. \`gh pr create\` is wrong here — the PR already exists.
+- Do **not** \`gh pr merge\` — the human merges. You only iterate until they do.
+- Do **not** force-push or rewrite history — others may have the branch checked out, and
+  the PR's review history must stay intact.
+- Do **not** apply Copilot/Codex/bot suggestions without analyzing the underlying problem.
+- Do **not** touch files outside the scope of this PR.
+- Do **not** delete or rewrite the worktree yourself — the wrapper handles that.
+- If you cannot complete the work, leave the branch in a clean state, document what's left
+  in a PR comment, and exit.
+`;
+
 export function renderPrompt(ctx: PromptContext): string {
   const lines: string[] = [];
   lines.push(`# Handoff: ${ctx.repoName}`);
@@ -175,6 +315,20 @@ export function renderPrompt(ctx: PromptContext): string {
     lines.push('');
     lines.push(ctx.issue.body.trim() || '_(no body)_');
     lines.push('');
+  } else if (ctx.pr) {
+    lines.push(`## PR #${ctx.pr.number}: ${ctx.pr.title}`);
+    lines.push('');
+    lines.push(`<${ctx.pr.url}>`);
+    lines.push('');
+    lines.push(`**Head branch:** \`${ctx.pr.headBranch}\` → **base:** \`${ctx.pr.baseBranch}\``);
+    if (ctx.pr.isDraft) {
+      lines.push('');
+      lines.push('**This PR is currently a draft.** Completing it is fine; do not mark it');
+      lines.push('ready-for-review unless the user asks.');
+    }
+    lines.push('');
+    lines.push(ctx.pr.body.trim() || '_(no body)_');
+    lines.push('');
   } else if (ctx.freeformDescription) {
     lines.push('## Task');
     lines.push('');
@@ -182,7 +336,11 @@ export function renderPrompt(ctx: PromptContext): string {
     lines.push('');
   }
 
-  lines.push(ctx.loop ? WORKFLOW_CONTRACT_LOOP : WORKFLOW_CONTRACT);
+  if (ctx.pr) {
+    lines.push(ctx.loop ? WORKFLOW_CONTRACT_PR_LOOP : WORKFLOW_CONTRACT_PR);
+  } else {
+    lines.push(ctx.loop ? WORKFLOW_CONTRACT_LOOP : WORKFLOW_CONTRACT);
+  }
 
   return lines.join('\n');
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -97,7 +97,9 @@ export function serializeConfig(config: TelemetryConfig): string {
 
 // ---------- pure: events ----------
 
-export type RefType = 'issue' | 'freeform';
+// `pr` was added with PR-as-ref handoffs (#60). It mirrors `args.ts:Ref`'s
+// `kind` — no PII either way, so widening the union needs no event reshape.
+export type RefType = 'issue' | 'freeform' | 'pr';
 /**
  * Outcome of a `handoff cleanup` invocation.
  * - `merged`:   PR was merged → worktree + branch removed.

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -6,14 +6,16 @@ import { HandoffError } from './errors.ts';
 
 export const WORKSPACE_DIRNAME = '.handoff';
 export const STATE_FILENAME = 'state.json';
-export const STATE_VERSION = 1;
+// Bumped 1 → 2 when the `pr` ref variant landed (#60). A schema change, so
+// per CLAUDE.md the version moves; `assertStateVersion` then rejects v1
+// state from a pre-#60 worktree rather than silently mis-parsing it.
+export const STATE_VERSION = 2;
 
 export type IssueRefRecord = { type: 'issue'; number: number };
 export type FreeformRefRecord = { type: 'freeform'; text: string };
-// Note: a PrRefRecord variant will be added when first-class PR handoffs land
-// (#10). Until then, only the variants the CLI actually emits live in the
-// union, so the schema and the writer can't drift.
-export type RefRecord = IssueRefRecord | FreeformRefRecord;
+/** An existing PR handed off to be completed in place — see `args.ts:PrRef`. */
+export type PrRefRecord = { type: 'pr'; number: number };
+export type RefRecord = IssueRefRecord | FreeformRefRecord | PrRefRecord;
 
 export interface WorkspaceState {
   version: typeof STATE_VERSION;

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -305,6 +305,108 @@ describe('parseInvocation', () => {
     expect(() => parseInvocation(['cleanup'])).toThrow(ArgsError);
   });
 
+  describe('PR refs (#60)', () => {
+    it('parses the "PR #N" two-token form', () => {
+      expect(parseInvocation(['claude', 'PR', '#5'])).toEqual({
+        tool: 'claude',
+        refs: [{ kind: 'pr', number: 5 }],
+        loop: false,
+      });
+    });
+
+    it('parses the "pr#N" single-token shorthand', () => {
+      expect(parseInvocation(['claude', 'pr#5'])).toEqual({
+        tool: 'claude',
+        refs: [{ kind: 'pr', number: 5 }],
+        loop: false,
+      });
+    });
+
+    it('is case-insensitive on the pr keyword and tolerates a hash-less number', () => {
+      for (const tokens of [
+        ['claude', 'PR#5'],
+        ['claude', 'Pr#5'],
+        ['claude', 'pr', '#5'],
+        ['claude', 'PR', '5'],
+      ]) {
+        expect(parseInvocation(tokens)).toEqual({
+          tool: 'claude',
+          refs: [{ kind: 'pr', number: 5 }],
+          loop: false,
+        });
+      }
+    });
+
+    it('defaults to claude for a tool-less PR ref', () => {
+      expect(parseInvocation(['PR', '#5'])).toEqual({
+        tool: 'claude',
+        refs: [{ kind: 'pr', number: 5 }],
+        loop: false,
+      });
+      expect(parseInvocation(['pr#5'])).toEqual({
+        tool: 'claude',
+        refs: [{ kind: 'pr', number: 5 }],
+        loop: false,
+      });
+    });
+
+    it('accepts PR refs for codex and copilot — any tool can complete a PR', () => {
+      for (const tool of ['codex', 'copilot'] as const) {
+        expect(parseInvocation([tool, 'PR', '#5'])).toEqual({
+          tool,
+          refs: [{ kind: 'pr', number: 5 }],
+          loop: false,
+        });
+      }
+    });
+
+    it('parses a fleet mixing issue and PR refs', () => {
+      expect(parseInvocation(['claude', '#1', 'PR', '#2', 'pr#3'])).toEqual({
+        tool: 'claude',
+        refs: [
+          { kind: 'issue', number: 1 },
+          { kind: 'pr', number: 2 },
+          { kind: 'pr', number: 3 },
+        ],
+        loop: false,
+      });
+    });
+
+    it('accepts --loop with a PR ref for claude', () => {
+      // #60: the user opted in — a PR handoff can stay resident through the
+      // review cycle. --loop stays claude-only via the existing guard.
+      expect(parseInvocation(['claude', '--loop', 'PR', '#5'])).toEqual({
+        tool: 'claude',
+        refs: [{ kind: 'pr', number: 5 }],
+        loop: true,
+      });
+      expect(parseInvocation(['--loop', 'pr#5'])).toEqual({
+        tool: 'claude',
+        refs: [{ kind: 'pr', number: 5 }],
+        loop: true,
+      });
+    });
+
+    it('rejects --loop with a PR ref for codex/copilot', () => {
+      expect(() => parseInvocation(['codex', '--loop', 'PR', '#5'])).toThrow(
+        /--loop is only supported/,
+      );
+      expect(() => parseInvocation(['copilot', '--loop', 'pr#5'])).toThrow(
+        /--loop is only supported/,
+      );
+    });
+
+    it('does not mistake a free-form description starting with "pr" for a PR ref', () => {
+      // "pr" followed by a non-number is free-form text, not a PR ref — the
+      // same trade-off the "Issue" keyword has always had.
+      expect(parseInvocation(['claude', 'pr', 'the', 'release'])).toEqual({
+        tool: 'claude',
+        refs: [{ kind: 'freeform', text: 'pr the release' }],
+        loop: false,
+      });
+    });
+  });
+
   describe('telemetry subcommand', () => {
     it('parses enable with no endpoint', () => {
       expect(parseInvocation(['telemetry', 'enable'])).toEqual({
@@ -523,6 +625,22 @@ describe('extractGlobalFlags', () => {
     // handoff --verbose fix the --verbose flag   → --verbose before "fix"
     // is a flag; --verbose after is free-form text.
     expect(extractGlobalFlags(['--verbose', 'fix', 'the', '--verbose', 'flag'])).toEqual({
+      verbose: true,
+      debug: false,
+    });
+  });
+
+  // #60: the ref-scan loop must recognize PR refs too, or a global flag
+  // trailing a PR ref would be misread as the start of free-form mode.
+  it('detects --debug after a "PR #N" two-token ref', () => {
+    expect(extractGlobalFlags(['claude', 'PR', '#5', '--debug'])).toEqual({
+      verbose: false,
+      debug: true,
+    });
+  });
+
+  it('detects --verbose after an omitted-tool pr#N shorthand ref', () => {
+    expect(extractGlobalFlags(['pr#5', '--verbose'])).toEqual({
       verbose: true,
       debug: false,
     });

--- a/tests/branch.test.ts
+++ b/tests/branch.test.ts
@@ -7,15 +7,11 @@ describe('branchName', () => {
     expect(branchName({ tool: 'claude', issueNumber: 7 })).toBe('claude/issue-7');
   });
 
-  it('builds a PR branch as <tool>/pr-<N>', () => {
-    expect(branchName({ tool: 'codex', prNumber: 12 })).toBe('codex/pr-12');
-  });
-
   it('builds a free-form branch as <tool>/<slug>', () => {
     expect(branchName({ tool: 'codex', slug: 'cleanup-readme' })).toBe('codex/cleanup-readme');
   });
 
-  it('throws when given neither issueNumber nor prNumber nor slug', () => {
+  it('throws when given neither issueNumber nor slug', () => {
     expect(() => branchName({ tool: 'claude' })).toThrow();
   });
 });
@@ -23,8 +19,15 @@ describe('branchName', () => {
 describe('branchTail', () => {
   it('extracts everything after the first slash', () => {
     expect(branchTail('claude/issue-7')).toBe('issue-7');
-    expect(branchTail('codex/pr-12')).toBe('pr-12');
     expect(branchTail('claude/cleanup-readme')).toBe('cleanup-readme');
+  });
+
+  it('extracts only past the first slash for multi-segment branches', () => {
+    // PR-as-ref handoffs check out the PR's own head branch, which often
+    // carries a slash (e.g. `feature/x`). branchTail keeps everything past
+    // the first slash so worktreePath() can flatten it.
+    expect(branchTail('feature/login-fix')).toBe('login-fix');
+    expect(branchTail('user/feature/x')).toBe('feature/x');
   });
 
   it('returns the input unchanged when there is no slash', () => {
@@ -42,12 +45,6 @@ describe('isHandoffBranch', () => {
     for (const tool of ['claude', 'codex', 'copilot'] as const) {
       expect(isHandoffBranch(branchName({ tool, issueNumber: 1 }))).toBe(true);
       expect(isHandoffBranch(branchName({ tool, issueNumber: 9999 }))).toBe(true);
-    }
-  });
-
-  it('accepts every pr-form branch from branchName()', () => {
-    for (const tool of ['claude', 'codex', 'copilot'] as const) {
-      expect(isHandoffBranch(branchName({ tool, prNumber: 42 }))).toBe(true);
     }
   });
 
@@ -114,11 +111,13 @@ describe('worktreePath', () => {
     expect(out.replace(/\\/g, '/')).toBe('/work/handoff-issue-7');
   });
 
-  it('handles PR branches', () => {
+  it('handles a PR head branch the worktree was checked out onto', () => {
+    // PR-as-ref handoffs use the PR's own head branch; branchTail flattens
+    // any slash so the sibling directory name stays path-safe.
     const out = worktreePath({
       repoRoot: '/work/scope',
-      branch: 'codex/pr-12',
+      branch: 'feature/login-fix',
     });
-    expect(out.replace(/\\/g, '/')).toBe('/work/scope-pr-12');
+    expect(out.replace(/\\/g, '/')).toBe('/work/scope-login-fix');
   });
 });

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -226,6 +226,44 @@ describe('cleanup', () => {
     expect(result.message).toContain('branch codex/issue-11 was already gone');
     expect(state.calls.deleteBranch.length).toBe(0);
   });
+
+  it('keeps the head branch when keepBranch is set (#60 PR handoff)', async () => {
+    // PR-as-ref cleanup removes the worktree but must not delete the PR's
+    // own head branch — it belongs to the PR. branchExists/deleteBranch are
+    // never consulted on this path.
+    state.mergedReturn = true;
+    state.worktreeOnDisk = true;
+
+    const result = await cleanup('feature/the-thing', {
+      repoRoot: '/work/handoff',
+      deps,
+      keepBranch: true,
+    });
+
+    expect(result.status).toBe('removed');
+    expect(result.message).toContain('Removed worktree');
+    expect(result.message).toContain('retained branch feature/the-thing (PR head branch)');
+    expect(state.calls.removeWorktree.length).toBe(1);
+    expect(state.calls.branchExists).toEqual([]);
+    expect(state.calls.deleteBranch).toEqual([]);
+  });
+
+  it('keepBranch + force removes the worktree but still retains the branch', async () => {
+    state.worktreeOnDisk = true;
+
+    const result = await cleanup('feature/the-thing', {
+      repoRoot: '/work/handoff',
+      deps,
+      force: true,
+      keepBranch: true,
+    });
+
+    expect(result.status).toBe('removed');
+    expect(result.message).toContain('retained branch feature/the-thing (PR head branch)');
+    expect(result.message).toContain('forced — merge check skipped');
+    expect(state.calls.prMergedFor).toEqual([]);
+    expect(state.calls.deleteBranch).toEqual([]);
+  });
 });
 
 describe('cleanup — production wiring (no opts.deps)', () => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -31,6 +31,8 @@ let restoreTerminal: (() => void) | undefined;
 
 const REPO_VIEW_ARGV = ['repo', 'view', '--json', 'defaultBranchRef'];
 const ISSUE_VIEW_FIELDS = 'number,title,body,labels,url';
+const PR_VIEW_FIELDS =
+  'number,title,body,url,state,headRefName,baseRefName,isDraft,isCrossRepository';
 
 beforeEach(() => {
   // Reset everything up front so a partial `beforeEach` failure leaves
@@ -203,6 +205,66 @@ describe('cli integration — happy path', () => {
     // not in spawn options. Pin that the worktree path is in there
     // somewhere.
     expect(launchArgv).toContain(wt);
+  });
+});
+
+describe('cli integration — PR handoff (#60)', () => {
+  it('handoff PR #5: detaches a worktree, checks the PR out, writes a PR PROMPT.md', async () => {
+    const { spawn } = fixtures();
+    spawn.expectGh(REPO_VIEW_ARGV, { defaultBranchRef: { name: 'dev' } });
+    spawn.expectGh(['pr', 'view', '5', '--json', PR_VIEW_FIELDS], {
+      number: 5,
+      title: 'Add the thing',
+      body: 'Half-finished — needs tests.',
+      url: 'https://example.test/pull/5',
+      state: 'OPEN',
+      headRefName: 'feature/the-thing',
+      baseRefName: 'dev',
+      isDraft: false,
+      isCrossRepository: false,
+    });
+    // `gh pr checkout` is faked — the unit tests cover its argv and the real
+    // detached-worktree git op separately; here we pin the orchestration.
+    spawn.expect({ command: 'gh', argv: ['pr', 'checkout', '5'], response: { stdout: '' } });
+
+    const exitCode = await cliMain(['PR', '#5']);
+    expect(exitCode).toBe(0);
+
+    // Worktree path derives from the PR's *own* head branch, not a
+    // synthesized `<tool>/pr-N` name.
+    const wt = expectedWorktreePath('the-thing');
+    expect(existsSync(wt)).toBe(true);
+
+    const prompt = readFileSync(join(wt, 'PROMPT.md'), 'utf8');
+    expect(prompt).toContain('## PR #5: Add the thing');
+    expect(prompt).toContain('Workflow contract (PR completion mode)');
+
+    const state = JSON.parse(readFileSync(join(wt, '.handoff', 'state.json'), 'utf8'));
+    expect(state.ref).toEqual({ type: 'pr', number: 5 });
+    expect(state.branch).toBe('feature/the-thing');
+
+    expect(terminalCalls).toHaveLength(1);
+    expect(terminalCalls[0]?.args.join(' ')).toContain('feature/the-thing');
+  });
+
+  it('handoff PR #6: refuses a fork PR with exit 1 and never opens a worktree', async () => {
+    const { spawn } = fixtures();
+    spawn.expectGh(REPO_VIEW_ARGV, { defaultBranchRef: { name: 'dev' } });
+    spawn.expectGh(['pr', 'view', '6', '--json', PR_VIEW_FIELDS], {
+      number: 6,
+      title: 'Fork PR',
+      body: '',
+      url: 'https://example.test/pull/6',
+      state: 'OPEN',
+      headRefName: 'their-branch',
+      baseRefName: 'dev',
+      isDraft: false,
+      isCrossRepository: true,
+    });
+
+    const exitCode = await cliMain(['PR', '#6']);
+    expect(exitCode).toBe(1);
+    expect(terminalCalls).toHaveLength(0);
   });
 });
 

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import {
   GitError,
   branchExists,
+  createDetachedWorktree,
   createWorktree,
   currentRepoRoot,
   deleteBranch,
@@ -155,6 +156,31 @@ describe('createWorktree', () => {
     expect((err as Error).message).toContain('git branch -D feature/x');
     // No partial state on the filesystem — we bailed before `git worktree add`.
     expect(existsSync(linked)).toBe(false);
+  });
+});
+
+describe('createDetachedWorktree', () => {
+  it('creates a worktree in detached-HEAD state with no new branch', async () => {
+    process.chdir(repo.path);
+    const linked = worktreePath({ repoRoot: repo.path, branch: 'feature/the-thing' });
+
+    await createDetachedWorktree(linked);
+
+    expect(existsSync(linked)).toBe(true);
+    // Detached HEAD: `rev-parse --abbrev-ref HEAD` reports the literal
+    // "HEAD". gh pr checkout switches it onto the PR branch afterwards.
+    const head = repo.git(['-C', linked, 'rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
+    expect(head).toBe('HEAD');
+  });
+
+  it('rejects when the target path already exists', async () => {
+    // git refuses `worktree add` onto an existing non-empty directory; the
+    // RunError propagates (cli.ts maps it to exit 2).
+    process.chdir(repo.path);
+    const linked = worktreePath({ repoRoot: repo.path, branch: 'feature/the-thing' });
+    await createDetachedWorktree(linked);
+
+    await expect(createDetachedWorktree(linked)).rejects.toThrow();
   });
 });
 

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
-import { GhError, defaultBranch, fetchIssue, prMergedFor } from '../src/github.ts';
+import {
+  GhError,
+  checkoutPullRequest,
+  defaultBranch,
+  fetchIssue,
+  fetchPullRequest,
+  prMergedFor,
+} from '../src/github.ts';
 import type { HandoffError } from '../src/errors.ts';
 import { createScriptedSpawn, type ScriptedSpawn } from './helpers/scriptedSpawn.ts';
 
@@ -128,6 +135,125 @@ describe('fetchIssue', () => {
     });
     const issue = await fetchIssue(7);
     expect(issue.labels).toEqual([]);
+  });
+});
+
+describe('fetchPullRequest', () => {
+  const PR_FIELDS = 'number,title,body,url,state,headRefName,baseRefName,isDraft,isCrossRepository';
+  const ARGV = ['pr', 'view', '5', '--json', PR_FIELDS];
+
+  function payload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      number: 5,
+      title: 'Add the thing',
+      body: 'half-finished body',
+      url: 'https://example.test/pull/5',
+      state: 'OPEN',
+      headRefName: 'feature/the-thing',
+      baseRefName: 'dev',
+      isDraft: false,
+      isCrossRepository: false,
+      ...overrides,
+    };
+  }
+
+  it('parses a complete PR payload', async () => {
+    spawn.expectGh(ARGV, payload());
+
+    const pr = await fetchPullRequest(5);
+
+    expect(pr).toEqual({
+      number: 5,
+      title: 'Add the thing',
+      body: 'half-finished body',
+      url: 'https://example.test/pull/5',
+      state: 'OPEN',
+      headRefName: 'feature/the-thing',
+      baseRefName: 'dev',
+      isDraft: false,
+      isCrossRepository: false,
+    });
+  });
+
+  it('carries the draft and cross-repository flags through verbatim', async () => {
+    // cli.ts gates fork refusal on isCrossRepository and allows drafts, so
+    // both flags must survive the parse unchanged.
+    spawn.expectGh(ARGV, payload({ isDraft: true, isCrossRepository: true }));
+    const pr = await fetchPullRequest(5);
+    expect(pr.isDraft).toBe(true);
+    expect(pr.isCrossRepository).toBe(true);
+  });
+
+  it('throws GhError when gh exits non-zero (e.g. PR not found)', async () => {
+    spawn.expect({
+      command: 'gh',
+      argv: ARGV,
+      response: { stderr: 'GraphQL: Could not resolve to a PullRequest (HTTP 404)', exitCode: 1 },
+    });
+
+    let err: unknown;
+    try {
+      await fetchPullRequest(5);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(GhError);
+    expect((err as Error).message).toContain('gh pr view 5');
+  });
+
+  it('throws GhError when the payload is missing required fields', async () => {
+    // Same defensive-parse contract as fetchIssue: a valid-JSON but
+    // incomplete payload must fail loudly, not propagate undefined fields
+    // into worktree creation.
+    spawn.expectGh(ARGV, { number: 5, title: 'no refs' });
+
+    let err: unknown;
+    try {
+      await fetchPullRequest(5);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(GhError);
+    expect((err as Error).message).toContain('Unexpected gh pr payload');
+  });
+
+  it('rejects an unrecognized PR state', async () => {
+    // state drives the open/closed/merged gate in cli.ts; an unknown value
+    // must not slip through as a valid PullRequestState.
+    spawn.expectGh(ARGV, payload({ state: 'LOCKED' }));
+    await expect(fetchPullRequest(5)).rejects.toBeInstanceOf(GhError);
+  });
+
+  it('rejects an empty headRefName', async () => {
+    // An empty head branch would later concatenate into a worktree path.
+    spawn.expectGh(ARGV, payload({ headRefName: '' }));
+    await expect(fetchPullRequest(5)).rejects.toBeInstanceOf(GhError);
+  });
+});
+
+describe('checkoutPullRequest', () => {
+  it('runs `gh pr checkout <n>` in the given worktree cwd', async () => {
+    spawn.expect({
+      command: 'gh',
+      argv: ['pr', 'checkout', '5'],
+      response: { stdout: '' },
+    });
+
+    await checkoutPullRequest(5, '/work/handoff-the-thing');
+
+    expect(spawn.calls).toEqual([
+      { command: 'gh', args: ['pr', 'checkout', '5'], cwd: '/work/handoff-the-thing' },
+    ]);
+  });
+
+  it('surfaces a GhError when the checkout fails', async () => {
+    spawn.expect({
+      command: 'gh',
+      argv: ['pr', 'checkout', '5'],
+      response: { stderr: 'fatal: could not checkout', exitCode: 1 },
+    });
+
+    await expect(checkoutPullRequest(5, '/work/x')).rejects.toBeInstanceOf(GhError);
   });
 });
 

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -135,4 +135,82 @@ describe('renderPrompt', () => {
     });
     expect(out).toContain('_(no body)_');
   });
+
+  it('renders a PR-completion handoff (#60)', () => {
+    const out = renderPrompt({
+      tool: 'codex',
+      repoName: 'handoff',
+      branch: 'feature/the-thing',
+      parentBranch: 'dev',
+      worktreePath: '/work/handoff-the-thing',
+      pr: {
+        number: 5,
+        title: 'Add the thing',
+        body: 'Half-finished — needs tests.',
+        url: 'https://github.com/x/y/pull/5',
+        headBranch: 'feature/the-thing',
+        baseBranch: 'dev',
+        isDraft: false,
+      },
+    });
+    expect(out).toContain('## PR #5: Add the thing');
+    expect(out).toContain('Half-finished — needs tests.');
+    expect(out).toContain('**Head branch:** `feature/the-thing` → **base:** `dev`');
+    expect(out).toContain('Workflow contract (PR completion mode)');
+    // PR mode finishes in place: push to the existing branch, never a new PR.
+    expect(out).toContain('PR updated:');
+    expect(out).toContain('open a new PR');
+    expect(out).not.toContain('## Issue');
+    expect(out).not.toContain('## Task');
+    expect(out).not.toContain('Enter the review loop');
+  });
+
+  it('flags a draft PR without forcing it ready-for-review', () => {
+    const out = renderPrompt({
+      tool: 'claude',
+      repoName: 'handoff',
+      branch: 'feature/draft-pr',
+      parentBranch: 'dev',
+      worktreePath: '/tmp/x',
+      pr: {
+        number: 8,
+        title: 'WIP',
+        body: '',
+        url: 'https://github.com/x/y/pull/8',
+        headBranch: 'feature/draft-pr',
+        baseBranch: 'dev',
+        isDraft: true,
+      },
+    });
+    expect(out).toContain('currently a draft');
+    expect(out).toContain('_(no body)_');
+  });
+
+  it('renders the PR loop contract when loop is true', () => {
+    const out = renderPrompt({
+      tool: 'claude',
+      repoName: 'handoff',
+      branch: 'feature/the-thing',
+      parentBranch: 'dev',
+      worktreePath: '/tmp/x',
+      loop: true,
+      pr: {
+        number: 5,
+        title: 'Add the thing',
+        body: 'body',
+        url: 'https://github.com/x/y/pull/5',
+        headBranch: 'feature/the-thing',
+        baseBranch: 'dev',
+        isDraft: false,
+      },
+    });
+    expect(out).toContain('Workflow contract (PR completion + review loop)');
+    expect(out).toContain('Enter the review loop');
+    expect(out).toContain('[handoff loop] bailing');
+    expect(out).toContain('CONFLICTING');
+    expect(out).toContain('?since=');
+    // It's the PR loop, not the issue loop, and never re-opens a PR.
+    expect(out).not.toContain('Workflow contract (loop mode)');
+    expect(out).toContain('open a new PR');
+  });
 });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -177,6 +177,18 @@ describe('event constructors — no-PII shape', () => {
     expect(Object.keys(ev.payload).sort()).toEqual([...ALLOWED_KEYS['handoff.start']].sort());
   });
 
+  it('handoff.start accepts the pr refType (#60) without reshaping the payload', () => {
+    const ev = eventStart({
+      tool: 'claude',
+      refType: 'pr',
+      fleet: 1,
+      loop: false,
+      sessionId: 'abc',
+    });
+    expect(ev.payload.refType).toBe('pr');
+    expect(Object.keys(ev.payload).sort()).toEqual([...ALLOWED_KEYS['handoff.start']].sort());
+  });
+
   it('handoff.cleanup emits exactly the allowlisted keys', () => {
     const ev = eventCleanup({ tool: 'codex', outcome: 'merged', durationMs: 12345 });
     expect(ev.name).toBe('handoff.cleanup');

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -73,13 +73,34 @@ describe('writeState / readState', () => {
   it('returns null when there is no state file', () => {
     expect(readState(root)).toBeNull();
   });
+
+  it('round-trips a PR ref record (#60)', () => {
+    const state: WorkspaceState = {
+      ...sample(),
+      ref: { type: 'pr', number: 12 },
+      branch: 'feature/the-thing',
+      loop: false,
+    };
+    writeState(root, state);
+    expect(readState(root)).toEqual(state);
+  });
 });
 
 describe('readState schema-version guard', () => {
   it('throws WorkspaceStateError on a state with a future version', () => {
     writeState(root, sample());
-    const future = { ...sample(), version: 2 };
+    const future = { ...sample(), version: STATE_VERSION + 1 };
     writeFileSync(statePath(root), JSON.stringify(future), 'utf8');
+
+    expect(() => readState(root)).toThrow(WorkspaceStateError);
+  });
+
+  it('rejects a pre-#60 v1 state rather than mis-parsing it', () => {
+    // STATE_VERSION moved 1 → 2 when the `pr` ref variant landed. A v1
+    // state file (from a worktree created before #60) must be rejected by
+    // the version guard, not read as if its schema still matched.
+    writeState(root, sample());
+    writeFileSync(statePath(root), JSON.stringify({ ...sample(), version: 1 }), 'utf8');
 
     expect(() => readState(root)).toThrow(WorkspaceStateError);
   });


### PR DESCRIPTION
Closes #60.

Adds a `PR #N` ref kind: `handoff PR #5` hands an **existing open PR** to an agent to *complete in place* — it checks the PR's own head branch out into a worktree, writes a PR-flavored `PROMPT.md`, and the agent finishes the work and pushes back to the same branch. It does **not** open a new PR.

## Surface

```
handoff PR #5          # complete an existing PR (any tool)
handoff codex PR #5    # explicit tool
handoff pr#5           # shorthand — pr#N, case-insensitive
handoff --loop PR #5   # complete, then stay resident through review (claude only)
```

## How it works

- `fetchPullRequest` (`gh pr view --json`) resolves the PR; `assertPrHandoffable` refuses a closed/merged PR and a fork PR (`isCrossRepository`) — both exit 1 with a recovery hint.
- The worktree is created detached, then `gh pr checkout` switches it onto the PR's **own head branch** (push tracking wired), so the agent's `git push` updates the PR.
- `PROMPT.md` uses `WORKFLOW_CONTRACT_PR` / `WORKFLOW_CONTRACT_PR_LOOP`: review the existing diff + conversation, finish the work, push to the same branch, never `gh pr create`, never force-push.
- `state.json` records `{ type: 'pr', number }`; cleanup removes the worktree but **keeps** the PR's branch (`keepBranch`).

## Scope decisions (confirmed with the issue author)

- **Fork / cross-repo PRs:** refused with a clear error — the agent may not be able to push to a fork. Fork support is a follow-up.
- **`--loop` + PR:** supported. `--loop` stays claude-only via the existing guard, so `--loop PR #N` is accepted for claude and rejected for codex/copilot with no new code.

## Other changes

- `STATE_VERSION` 1 → 2 (schema change — the `pr` ref variant). `safeReadState` swallows the version-mismatch throw, so an in-flight v1 worktree still cleans up.
- The unused, now-rejected `tool/pr-N` branch convention is removed (separate commit).
- Runner scripts are **unchanged** — the tool invocation and `cleanup <branch>` call are identical; `keepBranch` is derived from `state.json`.

## Relationship to #10

#10 (claude-only, review-loop only) is the narrower case; this is the superset. #60 landing first means #10 becomes a special-cased mode within this contract.

## Tests

`bun run test` → 266 pass, 0 fail; `typecheck` and `lint` clean. New unit coverage across args / github / git / prompt / cleanup / workspace / telemetry, plus 2 cli integration tests (happy path + fork refusal). Smoke-tested the refusal path against a real merged PR.

## Cross-platform

No terminal / runner-script / path code changed — the runner surface is untouched, so no platform smoke test was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)